### PR TITLE
[Docs] Update Balance Ball experiment eliminating graph placeholders

### DIFF
--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -93,8 +93,6 @@ Because TensorFlowSharp support is still experimental, it is disabled by default
 4. Select the `Ball3DBrain` object from the Scene hierarchy.
 5. Change the `Type of Brain` to `Internal`.
 6. Drag the `<env_name>.bytes` file from the Project window of the Editor to the `Graph Model` placeholder in the `3DBallBrain` inspector window.
-7. Set the `Graph Placeholder` size to 1 (_Note that step 7 and 8 are done because 3DBall is a continuous control environment, and the TensorFlow model requires a noise parameter to decide actions. In cases with discrete control, epsilon is not needed_).
-8. Add a placeholder called `epsilon` with a type of `floating point` and a range of values from `0` to `0`.
-9. Press the Play button at the top of the editor.
+7. Press the Play button at the top of the editor.
 
 If you followed these steps correctly, you should now see the trained model being used to control the behavior of the balance ball within the Editor itself. From here you can re-build the Unity binary, and run it standalone with your agent's new learned behavior built right in.


### PR DESCRIPTION
Updating Balance Ball docs to reflect [this](https://github.com/Unity-Technologies/ml-agents/commit/fd070935b94a444aa7c614849ec2648a8e70a581) commit. 