### PR TITLE
Add ignore for plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /unity-environment/[Pp]ackages/
 /unity-environment/[Uu]nity[Pp]ackage[Mm]anager/
 /unity-environment/Assets/AssetStoreTools*
+/unity-environment/Assets/Plugins*
 
 # Tensorflow Model Info
 /models


### PR DESCRIPTION
The Rider IDE creates additional files in the Unity project which should be ignored in version control. Since all ML-Agents specific plugins are located within the `ML-Agents` sub-folder, I propose this repo ignore the high-level Plugins folder.