### PR TITLE
Replace CC `tanh` activation with `swish`

### DIFF
--- a/python/trainer_config.yaml
+++ b/python/trainer_config.yaml
@@ -118,6 +118,7 @@ Ball3DBrain:
     buffer_size: 12000
     summary_freq: 1000
     time_horizon: 1000
+    lambd: 0.99
     gamma: 0.995
     beta: 0.001
 

--- a/python/trainer_config.yaml
+++ b/python/trainer_config.yaml
@@ -114,7 +114,7 @@ VisualPyramidBrain:
 
 Ball3DBrain:
     normalize: true
-    batch_size: 1200
+    batch_size: 64
     buffer_size: 12000
     summary_freq: 1000
     time_horizon: 1000

--- a/python/unitytrainers/models.py
+++ b/python/unitytrainers/models.py
@@ -168,10 +168,7 @@ class LearningModel(object):
         :return: List of encoded streams.
         """
         brain = self.brain
-        if brain.vector_action_space_type == "continuous":
-            activation_fn = tf.nn.tanh
-        else:
-            activation_fn = self.swish
+        activation_fn = self.swish
 
         self.visual_in = []
         for i in range(brain.number_visual_observations):


### PR DESCRIPTION
Improves performance by ~25% on Walker and Crawler. Slight adjustments to 3DBall to ensure no performance loss. 

Crawler and Walker models on master were actually trained using `swish`, so making the PR into hotfix branch for consistency. 