### PR TITLE
Fix for #1093

### DIFF
--- a/unity-environment/Assets/ML-Agents/Scripts/Batcher.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/Batcher.cs
@@ -167,7 +167,6 @@ namespace MLAgents
             {
                 StackedVectorObservation = { info.stackedVectorObservation },
                 StoredVectorActions = { info.storedVectorActions },
-                Memories = { info.memories },
                 StoredTextActions = info.storedTextActions,
                 TextObservation = info.textObservation,
                 Reward = info.reward,
@@ -175,6 +174,11 @@ namespace MLAgents
                 Done = info.done,
                 Id = info.id,
             };
+
+            if (info.memories != null)
+            {
+                agentInfoProto.Memories.Add(info.memories);
+            }
             foreach (Texture2D obs in info.visualObservations)
             {
                 agentInfoProto.VisualObservations.Add(


### PR DESCRIPTION
Check in the batcher that the memories are not null before adding them to the agentInfoProto