### PR TITLE
Develop

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -54,6 +54,14 @@ and run from the command line:
 If you'd like to use Docker for ML-Agents, please follow 
 [this guide](Using-Docker.md). 
 
+## Unity Packages
+
+You can download ML-Agents as Unity Packages:
+
+ * [ML-Agents with TensorflowSharp Plugin](https://s3.amazonaws.com/unity-ml-agents/0.3/ML-AgentsWithPlugin.unitypackage)
+ * [ML-Agents without TensorflowSharp Plugin](https://s3.amazonaws.com/unity-ml-agents/0.3/ML-AgentsNoPlugin.unitypackage)
+ * [TensorflowSharp Plugin Only](https://s3.amazonaws.com/unity-ml-agents/0.3/TFSharpPlugin.unitypackage)
+
 ## Help
 
 If you run into any problems installing ML-Agents, 


### PR DESCRIPTION
In an empty project I get a compilation error after importing the ML-Agents folder that contains all scripts and examples.

This is the error log:

Assets/ML-Agents/Scripts/ExternalCommunicator.cs(269,24): error CS1061: Type `System.Text.StringBuilder' does not contain a definition for `Clear' and no extension method `Clear' of type `System.Text.StringBuilder' could be found. Are you missing an assembly reference?