### PR TITLE
Fixed brain editor bug

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -142,6 +142,15 @@ public class Brain : MonoBehaviour
             }
             CoreBrains = new_CoreBrains;
         }
+        // Check whether all CoreBrain are ready
+        else
+        {
+            foreach (BrainType bt in System.Enum.GetValues(typeof(BrainType)))
+            {
+                if (CoreBrains[(int)bt] != null) continue;
+                CoreBrains[(int)bt] = ScriptableObject.CreateInstance("CoreBrain" + bt.ToString());
+            }
+        }
 
         // If the stored instanceID does not match the current instanceID, 
         // this means that the Brain GameObject was duplicated, and


### PR DESCRIPTION
In some cases, ScriptableObject of CoreBrain are null and it fails in error when opening inspector outputting the following error though I don't know why...

```
ArgumentException: The Object you want to instantiate is null.
UnityEngine.Object.CheckNullArgument (System.Object arg, System.String message) (at /Users/builduser/buildslave/unity/build/Runtime/Export/UnityEngineObject.cs:238)
UnityEngine.Object.Instantiate[ScriptableObject] (UnityEngine.ScriptableObject original) (at /Users/builduser/buildslave/unity/build/Runtime/Export/UnityEngineObject.cs:199)
Brain.UpdateCoreBrains () (at Assets/ML-Agents/Scripts/Brain.cs:167)
BrainEditor.OnInspectorGUI () (at Assets/ML-Agents/Editor/BrainEditor.cs:45)
UnityEditor.InspectorWindow.DrawEditor (UnityEditor.Editor[] editors, Int32 editorIndex, Boolean rebuildOptimizedGUIBlock, System.Boolean& showImportedObjectBarNext, UnityEngine.Rect& importedObjectBarRect) (at /Users/builduser/buildslave/unity/build/Editor/Mono/Inspector/InspectorWindow.cs:1240)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```

The values in inspector is like the following image.
![image](https://gist.githubusercontent.com/dora-gt/4a22ecf6d2e42ea90d7e90d5884c122a/raw/0a015edf08e4e8f69ecc04b17dbb0e9003bd18ee/Inspector.png)

So, I fixed to fill all the CoreBrains with default value.