### PR TITLE
 Fixed indent error in initialization

### DIFF
--- a/python/unityagents/curriculum.py
+++ b/python/unityagents/curriculum.py
@@ -44,7 +44,7 @@ class Curriculum(object):
                         "The parameter {0} in Curriculum {1} must have {2} values "
                         "but {3} were found".format(key, location,
                                                     self.max_lesson_number + 1, len(parameters[key])))
-        self.set_lesson_number(lesson)
+            self.set_lesson_number(lesson)
 
     @property
     def measure(self):


### PR DESCRIPTION
Hello, just a small typo found in curriculum.py when trying to train without curriculum_file.

set_lesson_number was called even if curriculum_file was equal to None, which was causing an error in the function since self.max_lesson_number wasn't declared.