### PR TITLE
Fixed Python tests.

### DIFF
--- a/python/tests/mock_communicator.py
+++ b/python/tests/mock_communicator.py
@@ -30,7 +30,6 @@ class MockCommunicator(Communicator):
             camera_resolutions=resolutions,
             vector_action_descriptions=["", ""],
             vector_action_space_type=int(not self.is_discrete),
-            vector_observation_space_type=1,
             brain_name="RealFakeBrain",
             brain_type=2
         )

--- a/python/tests/test_unitytrainers.py
+++ b/python/tests/test_unitytrainers.py
@@ -24,8 +24,7 @@ dummy_start = '''{
       "memorySize": 0,
       "cameraResolutions": [],
       "vectorActionDescriptions": ["",""],
-      "vectorActionSpaceType": 1,
-      "vectorObservationSpaceType": 1
+      "vectorActionSpaceType": 1
       }]
 }'''.encode()
 


### PR DESCRIPTION
Discrete observations were removed but the tests were not updated to reflect this.

- Removed all references to vector_observation_space_type and vectorObservationSpaceType in Python tests.
- Tests are all now passing.

Every Unity environment in the repo references seems to still reference vectorObservationSpaceType when I do a search for "vectorObservationSpaceType". Is this okay?