### PR TITLE
Fixed to give lesson index parameter when start up

### DIFF
--- a/python/PPO.ipynb
+++ b/python/PPO.ipynb
@@ -51,6 +51,7 @@
     "save_freq = 50000 # Frequency at which to save model.\n",
     "env_name = \"environment\" # Name of the training environment file.\n",
     "curriculum_file = None\n",
+    "lesson = 0 # Start learning from this lesson\n",
     "\n",
     "### Algorithm-specific parameters for tuning\n",
     "gamma = 0.99 # Reward discount rate.\n",
@@ -88,7 +89,7 @@
    },
    "outputs": [],
    "source": [
-    "env = UnityEnvironment(file_name=env_name, curriculum=curriculum_file)\n",
+    "env = UnityEnvironment(file_name=env_name, curriculum=curriculum_file, lesson=lesson)\n",
     "print(str(env))\n",
     "brain_name = env.external_brain_names[0]"
    ]

--- a/python/ppo.py
+++ b/python/ppo.py
@@ -56,6 +56,7 @@ worker_id = int(options['--worker-id'])
 curriculum_file = str(options['--curriculum'])
 if curriculum_file == "None":
     curriculum_file = None
+lesson = int(options['--lesson'])
 
 # Algorithm-specific parameters for tuning
 gamma = float(options['--gamma'])
@@ -70,7 +71,6 @@ learning_rate = float(options['--learning-rate'])
 hidden_units = int(options['--hidden-units'])
 batch_size = int(options['--batch-size'])
 normalize = options['--normalize']
-lesson = int(options['--lesson'])
 
 env = UnityEnvironment(file_name=env_name, worker_id=worker_id, curriculum=curriculum_file, lesson=lesson)
 print(str(env))

--- a/python/ppo.py
+++ b/python/ppo.py
@@ -36,6 +36,7 @@ Options:
   --time-horizon=<n>         How many steps to collect per agent before adding to buffer [default: 2048].
   --train                    Whether to train model, or only run inference [default: False].
   --worker-id=<n>            Number to add to communication port (5005). Used for multi-environment [default: 0].
+  --lesson=<n>               Start learning from this lesson [default: 0].
 '''
 
 options = docopt(_USAGE)
@@ -69,8 +70,9 @@ learning_rate = float(options['--learning-rate'])
 hidden_units = int(options['--hidden-units'])
 batch_size = int(options['--batch-size'])
 normalize = options['--normalize']
+lesson = int(options['--lesson'])
 
-env = UnityEnvironment(file_name=env_name, worker_id=worker_id, curriculum=curriculum_file)
+env = UnityEnvironment(file_name=env_name, worker_id=worker_id, curriculum=curriculum_file, lesson=lesson)
 print(str(env))
 brain_name = env.external_brain_names[0]
 

--- a/python/unityagents/curriculum.py
+++ b/python/unityagents/curriculum.py
@@ -5,13 +5,12 @@ from .exception import UnityEnvironmentException
 
 
 class Curriculum(object):
-    def __init__(self, location, default_reset_parameters):
+    def __init__(self, location, default_reset_parameters, lesson):
         """
         Initializes a Curriculum object.
         :param location: Path to JSON defining curriculum.
         :param default_reset_parameters: Set of reset parameters for environment.
         """
-        self.lesson_number = 0
         self.lesson_length = 0
         self.measure_type = None
         if location is None:
@@ -45,6 +44,7 @@ class Curriculum(object):
                         "The parameter {0} in Curriculum {1} must have {2} values "
                         "but {3} were found".format(key, location,
                                                     self.max_lesson_number + 1, len(parameters[key])))
+        self.set_lesson_number(lesson)
 
     @property
     def measure(self):

--- a/python/unityagents/environment.py
+++ b/python/unityagents/environment.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("unityagents")
 
 class UnityEnvironment(object):
     def __init__(self, file_name, worker_id=0,
-                 base_port=5005, curriculum=None):
+                 base_port=5005, curriculum=None, lesson=0):
         """
         Starts a new unity environment and establishes a connection with the environment.
         Notice: Currently communication between Unity and Python takes place over an open socket without authentication.
@@ -127,7 +127,7 @@ class UnityEnvironment(object):
             self._num_brains = len(self._brain_names)
             self._num_external_brains = len(self._external_brain_names)
             self._resetParameters = p["resetParameters"]
-            self._curriculum = Curriculum(curriculum, self._resetParameters)
+            self._curriculum = Curriculum(curriculum, self._resetParameters, lesson)
             for i in range(self._num_brains):
                 self._brains[self._brain_names[i]] = BrainParameters(self._brain_names[i], p["brainParameters"][i])
             self._loaded = True


### PR DESCRIPTION
Fixed to give lesson index parameter when start up.
With this option, user can use `--load` and `--curriculum=<file>` at the same time, and start lesson from one that user exactly wants.