### PR TITLE
Fixing bug when no curriculum folder is passed.

### DIFF
--- a/python/unitytrainers/trainer.py
+++ b/python/unitytrainers/trainer.py
@@ -130,7 +130,7 @@ class Trainer(object):
         """
         raise UnityTrainerException("The update_model method was not implemented.")
 
-    def write_summary(self, lesson_num):
+    def write_summary(self, lesson_num=0):
         """
         Saves training statistics to Tensorboard.
         :param lesson_num: The lesson the trainer is at.


### PR DESCRIPTION
- The old Curriculum object would accept None
as a location for the curriculum. If the
location was None, it would return default
values as its config and lesson number.

- The new MetaCurriculum does not accept
None as a location for the curriculum
folder. This was done to remove unnecessary
edge case functionality from curriculums.

- None checks have been added into
trainer_controller. In the future,
it should be possible to better refactor
trainer_controller so that these None
checks can be removed. This is preferable
to hard-coding default behavior into
MetaCurriculum objects when a metacurriculum
would not even be in place.