### PR TITLE
Slightly improved the instructions in the Ball Balancing tutorial

### DIFF
--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -317,7 +317,7 @@ during a successful training session.
 Once the training process completes, and the training process saves the model 
 (denoted by the `Saved Model` message) you can add it to the Unity project and 
 use it with agents having an **Internal** brain type.
-**Note** You shouldn't just close the unity Window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the triaing session and export the .byted file. Otherwise, the .bytes file will never be exported into the ml-agents folder.
+**Note** If you're using Anaconda, you shouldn't just close the Unity Window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the training session and export the .bytes file. Otherwise, the .bytes file will never be exported into the ml-agents folder.
 
 ### Setting up TensorFlowSharp Support
 

--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -267,7 +267,7 @@ for each training run. In other words, "BalanceBall1" for the first run,
 every training run are saved to the same directory and will all be included 
 on the same graph.
 
-To summarize, go to your command line, enter the `ml-agents` directory and type: 
+To summarize, go to your Anaconda command line, activate the ml-agents environment, enter the `ml-agents` directory and type: 
 
 ```python
 python3 python/learn.py <env_file_path> --run-id=<run-identifier> --train 
@@ -316,6 +316,7 @@ during a successful training session.
 Once the training process completes, and the training process saves the model 
 (denoted by the `Saved Model` message) you can add it to the Unity project and 
 use it with agents having an **Internal** brain type.
+**Note** You shouldn't just close the unity window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the triaing session and export the .byted file. Otherwise,, the byte file will neevr be exported into the ml-agents folder.
 
 ### Setting up TensorFlowSharp Support
 

--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -267,11 +267,12 @@ for each training run. In other words, "BalanceBall1" for the first run,
 every training run are saved to the same directory and will all be included 
 on the same graph.
 
-To summarize, go to your Anaconda command line, activate the ml-agents environment, enter the `ml-agents` directory and type: 
+To summarize, go to your command line, enter the `ml-agents` directory and type: 
 
 ```python
 python3 python/learn.py <env_file_path> --run-id=<run-identifier> --train 
 ```
+**Note**: If you're using Anaconda, don't forget to activate the ml-agents environment first.
 
 The `--train` flag tells ML-Agents to run in training mode. `env_file_path` should be the path to the Unity executable that was just created. 
 

--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -317,7 +317,7 @@ during a successful training session.
 Once the training process completes, and the training process saves the model 
 (denoted by the `Saved Model` message) you can add it to the Unity project and 
 use it with agents having an **Internal** brain type.
-**Note** If you're using Anaconda, you shouldn't just close the Unity Window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the training session and export the .bytes file. Otherwise, the .bytes file will never be exported into the ml-agents folder.
+**Note:** Do not just close the Unity Window once the `Saved Model` message appears. Either wait for the training process to close the window or press Ctrl+C at the command-line prompt. If you simply close the window manually, the .bytes file containing the trained model is not exported into the ml-agents folder.
 
 ### Setting up TensorFlowSharp Support
 

--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -316,7 +316,7 @@ during a successful training session.
 Once the training process completes, and the training process saves the model 
 (denoted by the `Saved Model` message) you can add it to the Unity project and 
 use it with agents having an **Internal** brain type.
-**Note** You shouldn't just close the unity window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the triaing session and export the .byted file. Otherwise,, the byte file will neevr be exported into the ml-agents folder.
+**Note** You shouldn't just close the unity Window once the `Saved Model` message appears. Press Ctrl+C in the Anaconda prompt, and this will formally end the triaing session and export the .byted file. Otherwise, the .bytes file will never be exported into the ml-agents folder.
 
 ### Setting up TensorFlowSharp Support
 


### PR DESCRIPTION
I added some important clarifications about some steps.
There were some important things that should have been mentioned in this tutorial, and it took me a while to figure them out. Most importantly, it was never mentioned how to properly end a training session in the Anaconda prompt to receive an exported .bytes file.
I was under the impression that simply closing the Unity window was enough, but instead I had to press Ctrl + C in the Anaconda prompt to export the .bytes file before ending everything.
Something like that isn't immediately obvious.