### PR TITLE
Use PNG instead of JPG

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Batcher.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Batcher.cs
@@ -178,7 +178,7 @@ namespace MLAgents
             foreach (Texture2D obs in info.visualObservations)
             {
                 agentInfoProto.VisualObservations.Add(
-                    ByteString.CopyFrom(obs.EncodeToJPG())
+                    ByteString.CopyFrom(obs.EncodeToPNG())
                 );
             }
             return agentInfoProto;


### PR DESCRIPTION
Replace lossy JPG visual observation with lossless PNG.