### PR TITLE
dev-logParam

### DIFF
--- a/python/PPO.ipynb
+++ b/python/PPO.ipynb
@@ -62,7 +62,13 @@
     "buffer_size = 2048 # How large the experience buffer should be before gradient descent.\n",
     "learning_rate = 3e-4 # Model learning rate.\n",
     "hidden_units = 64 # Number of units in hidden layer.\n",
-    "batch_size = 64 # How many experiences per gradient descent update step."
+    "batch_size = 64 # How many experiences per gradient descent update step.\n",
+    "\n",
+    "### Logging dictionary for hyperparameters\n",
+    "hyperparameter_dict = {'max_steps':max_steps, 'run_path':run_path, 'env_name':env_name,\n",
+    "    'curriculum_file':curriculum_file, 'gamma':gamma, 'lambd':lambd, 'time_horizon':time_horizon,\n",
+    "    'beta':beta, 'num_epoch':num_epoch, 'epsilon':epsilon, 'buffe_size':buffer_size,\n",
+    "    'leaning_rate':learning_rate, 'hidden_units':hidden_units, 'batch_size':batch_size}"
    ]
   },
   {
@@ -75,14 +81,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "env = UnityEnvironment(file_name=env_name, curriculum=curriculum_file)\n",
     "print(str(env))\n",
-    "brain_name = env.brain_names[0]"
+    "brain_name = env.external_brain_names[0]"
    ]
   },
   {
@@ -96,7 +100,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -151,6 +154,8 @@
     "    summary_writer = tf.summary.FileWriter(summary_path)\n",
     "    info = env.reset(train_mode=train_model, progress=get_progress())[brain_name]\n",
     "    trainer = Trainer(ppo_model, sess, info, is_continuous, use_observations, use_states, train_model)\n",
+    "    if train_model:\n",
+    "        trainer.write_text(summary_writer, 'Hyperparameters', hyperparameter_dict, steps)\n",
     "    while steps <= max_steps:\n",
     "        if env.global_done:\n",
     "            info = env.reset(train_mode=train_model, progress=get_progress())[brain_name]\n",
@@ -203,21 +208,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/python/ppo.py
+++ b/python/ppo.py
@@ -117,6 +117,8 @@ with tf.Session() as sess:
     summary_writer = tf.summary.FileWriter(summary_path)
     info = env.reset(train_mode=train_model, progress=get_progress())[brain_name]
     trainer = Trainer(ppo_model, sess, info, is_continuous, use_observations, use_states, train_model)
+    if train_model:
+        trainer.write_text(summary_writer, 'Hyperparameters', options, steps)
     while steps <= max_steps or not train_model:
         if env.global_done:
             info = env.reset(train_mode=train_model, progress=get_progress())[brain_name]

--- a/python/ppo/trainer.py
+++ b/python/ppo/trainer.py
@@ -205,3 +205,23 @@ class Trainer(object):
         summary.value.add(tag='Info/Lesson', simple_value=lesson_number)
         summary_writer.add_summary(summary, steps)
         summary_writer.flush()
+
+    def write_text(self, summary_writer, key, input_dict, steps):
+        """
+        Saves text to Tensorboard.
+        Note: Only works on tensorflow r1.2 or above.
+        :param summary_writer: writer associated with Tensorflow session.
+        :param key: The name of the text.
+        :param input_dict: A dictionary that will be displayed in a table on Tensorboard.
+        :param steps: Number of environment steps in training process.
+        """
+        try:
+            s_op = tf.summary.text(key,
+                    tf.convert_to_tensor(([[str(x), str(input_dict[x])] for x in input_dict]))
+                    )
+            s = self.sess.run(s_op)
+            summary_writer.add_summary(s, steps)
+        except:
+            pass
+
+

--- a/python/ppo/trainer.py
+++ b/python/ppo/trainer.py
@@ -222,6 +222,7 @@ class Trainer(object):
             s = self.sess.run(s_op)
             summary_writer.add_summary(s, steps)
         except:
+            print("Cannot write text summary for Tensorboard. Tensorflow version must be r1.2 or above.")
             pass
 
 


### PR DESCRIPTION
Added the method write text to trainer so it is easy to write log the hyperparameters as a dictionary. Note: needs tensorflow version r1.2 or above.
You can call it with :
```python
trainer.write_text(summary_writer, 'Hyperparameters', options, steps)
```
Where `options` is a dictionary