### PR TITLE
Fixing curriculum reset parameter bug.

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Academy.cs
@@ -345,6 +345,18 @@ namespace MLAgents
             ConfigureEnvironment();
         }
 
+        private void UpdateResetParameters()
+        {
+            var newResetParameters = brainBatcher.GetEnvironmentParameters();
+            if (newResetParameters != null)
+            {
+                foreach (var kv in newResetParameters.FloatParameters)
+                {
+                    resetParameters[kv.Key] = kv.Value;
+                }
+            }
+        }
+
         void HandleLog(string logString, string stackTrace, LogType type)
         {
             logWriter = new StreamWriter(logPath, true);
@@ -527,15 +539,7 @@ namespace MLAgents
                 if (brainBatcher.GetCommand() ==
                     MLAgents.CommunicatorObjects.CommandProto.Reset)
                 {
-                    // Update reset parameters.
-                    var newResetParameters = brainBatcher.GetEnvironmentParameters();
-                    if (newResetParameters != null)
-                    {
-                        foreach (var kv in newResetParameters.FloatParameters)
-                        {
-                            resetParameters[kv.Key] = kv.Value;
-                        }
-                    }
+                    UpdateResetParameters();
 
                     SetIsInference(!brainBatcher.GetIsTraining());
 
@@ -554,6 +558,7 @@ namespace MLAgents
             }
             else if (!firstAcademyReset)
             {
+                UpdateResetParameters();
                 ForcedFullReset();
             }
 


### PR DESCRIPTION
The environment did not respond to reset parameter values defined by a curriculum until the second reset. This was because on the first reset, the reset parameters were not updated by the Academy.

This bug is has been brought up in a couple issues:
- https://github.com/Unity-Technologies/ml-agents/issues/1041
- https://github.com/Unity-Technologies/ml-agents/issues/972

All C# tests are still passing. I have tested this on environments like 3DBall and WallJump. It would be great if I could get more suggestions for how to test these changes.