### PR TITLE
Modified the brain.SendState method to be brain.Request

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// Struct that contains all the information for an Agent, including its 
 /// observations, actions and current status, that is sent to the Brain.
 /// </summary>
-public struct AgentInfo
+public class AgentInfo
 {
     /// <summary>
     /// Most recent agent vector (i.e. numeric) observation.
@@ -74,11 +74,12 @@ public struct AgentInfo
 /// Struct that contains the action information sent from the Brain to the 
 /// Agent.
 /// </summary>
-public struct AgentAction
+public class AgentAction
 {
     public float[] vectorActions;
     public string textActions;
     public List<float> memories;
+
 }
 
 /// <summary>
@@ -563,7 +564,7 @@ public abstract class Agent : MonoBehaviour
         info.maxStepReached = maxStepReached;
         info.id = id;
 
-        brain.SendState(this, info);
+        brain.Request(info, action);
         info.textObservation = "";
     }
 
@@ -728,33 +729,6 @@ public abstract class Agent : MonoBehaviour
         ResetData();
         stepCount = 0;
         AgentReset();
-    }
-
-    /// <summary>
-    /// Updates the vector action.
-    /// </summary>
-    /// <param name="vectorActions">Vector actions.</param>
-    public void UpdateVectorAction(float[] vectorActions)
-    {
-        action.vectorActions = vectorActions;
-    }
-
-    /// <summary>
-    /// Updates the memories action.
-    /// </summary>
-    /// <param name="memories">Memories.</param>
-    public void UpdateMemoriesAction(List<float> memories)
-    {
-        action.memories = memories;
-    }
-
-    /// <summary>
-    /// Updates the text action.
-    /// </summary>
-    /// <param name="textActions">Text actions.</param>
-    public void UpdateTextAction(string textActions)
-    {
-        action.textActions = textActions;
     }
 
     /// <summary>

--- a/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Agent.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 
 /// <summary>
-/// Struct that contains all the information for an Agent, including its 
+/// Class that contains all the information for an Agent, including its 
 /// observations, actions and current status, that is sent to the Brain.
 /// </summary>
 public class AgentInfo
@@ -71,8 +71,9 @@ public class AgentInfo
 }
 
 /// <summary>
-/// Struct that contains the action information sent from the Brain to the 
-/// Agent.
+/// Class that contains the action information sent from the Brain to the 
+/// Agent. The AgentAction is a reference that enables the brain to directly
+/// modify its values.
 /// </summary>
 public class AgentAction
 {
@@ -201,10 +202,10 @@ public abstract class Agent : MonoBehaviour
     public AgentParameters agentParameters;
 
     /// Current Agent information (message sent to Brain).
-    AgentInfo info;
+    AgentInfo info = new AgentInfo();
 
     /// Current Agent action (message sent from Brain).
-    AgentAction action;
+    AgentAction action = new AgentAction();
 
     /// Represents the reward the agent accumulated during the current step.
     /// It is reset to 0 at the beginning of every step.

--- a/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Brain.cs
@@ -88,8 +88,8 @@ public class Brain : MonoBehaviour
 {
     private bool isInitialized = false;
 
-    private Dictionary<Agent, AgentInfo> agentInfos =
-        new Dictionary<Agent, AgentInfo>(1024);
+    private Dictionary<AgentInfo, AgentAction> agentRequests =
+        new Dictionary<AgentInfo, AgentAction>(1024);
 
     [Tooltip("Define state, observation, and action spaces for the Brain.")]
     /**< \brief Defines brain specific parameters such as the state size*/
@@ -211,34 +211,31 @@ public class Brain : MonoBehaviour
         isInitialized = true;
     }
 
-    public void SendState(Agent agent, AgentInfo info)
+    public void Request(AgentInfo info, AgentAction action)
     {
-        // If the brain is not active or not properly initialized, an error is
-        // thrown.
         if (!gameObject.activeSelf)
         {
             throw new UnityAgentsException(
-                string.Format("Agent {0} tried to request an action " +
-                "from brain {1} but it is not active.",
-                             agent.gameObject.name, gameObject.name));
+                string.Format("Attempt to request an action " +
+                "from brain {1} but it is not active.", 
+                              gameObject.name));
         }
         else if (!isInitialized)
         {
             throw new UnityAgentsException(
-                string.Format("Agent {0} tried to request an action " +
+                string.Format("Attempt to request an action " +
                 "from brain {1} but it was not initialized.",
-                             agent.gameObject.name, gameObject.name));
+                              gameObject.name));
         }
         else
         {
-            agentInfos.Add(agent, info);
+            agentRequests.Add(info, action);
         }
-
     }
 
     void DecideAction()
     {
-        coreBrain.DecideAction(agentInfos);
-        agentInfos.Clear();
+        coreBrain.DecideAction(agentRequests);
+        agentRequests.Clear();
     }
 }

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrain.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrain.cs
@@ -13,7 +13,7 @@ public interface CoreBrain
     /// Implement this method to initialize CoreBrain
     void InitializeCoreBrain(Communicator communicator);
     /// Implement this method to define the logic for deciding actions
-    void DecideAction(Dictionary<Agent, AgentInfo> agentInfo);
+    void DecideAction(Dictionary<AgentInfo, AgentAction> agentRequests);
     /// Implement this method to define what should be displayed in the brain Inspector
     void OnInspector();
 }

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
@@ -38,11 +38,11 @@ public class CoreBrainExternal : ScriptableObject, CoreBrain
 
     /// Uses the communicator to retrieve the actions, memories and values and
     ///  sends them to the agents
-    public void DecideAction(Dictionary<Agent, AgentInfo> agentInfo)
+    public void DecideAction(Dictionary<AgentInfo, AgentAction> agentRequest)
     {
         if (coord != null)
         {
-            coord.GiveBrainInfo(brain, agentInfo);
+            coord.GiveBrainInfo(brain, agentRequest);
         }
         return ;
     }

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainHeuristic.cs
@@ -44,11 +44,11 @@ public class CoreBrainHeuristic : ScriptableObject, CoreBrain
     }
 
     /// Uses the Decision Component to decide that action to take
-    public void DecideAction(Dictionary<Agent, AgentInfo> agentInfo)
+    public void DecideAction(Dictionary<AgentInfo, AgentAction> agentRequest)
     {
         if (coord!=null)
         {
-            coord.GiveBrainInfo(brain, agentInfo);
+            coord.GiveBrainInfo(brain, agentRequest);
         }
 
         if (decision == null)
@@ -56,25 +56,27 @@ public class CoreBrainHeuristic : ScriptableObject, CoreBrain
             throw new UnityAgentsException("The Brain is set to Heuristic, but no decision script attached to it");
         }
 
-        foreach (Agent agent in agentInfo.Keys)
+        foreach (AgentInfo info in agentRequest.Keys)
         {
-            agent.UpdateVectorAction(decision.Decide(
-                agentInfo[agent].stackedVectorObservation,
-                agentInfo[agent].visualObservations,
-                agentInfo[agent].reward,
-                agentInfo[agent].done,
-                agentInfo[agent].memories));
+            agentRequest[info].vectorActions = 
+                decision.Decide(
+                    info.stackedVectorObservation,
+                    info.visualObservations,
+                    info.reward,
+                    info.done,
+                    info.memories);
             
         }
 
-        foreach (Agent agent in agentInfo.Keys)
+        foreach (AgentInfo info in agentRequest.Keys)
         {
-            agent.UpdateMemoriesAction(decision.MakeMemory(
-                agentInfo[agent].stackedVectorObservation,
-                agentInfo[agent].visualObservations,
-                agentInfo[agent].reward,
-                agentInfo[agent].done,
-                agentInfo[agent].memories));
+            agentRequest[info].memories = 
+                decision.MakeMemory(
+                    info.stackedVectorObservation,
+                    info.visualObservations,
+                    info.reward,
+                    info.done,
+                    info.memories);
         }
     }
 

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainPlayer.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainPlayer.cs
@@ -67,15 +67,15 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
 
     /// Uses the continuous inputs or dicrete inputs of the player to 
     /// decide action
-    public void DecideAction(Dictionary<Agent, AgentInfo> agentInfo)
+    public void DecideAction(Dictionary<AgentInfo, AgentAction> agentRequest)
     {
 		if (coord != null)
 		{
-			coord.GiveBrainInfo(brain, agentInfo);
+			coord.GiveBrainInfo(brain, agentRequest);
 		}
         if (brain.brainParameters.vectorActionSpaceType == SpaceType.continuous)
         {
-            foreach (Agent agent in agentInfo.Keys)
+            foreach (AgentInfo info in agentRequest.Keys)
             {
                 var action = new float[brain.brainParameters.vectorActionSize];
                 foreach (ContinuousPlayerAction cha in continuousPlayerActions)
@@ -85,14 +85,14 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
                         action[cha.index] = cha.value;
                     }
                 }
-
-                agent.UpdateVectorAction(action);
+                agentRequest[info].vectorActions = action;
+                //agent.UpdateVectorAction(action);
             }
 
         }
         else
         {
-            foreach (Agent agent in agentInfo.Keys)
+            foreach (AgentInfo info in agentRequest.Keys)
             {
                 var action = new float[1] { defaultAction };
                 foreach (DiscretePlayerAction dha in discretePlayerActions)
@@ -105,7 +105,7 @@ public class CoreBrainPlayer : ScriptableObject, CoreBrain
                 }
 
 
-                agent.UpdateVectorAction(action);
+                agentRequest[info].vectorActions = action;
                 
             }
         }


### PR DESCRIPTION
 * brain.Request takes AgentInfo and AgentAction instead of Agent and AgentInfo
 * Made AgentInfo and AgentAction classes instead of structs so they are reference types instead of value types
 * This allows to modify the AgentAction by reference in the brain
 * The Brain receives an AgentInfo and And AgentAction and updates the later directly from the info in the former
 * Simplifies the logic
 * Enables the use of brain.Request without the need for an agent
 * Could enable an agent to hold multiple brains and query them for different purposes