### PR TITLE
Clarify documentation for step() in Python-API.md - Only API Docs

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -12,7 +12,7 @@ These classes are all defined in the `python/unityagents` folder of the ML-Agent
 
 To communicate with an agent in a Unity environment from a Python program, the agent must either use an **External** brain or use a brain that is broadcasting (has its **Broadcast** property set to true). Your code is expected to return actions for agents with external brains, but can only observe broadcasting brains (the information you receive for an agent is the same in both cases). See [Using the Broadcast Feature](Learning-Environment-Design-Brains.md#using-the-broadcast-feature).
 
-For a simple example of using the Python API to interact with a Unity environment, see the Basic [Jupyter](Background-Jupyter.md) notebook (`python/Basics.ipynb`), which opens an environment, runs a few simulation steps taking random actions, and closes the environment. 
+For a simple example of using the Python API to interact with a Unity environment, see the Basic [Jupyter](Background-Jupyter.md) notebook, which opens an environment, runs a few simulation steps taking random actions, and closes the environment. 
 
 _Notice: Currently communication between Unity and Python takes place over an open socket without authentication. As such, please make sure that the network where training takes place is secure. This will be addressed in a future release._
 
@@ -56,12 +56,20 @@ Sends a step signal to the environment using the actions. For each brain :
     - `memory` is an optional input that can be used to send a list of floats per agents to be retrieved at the next step.
     - `text_action` is an optional input that be used to send a single string per agent.
 
-Note that if you have more than one external brain in the environment, you must provide dictionaries from brain names to arrays for `action`, `memory` and `value`. For example: If you have two external brains named `brain1` and `brain2` each with one agent taking two continuous actions, then you can have:
-```python
-action = {'brain1':[1.0, 2.0], 'brain2':[3.0,4.0]}
-```
+    Returns a dictionary mapping brain names to BrainInfo objects.
+    
+    For example, to access the BrainInfo belonging to a brain called 'brain_name', and the BrainInfo field 'vector_observations':
+    ```python
+    info = env.step()
+    brainInfo = info['brain_name']
+    observations = brainInfo.vector_observations
+    ``` 
+
+    Note that if you have more than one external brain in the environment, you must provide dictionaries from brain names to arrays for     `action`, `memory` and `value`. For example: If you have two external brains named `brain1` and `brain2` each with one agent taking     two continuous actions, then you can have:
+    ```python
+    action = {'brain1':[1.0, 2.0], 'brain2':[3.0,4.0]}
+    ```
 
 Returns a dictionary mapping brain names to BrainInfo objects.  
 - **Close : `env.close()`**  
 Sends a shutdown signal to the environment and closes the communication socket.
-


### PR DESCRIPTION
 - Indent the section about providing actions to multiple brains to be in line with the rest of the step() docs.
 - Move the line about what step() returns closer to the top of the docs so it's harder to overlook.
 - Add a small code snippet about how to get BrainInfo belonging to a specific brain and how to get data from that BrainInfo object.