### PR TITLE
[Addresses #842]

### DIFF
--- a/python/unitytrainers/bc/trainer.py
+++ b/python/unitytrainers/bc/trainer.py
@@ -247,8 +247,10 @@ class BehavioralCloningTrainer(Trainer):
         for l in range(len(info_student.agents)):
             if info_student.local_done[l]:
                 agent_id = info_student.agents[l]
-                self.stats['cumulative_reward'].append(self.cumulative_rewards[agent_id])
-                self.stats['episode_length'].append(self.episode_steps[agent_id])
+                self.stats['cumulative_reward'].append(
+                    self.cumulative_rewards.get(agent_id, 0))
+                self.stats['episode_length'].append(
+                    self.episode_steps.get(agent_id, 0))
                 self.cumulative_rewards[agent_id] = 0
                 self.episode_steps[agent_id] = 0
 

--- a/python/unitytrainers/ppo/trainer.py
+++ b/python/unitytrainers/ppo/trainer.py
@@ -352,12 +352,15 @@ class PPOTrainer(Trainer):
 
                 self.training_buffer[agent_id].reset_agent()
                 if info.local_done[l]:
-                    self.stats['cumulative_reward'].append(self.cumulative_rewards[agent_id])
-                    self.stats['episode_length'].append(self.episode_steps[agent_id])
+                    self.stats['cumulative_reward'].append(
+                        self.cumulative_rewards.get(agent_id, 0))
+                    self.stats['episode_length'].append(
+                        self.episode_steps.get(agent_id, 0))
                     self.cumulative_rewards[agent_id] = 0
                     self.episode_steps[agent_id] = 0
                     if self.use_curiosity:
-                        self.stats['intrinsic_reward'].append(self.intrinsic_rewards[agent_id])
+                        self.stats['intrinsic_reward'].append(
+                            self.intrinsic_rewards.get(agent_id, 0))
                         self.intrinsic_rewards[agent_id] = 0
 
     def end_episode(self):


### PR DESCRIPTION
In the case the agent is done imediately after spawning, its stats are empty because the stats need at least 2 successive experieces to create the stats.
By specifying the default value of 0, the error does no longer appear