### PR TITLE
Improve memory management

### DIFF
--- a/python/unityagents/environment.py
+++ b/python/unityagents/environment.py
@@ -115,7 +115,6 @@ class UnityEnvironment(object):
                     "The API number is not compatible between Unity and python. Python API : {0}, Unity API : "
                     "{1}.\nPlease go to https://github.com/Unity-Technologies/ml-agents to download the latest version "
                     "of ML-Agents.".format(self._python_api, self._unity_api))
-
             self._data = {}
             self._global_done = None
             self._academy_name = p["AcademyName"]

--- a/unity-environment/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
@@ -9,7 +9,6 @@ public class Ball3DAgent : Agent
 
     public override List<float> CollectState()
     {
-        List<float> state = new List<float>();
         state.Add(gameObject.transform.rotation.z);
         state.Add(gameObject.transform.rotation.x);
         state.Add((ball.transform.position.x - gameObject.transform.position.x));

--- a/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/AreaAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/AreaAgent.cs
@@ -10,7 +10,6 @@ public class AreaAgent : Agent
     public override List<float> CollectState()
     {
         Vector3 velocity = GetComponent<Rigidbody>().velocity;
-
 		state.Add((transform.position.x - area.transform.position.x));
 		state.Add((transform.position.y - area.transform.position.y));
 		state.Add((transform.position.z + 5 - area.transform.position.z));

--- a/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/AreaAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/AreaAgent.cs
@@ -9,7 +9,6 @@ public class AreaAgent : Agent
 
     public override List<float> CollectState()
     {
-        List<float> state = new List<float>();
         Vector3 velocity = GetComponent<Rigidbody>().velocity;
 
 		state.Add((transform.position.x - area.transform.position.x));

--- a/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/Push/PushAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/Push/PushAgent.cs
@@ -7,16 +7,21 @@ public class PushAgent : AreaAgent
 	public GameObject goalHolder;
     public GameObject block;
 
+    Rigidbody rb;
+
+    Vector3 velocity;
+    Vector3 blockVelocity;
+
     public override void InitializeAgent()
     {
 		base.InitializeAgent();
+        rb = GetComponent<Rigidbody>();
     }
 
 	public override List<float> CollectState()
 	{
-		List<float> state = new List<float>();
-        Vector3 velocity = GetComponent<Rigidbody>().velocity;
-        Vector3 blockVelocity = block.GetComponent<Rigidbody>().velocity;
+        velocity = rb.velocity;
+        blockVelocity = block.GetComponent<Rigidbody>().velocity;
         state.Add((transform.position.x - area.transform.position.x));
         state.Add((transform.position.y - area.transform.position.y));
         state.Add((transform.position.z + 5 - area.transform.position.z));
@@ -60,7 +65,7 @@ public class PushAgent : AreaAgent
 	{
         float xVariation = GameObject.Find("Academy").GetComponent<PushAcademy>().xVariation;
         transform.position = new Vector3(Random.Range(-xVariation, xVariation), 1.1f, -8f) + area.transform.position;
-		GetComponent<Rigidbody>().velocity = new Vector3(0f, 0f, 0f);
+		rb.velocity = new Vector3(0f, 0f, 0f);
 
         area.GetComponent<Area>().ResetArea();
 	}

--- a/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/Wall/WallAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Area/Scripts/Wall/WallAgent.cs
@@ -15,7 +15,6 @@ public class WallAgent : AreaAgent
 
 	public override List<float> CollectState()
 	{
-		List<float> state = new List<float>();
         Vector3 velocity = GetComponent<Rigidbody>().velocity;
         state.Add((transform.position.x - area.transform.position.x));
         state.Add((transform.position.y - area.transform.position.y));

--- a/unity-environment/Assets/ML-Agents/Examples/Basic/Scripts/BasicAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Basic/Scripts/BasicAgent.cs
@@ -15,7 +15,6 @@ public class BasicAgent : Agent
 
 	public override List<float> CollectState()
 	{
-		List<float> state = new List<float>();
 		state.Add(position);
 		return state;
 	}

--- a/unity-environment/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgentConfigurable.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgentConfigurable.cs
@@ -56,7 +56,6 @@ public class CrawlerAgentConfigurable: Agent
 
     public override List<float> CollectState()
     {
-        List<float> state = new List<float>();
         state.Add(body.transform.rotation.eulerAngles.x);
         state.Add(body.transform.rotation.eulerAngles.y);
         state.Add(body.transform.rotation.eulerAngles.z);

--- a/unity-environment/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -33,7 +33,7 @@ public class GridAgent : Agent
         GameObject agent = academy.actorObjs[0];
         foreach (GameObject actor in academy.actorObjs)
         {
-            if (actor.tag == "agent")
+            if (actor.CompareTag("agent"))
             {
                 agent = actor;
                 state.Add(actor.transform.position.x / (gridSize + 1));
@@ -43,7 +43,7 @@ public class GridAgent : Agent
         }
         foreach (GameObject actor in academy.actorObjs)
         {
-            if (actor.tag == "goal")
+            if (actor.CompareTag("goal"))
             {
                 int distance = (int)Mathf.Abs(agent.transform.position.x - actor.transform.position.x) + (int)Mathf.Abs(agent.transform.position.z - actor.transform.position.z);
                 if (closestGoalDistance > distance)
@@ -52,7 +52,7 @@ public class GridAgent : Agent
                     currentClosestGoal = actor;
                 }
             }
-            if (actor.tag == "pit")
+            if (actor.CompareTag("pit"))
             {
                 int distance = (int)Mathf.Abs(agent.transform.position.x - actor.transform.position.x) + (int)Mathf.Abs(agent.transform.position.z - actor.transform.position.z);
                 if (closestPitDistance > distance)

--- a/unity-environment/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -31,7 +31,6 @@ public class GridAgent : Agent
         int closestPitDistance = 2 * (int)academy.resetParameters["gridSize"];
         GameObject currentClosestPit = academy.actorObjs[0];
         GameObject agent = academy.actorObjs[0];
-        List<float> state = new List<float>();
         foreach (GameObject actor in academy.actorObjs)
         {
             if (actor.tag == "agent")

--- a/unity-environment/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
@@ -21,7 +21,6 @@ public class ReacherAgent : Agent {
 
 	public override List<float> CollectState()
 	{
-		List<float> state = new List<float>();
         state.Add(pendulumA.transform.rotation.x);
         state.Add(pendulumA.transform.rotation.y);
         state.Add(pendulumA.transform.rotation.z);

--- a/unity-environment/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
+++ b/unity-environment/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
@@ -14,7 +14,6 @@ public class TennisAgent : Agent
 
     public override List<float> CollectState()
     {
-        List<float> state = new List<float>();
         state.Add(invertMult * gameObject.transform.position.x);
         state.Add(gameObject.transform.position.y);
         state.Add(invertMult * gameObject.GetComponent<Rigidbody>().velocity.x);

--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -74,8 +74,6 @@ public abstract class Academy : MonoBehaviour
     [HideInInspector]
     private List<Brain> brains = new List<Brain>();
 
-
-
     ExternalCommand externalCommand;
 
     private bool acceptingSteps;

--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -198,14 +198,18 @@ public abstract class Academy : MonoBehaviour
                 brain.SendDone();
             }
             brain.ResetIfDone();
-        }
 
-        SendState();
+            brain.SendState();
 
-        foreach (Brain brain in brains)
-        {
             brain.ResetDoneAndReward();
         }
+
+        //SendState();
+
+        //foreach (Brain brain in brains)
+        //{
+        //    brain.ResetDoneAndReward();
+        //}
     }
 
     // Called before AcademyReset().
@@ -226,13 +230,13 @@ public abstract class Academy : MonoBehaviour
     }
 
     // Instructs all brains to collect states from their agents.
-    private void SendState()
-    {
-        foreach (Brain brain in brains)
-        {
-            brain.SendState();
-        }
-    }
+    //private void SendState()
+    //{
+    //    foreach (Brain brain in brains)
+    //    {
+    //        brain.SendState();
+    //    }
+    //}
 
     // Instructs all brains to process states to produce actions.
     private void DecideAction()

--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -204,12 +204,6 @@ public abstract class Academy : MonoBehaviour
             brain.ResetDoneAndReward();
         }
 
-        //SendState();
-
-        //foreach (Brain brain in brains)
-        //{
-        //    brain.ResetDoneAndReward();
-        //}
     }
 
     // Called before AcademyReset().
@@ -228,15 +222,6 @@ public abstract class Academy : MonoBehaviour
         }
 
     }
-
-    // Instructs all brains to collect states from their agents.
-    //private void SendState()
-    //{
-    //    foreach (Brain brain in brains)
-    //    {
-    //        brain.SendState();
-    //    }
-    //}
 
     // Instructs all brains to process states to produce actions.
     private void DecideAction()

--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -62,13 +62,14 @@ public abstract class Academy : MonoBehaviour
     private ScreenConfiguration inferenceConfiguration = new ScreenConfiguration(1280, 720, 5, 1.0f, 60);
     [SerializeField]
     private ResetParameter[] defaultResetParameters;
-    public Dictionary<string, float> resetParameters;
+
     /**< \brief Contains a mapping from parameter names to float values. */
     /**< You can specify the Default Reset Parameters in the Inspector of the
-	 * Academy. You can modify these parameters when training with an External 
-	 * brain by passing a config dictionary at reset. Reference resetParameters
-	 * in your AcademyReset() or AcademyStep() to modify elements in your 
-	 * environment at reset time. */
+     * Academy. You can modify these parameters when training with an External 
+     * brain by passing a config dictionary at reset. Reference resetParameters
+     * in your AcademyReset() or AcademyStep() to modify elements in your 
+     * environment at reset time. */
+    public Dictionary<string, float> resetParameters;
 
 
     [HideInInspector]
@@ -79,26 +80,28 @@ public abstract class Academy : MonoBehaviour
     private bool acceptingSteps;
     private int framesSinceAction;
     private bool skippingFrames = true;
-    [HideInInspector]
-    public bool done;
+
     /**< \brief The done flag of the Academy. */
     /**< When set to true, the Academy will call AcademyReset() instead of 
-	* AcademyStep() at step time.
-	* If true, all agents done flags will be set to true.*/
+    * AcademyStep() at step time.
+    * If true, all agents done flags will be set to true.*/
     [HideInInspector]
-    public int episodeCount;
+    public bool done;
+
     /**< \brief Increments each time the environment is reset. */
     [HideInInspector]
-    public int currentStep;
+    public int episodeCount;
+
     /**< \brief Increments each time a step is taken in the environment. Is
     * reset to 0 during AcademyReset(). */
+    [HideInInspector]
+    public int currentStep;
 
-    public Communicator communicator;
     /**< \brief Do not modify : pointer to the communicator currently in 
      * use by the Academy. */
+    public Communicator communicator;
 
     private float timeAtStep;
-
 
     void Awake()
     {

--- a/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
@@ -9,75 +9,75 @@ using UnityEngine;
  */
 public abstract class Agent : MonoBehaviour
 {
-    public Brain brain;
     /**<  \brief  The brain that will control this agent. */
     /**< Use the inspector to drag the desired brain gameObject into
 	 * the Brain field */
+    public Brain brain;
 
-    public List<Camera> observations;
     /**<  \brief  The list of the cameras the Agent uses as observations. */
     /**< These cameras will be used to generate the observations */
+    public List<Camera> observations;
 
-    public int maxStep;
     /**<  \brief  The number of steps the agent takes before being done. */
     /**< If set to 0, the agent can only be set to done via a script.
     * If set to any positive integer, the agent will be set to done after that
     * many steps each episode. */
+    public int maxStep;
 
-    public bool resetOnDone = true;
     /**<  \brief Determines the behaviour of the Agent when done.*/
     /**< If true, the agent will reset when done. 
 	 * If not, the agent will remain done, and no longer take actions.*/
+    public bool resetOnDone = true;
 
-    public List<float> state;
     // State list for the agent.
+    public List<float> state;
 
-    [HideInInspector]
-    public float reward;
     /**< \brief Describes the reward for the given step of the agent.*/
     /**< It is reset to 0 at the beginning of every step. 
-	* Modify in AgentStep(). 
-	* Should be set to positive to reinforcement desired behavior, and
-	* set to a negative value to punish undesireable behavior.
+    * Modify in AgentStep(). 
+    * Should be set to positive to reinforcement desired behavior, and
+    * set to a negative value to punish undesireable behavior.
     * Additionally, the magnitude of the reward should not exceed 1.0 */
-
     [HideInInspector]
-    public bool done;
+    public float reward;
+
     /**< \brief Whether or not the agent is done*/
     /**< Set to true when the agent has acted in some way which ends the 
-	 * episode for the given agent. */
-
+     * episode for the given agent. */
     [HideInInspector]
-    public float value;
+    public bool done;
+
     /**< \brief The current value estimate of the agent */
     /**<  When using an External brain, you can pass value estimates to the
-	 * agent at every step using env.Step(actions, values).
-	 * If AgentMonitor is attached to the Agent, this value will be displayed.*/
+     * agent at every step using env.Step(actions, values).
+     * If AgentMonitor is attached to the Agent, this value will be displayed.*/
+    [HideInInspector]
+    public float value;
 
+    /**< \brief Do not modify: This keeps track of the cumulative reward.*/
     [HideInInspector]
     public float CumulativeReward;
-    /**< \brief Do not modify: This keeps track of the cumulative reward.*/
 
-    [HideInInspector]
-    public int stepCounter;
     /**< \brief Do not modify: This keeps track of the number of steps taken by
      * the agent each episode.*/
-
     [HideInInspector]
-    public float[] agentStoredAction;
+    public int stepCounter;
+
     /**< \brief Do not modify: This keeps track of the last actions decided by
      * the brain.*/
-
     [HideInInspector]
-    public float[] memory;
+    public float[] agentStoredAction;
+
     /**< \brief Do not modify directly: This is used by the brain to store 
      * information about the previous states of the agent*/
-
     [HideInInspector]
-    public int id;
+    public float[] memory;
+
     /**< \brief Do not modify : This is the unique Identifier each agent 
      * receives at initialization. It is used by the brain to identify
      * the agent.*/
+    [HideInInspector]
+    public int id;
 
     void OnEnable()
     {

--- a/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
@@ -29,6 +29,9 @@ public abstract class Agent : MonoBehaviour
     /**< If true, the agent will reset when done. 
 	 * If not, the agent will remain done, and no longer take actions.*/
 
+    public List<float> state;
+    // State list for the agent.
+
     [HideInInspector]
     public float reward;
     /**< \brief Describes the reward for the given step of the agent.*/
@@ -140,7 +143,7 @@ public abstract class Agent : MonoBehaviour
 	*/
     public virtual void InitializeAgent()
     {
-
+        state = new List<float>(brain.brainParameters.stateSize);
     }
 
     /// Collect the states of the agent with this method
@@ -151,9 +154,15 @@ public abstract class Agent : MonoBehaviour
 	 *  Note : The order of the elements in the state list is important.
 	 *  @returns state A list of floats corresponding to the state of the agent. 
 	*/
+
+    public List<float> ClearAndCollectState() {
+        state.Clear();
+        CollectState();
+        return state;
+    }
+
     public virtual List<float> CollectState()
     {
-        List<float> state = new List<float>();
         return state;
     }
 

--- a/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
@@ -217,7 +217,6 @@ public abstract class Agent : MonoBehaviour
     public void SetCumulativeReward()
     {
         CumulativeReward += reward;
-        //Debug.Log(reward);
     }
 
     /// Do not modify : Is used by the brain to collect done.

--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -90,12 +90,12 @@ public class BrainParameters
 public class Brain : MonoBehaviour
 {
     // Current agent info
-    public Dictionary<int, List<float>> currentStates = new Dictionary<int, List<float>>();
-    public Dictionary<int, List<Camera>> currentCameras = new Dictionary<int, List<Camera>>();
-    public Dictionary<int, float> currentRewards = new Dictionary<int, float>();
-    public Dictionary<int, bool> currentDones = new Dictionary<int, bool>();
-    public Dictionary<int, float[]> currentActions = new Dictionary<int, float[]>();
-    public Dictionary<int, float[]> currentMemories = new Dictionary<int, float[]>();
+    public Dictionary<int, List<float>> currentStates = new Dictionary<int, List<float>>(32);
+    public Dictionary<int, List<Camera>> currentCameras = new Dictionary<int, List<Camera>>(32);
+    public Dictionary<int, float> currentRewards = new Dictionary<int, float>(32);
+    public Dictionary<int, bool> currentDones = new Dictionary<int, bool>(32);
+    public Dictionary<int, float[]> currentActions = new Dictionary<int, float[]>(32);
+    public Dictionary<int, float[]> currentMemories = new Dictionary<int, float[]>(32);
 
 
     public BrainParameters brainParameters = new BrainParameters();
@@ -232,15 +232,10 @@ public class Brain : MonoBehaviour
             }
 
             currentStates.Add(idAgent.Key, states);
-
             currentCameras.Add(idAgent.Key, observations);
-
             currentRewards.Add(idAgent.Key, idAgent.Value.reward);
-
             currentDones.Add(idAgent.Key, idAgent.Value.done);
-
             currentActions.Add(idAgent.Key, idAgent.Value.agentStoredAction);
-
             currentMemories.Add(idAgent.Key, idAgent.Value.memory);
         }
     }

--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -212,7 +212,7 @@ public class Brain : MonoBehaviour
         foreach (KeyValuePair<int, Agent> idAgent in agents)
         {
             idAgent.Value.SetCumulativeReward();
-            List<float> states = idAgent.Value.CollectState();
+            List<float> states = idAgent.Value.ClearAndCollectState();
             if ((states.Count != brainParameters.stateSize) && (brainParameters.stateSpaceType == StateType.continuous))
             {
                 throw new UnityAgentsException(string.Format(@"The number of states does not match for agent {0}:
@@ -249,7 +249,7 @@ public class Brain : MonoBehaviour
         foreach (KeyValuePair<int, Agent> idAgent in agents)
         {
             idAgent.Value.SetCumulativeReward();
-            List<float> states = idAgent.Value.CollectState();
+            List<float> states = idAgent.Value.ClearAndCollectState();
             if ((states.Count != brainParameters.stateSize) && (brainParameters.stateSpaceType == StateType.continuous))
             {
                 throw new UnityAgentsException(string.Format(@"The number of states does not match for agent {0}:
@@ -389,8 +389,7 @@ public class Brain : MonoBehaviour
     /// which are not done
     public void Step()
     {
-        List<Agent> agentsToIterate = agents.Values.ToList();
-        foreach (Agent agent in agentsToIterate)
+        foreach (Agent agent in agents.Values)
         {
             if (!agent.done)
             {
@@ -402,8 +401,7 @@ public class Brain : MonoBehaviour
     /// Is used by the Academy to reset the agents if they are done
     public void ResetIfDone()
     {
-        List<Agent> agentsToIterate = agents.Values.ToList();
-        foreach (Agent agent in agentsToIterate)
+        foreach (Agent agent in agents.Values)
         {
             if (agent.done)
             {
@@ -422,8 +420,7 @@ public class Brain : MonoBehaviour
     /// Is used by the Academy to reset all agents 
     public void Reset()
     {
-        List<Agent> agentsToIterate = agents.Values.ToList();
-        foreach (Agent agent in agentsToIterate)
+        foreach (Agent agent in agents.Values)
         {
             agent.Reset();
             agent.done = false;

--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -490,14 +490,14 @@ public class Brain : MonoBehaviour
     ///  (as list of float arrays)
     public List<float[,,,]> GetObservationMatrixList(List<int> agent_keys)
     {
-        List<float[,,,]> observation_matrix_list = new List<float[,,,]>();
+        var observation_matrix_list = new List<float[,,,]>();
         Dictionary<int, List<Camera>> observations = CollectObservations();
         for (int obs_number = 0; obs_number < brainParameters.cameraResolutions.Length; obs_number++)
         {
-            int width = brainParameters.cameraResolutions[obs_number].width;
-            int height = brainParameters.cameraResolutions[obs_number].height;
-            bool bw = brainParameters.cameraResolutions[obs_number].blackAndWhite;
-            int pixels = 0;
+            var width = brainParameters.cameraResolutions[obs_number].width;
+            var height = brainParameters.cameraResolutions[obs_number].height;
+            var bw = brainParameters.cameraResolutions[obs_number].blackAndWhite;
+            var pixels = 0;
             if (bw)
                 pixels = 1;
             else
@@ -506,7 +506,7 @@ public class Brain : MonoBehaviour
             , height
             , width
             , pixels];
-            int i = 0;
+            var i = 0;
             foreach (int k in agent_keys)
             {
                 Camera agent_obs = observations[k][obs_number];

--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -97,21 +97,22 @@ public class Brain : MonoBehaviour
     public Dictionary<int, float[]> currentActions = new Dictionary<int, float[]>(32);
     public Dictionary<int, float[]> currentMemories = new Dictionary<int, float[]>(32);
 
-
-    public BrainParameters brainParameters = new BrainParameters();
     /**< \brief Defines brain specific parameters such as the state size*/
-    public BrainType brainType;
+    public BrainParameters brainParameters = new BrainParameters();
+
     /**<  \brief Defines what is the type of the brain : 
      * External / Internal / Player / Heuristic*/
+    public BrainType brainType;
+
     [HideInInspector]
-    public Dictionary<int, Agent> agents = new Dictionary<int, Agent>();
     /**<  \brief Keeps track of the agents which subscribe to this brain*/
+    public Dictionary<int, Agent> agents = new Dictionary<int, Agent>();
 
     [SerializeField]
     ScriptableObject[] CoreBrains;
 
-    public CoreBrain coreBrain;
     /**<  \brief Reference to the current CoreBrain used by the brain*/
+    public CoreBrain coreBrain;
 
     //Ensures the coreBrains are not dupplicated with the brains
     [SerializeField]

--- a/unity-environment/Assets/ML-Agents/Scripts/Communicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Communicator.cs
@@ -9,21 +9,27 @@ using UnityEngine;
  */
 public struct AcademyParameters
 {
-    public string AcademyName;
     /**< \brief The name of the Academy. If the communicator is External, 
      * it will be the name of the Academy GameObject */
-    public string apiNumber;
+    public string AcademyName;
+
     /**< \brief The API number for the communicator. */
+    public string apiNumber;
+
+    /**< \brief The location of the logfile*/
     public string logPath;
-	/**< \brief The location of the logfile*/
-	public Dictionary<string, float> resetParameters;
+
     /**< \brief The default reset parameters are sent via socket*/
-    public List<string> brainNames;
+	public Dictionary<string, float> resetParameters;
+
     /**< \brief A list of the all the brains names sent via socket*/
-    public List<BrainParameters> brainParameters;
+    public List<string> brainNames;
+
     /**< \brief  A list of the External brains parameters sent via socket*/
-    public List<string> externalBrainNames;
+    public List<BrainParameters> brainParameters;
+
     /**< \brief  A list of the External brains names sent via socket*/
+    public List<string> externalBrainNames;
 }
 
 public enum ExternalCommand

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
@@ -5,9 +5,8 @@ using UnityEngine;
 /// CoreBrain which decides actions via communication with an external system such as Python.
 public class CoreBrainExternal : ScriptableObject, CoreBrain
 {
-
-    public Brain brain;
     /**< Reference to the brain that uses this CoreBrainExternal */
+    public Brain brain;
 
     ExternalCommunicator coord;
 

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
@@ -12,13 +12,13 @@ public class CoreBrainHeuristic : ScriptableObject, CoreBrain
     [SerializeField]
     private bool broadcast = true;
 
-    public Brain brain;
     /**< Reference to the brain that uses this CoreBrainHeuristic */
+    public Brain brain;
 
     ExternalCommunicator coord;
 
-    public Decision decision;
     /**< Reference to the Decision component used to decide the actions */
+    public Decision decision;
 
     /// Create the reference to the brain
     public void SetBrain(Brain b)

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
@@ -51,8 +51,8 @@ public class CoreBrainHeuristic : ScriptableObject, CoreBrain
             throw new UnityAgentsException("The Brain is set to Heuristic, but no decision script attached to it");
         }
 
-        Dictionary<int, float[]> actions = new Dictionary<int, float[]>();
-        Dictionary<int, float[]> new_memories = new Dictionary<int, float[]>();
+        var actions = new Dictionary<int, float[]>();
+        var new_memories = new Dictionary<int, float[]>();
         Dictionary<int, List<float>> states = brain.CollectStates();
         Dictionary<int, List<Camera>> observations = brain.CollectObservations();
         Dictionary<int, float> rewards = brain.CollectRewards();

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainInternal.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainInternal.cs
@@ -153,7 +153,7 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
         {
             Dictionary<int, List<float>> states = brain.CollectStates();
             inputState = new float[currentBatchSize, brain.brainParameters.stateSize];
-            int i = 0;
+            var i = 0;
             foreach (int k in agentKeys)
             {
                 List<float> state_list = states[k];
@@ -175,7 +175,7 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
         {
             Dictionary<int, float[]> old_memories = brain.CollectMemories();
             inputOldMemories = new float[currentBatchSize, brain.brainParameters.memorySize];
-            int i = 0;
+            var i = 0;
             foreach (int k in agentKeys)
             {
                 float[] m = old_memories[k];
@@ -241,7 +241,7 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
         {
             if (brain.brainParameters.stateSpaceType == StateType.discrete)
             {
-                int[,] discreteInputState = new int[currentBatchSize, 1];
+                var discreteInputState = new int[currentBatchSize, 1];
                 for (int i = 0; i < currentBatchSize; i++)
                 {
                     discreteInputState[i, 0] = (int)inputState[i, 0];
@@ -290,14 +290,14 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
         // Create the recurrent tensor
         if (hasRecurrent)
         {
-            Dictionary<int, float[]> new_memories = new Dictionary<int, float[]>();
+            var new_memories = new Dictionary<int, float[]>();
 
             float[,] recurrent_tensor = networkOutput[1].GetValue() as float[,];
 
-            int i = 0;
+            var i = 0;
             foreach (int k in agentKeys)
             {
-                float[] m = new float[brain.brainParameters.memorySize];
+                var m = new float[brain.brainParameters.memorySize];
                 for (int j = 0; j < brain.brainParameters.memorySize; j++)
                 {
                     m[j] = recurrent_tensor[i, j];
@@ -309,15 +309,15 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
             brain.SendMemories(new_memories);
         }
 
-        Dictionary<int, float[]> actions = new Dictionary<int, float[]>();
+        var actions = new Dictionary<int, float[]>();
 
         if (brain.brainParameters.actionSpaceType == StateType.continuous)
         {
-            float[,] output = networkOutput[0].GetValue() as float[,];
-            int i = 0;
+            var output = networkOutput[0].GetValue() as float[,];
+            var i = 0;
             foreach (int k in agentKeys)
             {
-                float[] a = new float[brain.brainParameters.actionSize];
+                var a = new float[brain.brainParameters.actionSize];
                 for (int j = 0; j < brain.brainParameters.actionSize; j++)
                 {
                     a[j] = output[i, j];
@@ -329,10 +329,10 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
         else if (brain.brainParameters.actionSpaceType == StateType.discrete)
         {
             long[,] output = networkOutput[0].GetValue() as long[,];
-            int i = 0;
+            var i = 0;
             foreach (int k in agentKeys)
             {
-                float[] a = new float[1] { (float)(output[i, 0]) };
+                var a = new float[1] { (float)(output[i, 0]) };
                 actions.Add(k, a);
                 i++;
             }
@@ -349,9 +349,9 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
 #if ENABLE_TENSORFLOW && UNITY_EDITOR
         EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
         broadcast = EditorGUILayout.Toggle("Broadcast", broadcast);
-        SerializedObject serializedBrain = new SerializedObject(this);
+        var serializedBrain = new SerializedObject(this);
         GUILayout.Label("Edit the Tensorflow graph parameters here");
-        SerializedProperty tfGraphModel = serializedBrain.FindProperty("graphModel");
+        var tfGraphModel = serializedBrain.FindProperty("graphModel");
         serializedBrain.Update();
         EditorGUILayout.ObjectField(tfGraphModel);
         serializedBrain.ApplyModifiedProperties();
@@ -405,7 +405,7 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
                         ObservationPlaceholderName[obs_number] = "observation_" + obs_number;
                     }
                 }
-                SerializedProperty opn = serializedBrain.FindProperty("ObservationPlaceholderName");
+                var opn = serializedBrain.FindProperty("ObservationPlaceholderName");
                 serializedBrain.Update();
                 EditorGUILayout.PropertyField(opn, true);
                 serializedBrain.ApplyModifiedProperties();
@@ -420,7 +420,7 @@ public class CoreBrainInternal : ScriptableObject, CoreBrain
 
 
 
-        SerializedProperty tfPlaceholders = serializedBrain.FindProperty("graphPlaceholders");
+        var tfPlaceholders = serializedBrain.FindProperty("graphPlaceholders");
         serializedBrain.Update();
         EditorGUILayout.PropertyField(tfPlaceholders, true);
         serializedBrain.ApplyModifiedProperties();

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainPlayer.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainPlayer.cs
@@ -69,7 +69,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
     {
         if (brain.brainParameters.actionSpaceType == StateType.continuous)
         {
-            float[] action = new float[brain.brainParameters.actionSize];
+            var action = new float[brain.brainParameters.actionSize];
             foreach (ContinuousPlayerAction cha in continuousPlayerActions)
             {
                 if (Input.GetKey(cha.key))
@@ -77,7 +77,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
                     action[cha.index] = cha.value;
                 }
             }
-            Dictionary<int, float[]> actions = new Dictionary<int, float[]>();
+            var actions = new Dictionary<int, float[]>();
             foreach (KeyValuePair<int, Agent> idAgent in brain.agents)
             {
                 actions.Add(idAgent.Key, action);
@@ -86,7 +86,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
         }
         else
         {
-            float[] action = new float[1] { defaultAction };
+            var action = new float[1] { defaultAction };
             foreach (DiscretePlayerAction dha in discretePlayerActions)
             {
                 if (Input.GetKey(dha.key))
@@ -95,7 +95,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
                     break;
                 }
             }
-            Dictionary<int, float[]> actions = new Dictionary<int, float[]>();
+            var actions = new Dictionary<int, float[]>();
             foreach (KeyValuePair<int, Agent> idAgent in brain.agents)
             {
                 actions.Add(idAgent.Key, action);
@@ -125,11 +125,11 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
 #if UNITY_EDITOR
         EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
         broadcast = EditorGUILayout.Toggle("Broadcast", broadcast);
-        SerializedObject serializedBrain = new SerializedObject(this);
+        var serializedBrain = new SerializedObject(this);
         if (brain.brainParameters.actionSpaceType == StateType.continuous)
         {
             GUILayout.Label("Edit the continuous inputs for you actions", EditorStyles.boldLabel);
-            SerializedProperty chas = serializedBrain.FindProperty("continuousPlayerActions");
+            var chas = serializedBrain.FindProperty("continuousPlayerActions");
             serializedBrain.Update();
             EditorGUILayout.PropertyField(chas, true);
             serializedBrain.ApplyModifiedProperties();
@@ -151,7 +151,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
         {
             GUILayout.Label("Edit the discrete inputs for you actions", EditorStyles.boldLabel);
             defaultAction = EditorGUILayout.IntField("Default Action", defaultAction);
-            SerializedProperty dhas = serializedBrain.FindProperty("discretePlayerActions");
+            var dhas = serializedBrain.FindProperty("discretePlayerActions");
             serializedBrain.Update();
             EditorGUILayout.PropertyField(dhas, true);
             serializedBrain.ApplyModifiedProperties();

--- a/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
@@ -98,10 +98,7 @@ public class ExternalCommunicator : Communicator
         hasSentState[brain.gameObject.name] = false;
     }
 
-    /// <summary>
     /// Attempts to make handshake with external API. 
-    /// </summary>
-    /// <returns><c>true</c>, if hand shake was communicatored, <c>false</c> otherwise.</returns>
     public bool CommunicatorHandShake()
     {
         try
@@ -130,7 +127,7 @@ public class ExternalCommunicator : Communicator
         sender = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         sender.Connect("localhost", comPort);
 
-        AcademyParameters accParamerters = new AcademyParameters();
+        var accParamerters = new AcademyParameters();
         accParamerters.brainParameters = new List<BrainParameters>();
         accParamerters.brainNames = new List<string>();
         accParamerters.externalBrainNames = new List<string>();
@@ -186,7 +183,7 @@ public class ExternalCommunicator : Communicator
     {
         sender.Send(Encoding.ASCII.GetBytes("CONFIG_REQUEST"));
         Receive();
-        ResetParametersMessage resetParams = JsonConvert.DeserializeObject<ResetParametersMessage>(rMessage);
+        var resetParams = JsonConvert.DeserializeObject<ResetParametersMessage>(rMessage);
         academy.isInference = !resetParams.train_model;
         return resetParams.parameters;
     }
@@ -196,7 +193,7 @@ public class ExternalCommunicator : Communicator
     private void ReadArgs()
     {
         string[] args = System.Environment.GetCommandLineArgs();
-        string inputPort = "";
+        var inputPort = "";
         for (int i = 0; i < args.Length; i++)
         {
             if (args[i] == "--port")
@@ -250,7 +247,7 @@ public class ExternalCommunicator : Communicator
     /// Collects the information from the brains and sends it accross the socket
     public void giveBrainInfo(Brain brain)
     {
-        string brainName = brain.gameObject.name;
+        var brainName = brain.gameObject.name;
         current_agents[brainName] = new List<int>(brain.agents.Keys);
         brain.CollectEverything();
 
@@ -313,17 +310,17 @@ public class ExternalCommunicator : Communicator
         // TO MODIFY	--------------------------------------------
         sender.Send(Encoding.ASCII.GetBytes("STEPPING"));
         Receive();
-        AgentMessage agentMessage = JsonConvert.DeserializeObject<AgentMessage>(rMessage);
+        var agentMessage = JsonConvert.DeserializeObject<AgentMessage>(rMessage);
 
         foreach (Brain brain in brains)
         {
             if (brain.brainType == BrainType.External)
             {
-                string brainName = brain.gameObject.name;
+                var brainName = brain.gameObject.name;
 
-                Dictionary<int, float[]> actionDict = new Dictionary<int, float[]>();
-                Dictionary<int, float[]> memoryDict = new Dictionary<int, float[]>();
-                Dictionary<int, float> valueDict = new Dictionary<int, float>();
+                var actionDict = new Dictionary<int, float[]>();
+                var memoryDict = new Dictionary<int, float[]>();
+                var valueDict = new Dictionary<int, float>();
 
                 for (int i = 0; i < current_agents[brainName].Count; i++)
                 {

--- a/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
@@ -43,7 +43,7 @@ public class ExternalCommunicator : Communicator
 
     const string api = "API-2";
 
-    private class StepMessage
+    struct StepMessage
     {
         public string brain_name { get; set; }
 
@@ -60,7 +60,7 @@ public class ExternalCommunicator : Communicator
         public List<bool> dones { get; set; }
     }
 
-    private class AgentMessage
+    struct AgentMessage
     {
         public Dictionary<string, List<float>> action { get; set; }
 
@@ -70,7 +70,7 @@ public class ExternalCommunicator : Communicator
 
     }
 
-    private class ResetParametersMessage
+    struct ResetParametersMessage
     {
         public Dictionary<string, float> parameters { get; set; }
 

--- a/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
@@ -43,6 +43,7 @@ public class ExternalCommunicator : Communicator
 
     const string api = "API-2";
 
+    /// Placeholder for state information to send.
     [System.Serializable]
     public struct StepMessage
     {
@@ -60,6 +61,7 @@ public class ExternalCommunicator : Communicator
 
     string rMessage;
 
+    /// Placeholder for returned message.
     struct AgentMessage
     {
         public Dictionary<string, List<float>> action { get; set; }
@@ -67,6 +69,7 @@ public class ExternalCommunicator : Communicator
         public Dictionary<string, List<float>> value { get; set; }
     }
 
+    /// Placeholder for reset parameter message
     struct ResetParametersMessage
     {
         public Dictionary<string, float> parameters { get; set; }
@@ -95,7 +98,10 @@ public class ExternalCommunicator : Communicator
         hasSentState[brain.gameObject.name] = false;
     }
 
-
+    /// <summary>
+    /// Attempts to make handshake with external API. 
+    /// </summary>
+    /// <returns><c>true</c>, if hand shake was communicatored, <c>false</c> otherwise.</returns>
     public bool CommunicatorHandShake()
     {
         try

--- a/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
@@ -65,7 +65,6 @@ public class ExternalCommunicator : Communicator
         public Dictionary<string, List<float>> action { get; set; }
         public Dictionary<string, List<float>> memory { get; set; }
         public Dictionary<string, List<float>> value { get; set; }
-
     }
 
     struct ResetParametersMessage

--- a/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/ExternalCommunicator.cs
@@ -32,13 +32,6 @@ public class ExternalCommunicator : Communicator
     List<bool> concatenatedDones = new List<bool>(32);
     List<float> concatenatedActions = new List<float>(1024);
 
-    //Dictionary<int, List<Camera>> collectedObservations;
-    //Dictionary<int, List<float>> collectedStates;
-    //Dictionary<int, float> collectedRewards;
-    //Dictionary<int, float[]> collectedMemories;
-    //Dictionary<int, bool> collectedDones;
-    //Dictionary<int, float[]> collectedActions;
-
     private int comPort;
     Socket sender;
     byte[] messageHolder;

--- a/unity-environment/Assets/ML-Agents/Scripts/Monitor.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Monitor.cs
@@ -62,11 +62,11 @@ public class Monitor : MonoBehaviour
      * @param value The value you want to display.
      * @param displayType The type of display.
      * @param target The transform you want to attach the information to.
-     */ 
+     */
     public static void Log(
-        string key, 
-        object value, 
-        MonitorType displayType = MonitorType.text, 
+        string key,
+        object value,
+        MonitorType displayType = MonitorType.text,
         Transform target = null)
     {
 
@@ -98,7 +98,7 @@ public class Monitor : MonoBehaviour
         }
         if (!displayValues.ContainsKey(key))
         {
-            DisplayValue dv = new DisplayValue();
+            var dv = new DisplayValue();
             dv.time = Time.timeSinceLevelLoad;
             dv.value = value;
             dv.monitorDisplayType = displayType;
@@ -231,7 +231,7 @@ public class Monitor : MonoBehaviour
             float paddingwidth = 10 * widthScaler;
 
             float scale = 1f;
-            Vector2 origin = new Vector3(0, Screen.height);
+            var origin = new Vector3(0, Screen.height);
             if (!(target == canvas.transform))
             {
                 Vector3 cam2obj = target.position - Camera.main.transform.position;
@@ -359,17 +359,14 @@ public class Monitor : MonoBehaviour
         valueStyle = GUI.skin.label;
         valueStyle.clipping = TextClipping.Overflow;
         valueStyle.wordWrap = false;
-
-
-
         barColors = new Color[6]{ Color.magenta, Color.blue, Color.cyan, Color.green, Color.yellow, Color.red };
         colorStyle = new GUIStyle[barColors.Length];
         for (int i = 0; i < barColors.Length; i++)
         {
-            Texture2D texture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
+            var texture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
             texture.SetPixel(0, 0, barColors[i]);
             texture.Apply();
-            GUIStyle staticRectStyle = new GUIStyle();
+            var staticRectStyle = new GUIStyle();
             staticRectStyle.normal.background = texture;
             colorStyle[i] = staticRectStyle;
         }


### PR DESCRIPTION
* More efficient memory usage within core ML-Agents scripts, with special focus on `ExternalCommunication.cs`. 

* Reduces GC memory each frame from ~25 to ~5 when using external brain on `Push Area` environment, and `Time.Scale` of `25`.

* Introduces small breaking change where `state` var in `CollectState()` no longer needs to be created every time. This also means attempts to create it throw an error, as it is now created when the Agent is initialized. The fix is to delete the line, but this will need to be done by developers who have implemented their own environments. 