### PR TITLE
BrainEditor: Replaced `new SerializedObject()` with property.

### DIFF
--- a/unity-environment/Assets/ML-Agents/Editor/BrainEditor.cs
+++ b/unity-environment/Assets/ML-Agents/Editor/BrainEditor.cs
@@ -16,7 +16,7 @@ public class BrainEditor : Editor
 	public override void OnInspectorGUI ()
 	{
 		Brain myBrain = (Brain)target;
-		SerializedObject serializedBrain = new SerializedObject (target);
+		SerializedObject serializedBrain = serializedObject;
 
 		if (myBrain.transform.parent == null) {
 			EditorGUILayout.HelpBox ("A Brain GameObject must be a child of an Academy GameObject!", MessageType.Error);

--- a/unity-environment/Assets/ML-Agents/Editor/BrainEditor.cs
+++ b/unity-environment/Assets/ML-Agents/Editor/BrainEditor.cs
@@ -11,8 +11,6 @@ using System.Linq;
 [CustomEditor (typeof(Brain))]
 public class BrainEditor : Editor
 {
-	
-
 	public override void OnInspectorGUI ()
 	{
 		Brain myBrain = (Brain)target;
@@ -24,15 +22,13 @@ public class BrainEditor : Editor
 			EditorGUILayout.HelpBox ("The Parent of a Brain must have an Academy Component attached to it!", MessageType.Error);
 		}
 
-
-		SerializedProperty bp = serializedBrain.FindProperty ("brainParameters");
-		if (myBrain.brainParameters.actionDescriptions == null) {
-			myBrain.brainParameters.actionDescriptions = new string[myBrain.brainParameters.actionSize];
-		}
-		if (myBrain.brainParameters.actionSize != myBrain.brainParameters.actionDescriptions.Count()) {
-			myBrain.brainParameters.actionDescriptions = new string[myBrain.brainParameters.actionSize];
-		}
+		BrainParameters parameters = myBrain.brainParameters;
+		if (parameters.actionDescriptions == null || parameters.actionDescriptions.Length != parameters.actionSize)
+			parameters.actionDescriptions = new string[parameters.actionSize];
+		
 		serializedBrain.Update();
+		
+		SerializedProperty bp = serializedBrain.FindProperty ("brainParameters");
 		EditorGUILayout.PropertyField(bp, true);
 
 		SerializedProperty bt = serializedBrain.FindProperty("brainType");
@@ -45,13 +41,10 @@ public class BrainEditor : Editor
 		serializedBrain.ApplyModifiedProperties();
 
 		myBrain.UpdateCoreBrains ();
-
 		myBrain.coreBrain.OnInspector ();
 
 		#if !NET_4_6 && ENABLE_TENSORFLOW
 		EditorGUILayout.HelpBox ("You cannot have ENABLE_TENSORFLOW without NET_4_6", MessageType.Error);
 		#endif
-
-
 	}
 }

--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -67,7 +67,7 @@ public abstract class Academy : MonoBehaviour
 
 
     [HideInInspector]
-    private Brain[] brains = new Brain[0];
+    private List<Brain> brains = new List<Brain>();
 
 
 
@@ -114,7 +114,7 @@ public abstract class Academy : MonoBehaviour
             resetParameters[kv.key] = kv.value;
         }
 
-        brains = gameObject.GetComponentsInChildren<Brain>();
+        GetBrains(gameObject, brains);
         InitializeAcademy();
 
         foreach (Brain brain in brains)
@@ -140,7 +140,6 @@ public abstract class Academy : MonoBehaviour
     public virtual void InitializeAcademy()
     {
 
-
     }
 
 
@@ -161,7 +160,6 @@ public abstract class Academy : MonoBehaviour
             Application.targetFrameRate = inferenceConfiguration.targetFrameRate;
         }
     }
-
 
     /// Environment specific step logic.
     /**
@@ -348,4 +346,17 @@ public abstract class Academy : MonoBehaviour
 
     }
 
+    private static void GetBrains(GameObject gameObject, List<Brain> brains)
+    {
+        var transform = gameObject.transform;
+        
+        for (var i = 0; i < transform.childCount; i++)
+        {
+            var child = transform.GetChild(i);
+            var brain = child.GetComponent<Brain>();
+
+            if (brain != null)
+                brains.Add(brain);
+        }
+    }
 }


### PR DESCRIPTION
Hi!

Just small adjustment for `BrainEditor`. There is a new `SerializedObject` every `OnInspectorGUI` right now, and this can be optimized away with `serializedObject` property, that do some caching.

![image](https://user-images.githubusercontent.com/7947142/31590058-2e1e41c2-b1bf-11e7-8561-1e2d1ecdefe6.png)
