### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,6 +62,14 @@ You can download ML-Agents as Unity Packages:
  * [ML-Agents without TensorflowSharp Plugin](https://s3.amazonaws.com/unity-ml-agents/0.3/ML-AgentsNoPlugin.unitypackage)
  * [TensorflowSharp Plugin Only](https://s3.amazonaws.com/unity-ml-agents/0.3/TFSharpPlugin.unitypackage)
 
+## Troubleshouting
+
+If you get the error : 
+
+    system.text.builder does not contain a definition for 'clear'
+
+You need to change the _Api Comptability Level_ : Edit -> Project Settings -> Player -> Other Settings -> Scripting Runtime Version = Experimental (.Net 4.6 Equivalent)
+
 ## Help
 
 If you run into any problems installing ML-Agents, 


### PR DESCRIPTION
By default Unity use .Net 3.5 which can cause trouble because the ML-Agents is using the function Clear on StringBuilder which is supported by .Net 4.0 or above