### PR TITLE
Fixed `Academy` children `Brain` gathering.

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -67,7 +67,7 @@ public abstract class Academy : MonoBehaviour
 
 
     [HideInInspector]
-    private Brain[] brains = new Brain[0];
+    private List<Brain> brains = new List<Brain>();
 
 
 
@@ -114,7 +114,7 @@ public abstract class Academy : MonoBehaviour
             resetParameters[kv.key] = kv.value;
         }
 
-        brains = gameObject.GetComponentsInChildren<Brain>();
+        GetBrains(gameObject, brains);
         InitializeAcademy();
 
         foreach (Brain brain in brains)
@@ -140,7 +140,6 @@ public abstract class Academy : MonoBehaviour
     public virtual void InitializeAcademy()
     {
 
-
     }
 
 
@@ -161,7 +160,6 @@ public abstract class Academy : MonoBehaviour
             Application.targetFrameRate = inferenceConfiguration.targetFrameRate;
         }
     }
-
 
     /// Environment specific step logic.
     /**
@@ -348,4 +346,17 @@ public abstract class Academy : MonoBehaviour
 
     }
 
+    private static void GetBrains(GameObject gameObject, List<Brain> brains)
+    {
+        var transform = gameObject.transform;
+        
+        for (var i = 0; i < transform.childCount; i++)
+        {
+            var child = transform.GetChild(i);
+            var brain = child.GetComponent<Brain>();
+
+            if (brain != null)
+                brains.Add(brain);
+        }
+    }
 }


### PR DESCRIPTION
Hi! Really like your project and wanting to help.

So I've found, that `Academy` is using `GetComponentsInChildren` method to gather all child `Brain` components. And, as far as I know (empirically too), this method has a tricky name: actually, it also takes `Brain` component from calling object.

Also `GetComponentsInChildren` looks recursively in all children of object, not the nearest only.

And there also is error (oh, I see the typo here):
![image](https://user-images.githubusercontent.com/7947142/31301168-e273a1fe-aaac-11e7-9739-e3cf66f276db.png)

Which, as I can see, means, that `Academy` will search for brain only it's children objects (not recursively), so for now we can get such error panel even in situations, when `Academy` will actually find some `Brains`.

For example, such configuration will result in one `Brain` in `Academy`:
![image](https://user-images.githubusercontent.com/7947142/31301304-de95b21a-aaad-11e7-9fa4-2c0b29d357fd.png)

I've fixed this by manually looping over children of `Academy`.

_P.S. It looks like I've accidentally removed some empty lines. If it's not ok, I'll revert. ^^_