### PR TITLE
Fixed issue with unity environment not being found on MacOS

### DIFF
--- a/python/unityagents/environment.py
+++ b/python/unityagents/environment.py
@@ -73,6 +73,10 @@ class UnityEnvironment(object):
             candidates = glob.glob(os.path.join(cwd, file_name + '.app', 'Contents', 'MacOS', true_filename))
             if len(candidates) == 0:
                 candidates = glob.glob(os.path.join(file_name + '.app', 'Contents', 'MacOS', true_filename))
+            if len(candidates) == 0:
+                candidates = glob.glob(os.path.join(cwd, file_name + '.app', 'Contents', 'MacOS', '*'))
+            if len(candidates) == 0:
+                candidates = glob.glob(os.path.join(file_name + '.app', 'Contents', 'MacOS', '*'))
             if len(candidates) > 0:
                 launch_string = candidates[0]
         elif platform == 'win32':


### PR DESCRIPTION
Fixes the problem for MacOS mentioned in #200 and #229.

When the internal executable can't be found, it will look for any file in the 'Contents/MacOS/' folder and run it. If another solution is preferred (like optionally specifying the correct file name), let me know. But this should work for now. 😄 