### PR TITLE
Printing Unity logo exception is now caught.

### DIFF
--- a/ml-agents/mlagents/learn.py
+++ b/ml-agents/mlagents/learn.py
@@ -69,9 +69,8 @@ def main():
                         ¬`▀▀▀█▓
 
         ''')
-    # TODO: figure this out
     except:
-        print('UNITY!!!')
+        print('Unity Technologies')
 
     logger = logging.getLogger('mlagents.learn')
     _USAGE = '''

--- a/ml-agents/mlagents/learn.py
+++ b/ml-agents/mlagents/learn.py
@@ -70,7 +70,7 @@ def main():
 
         ''')
     except:
-        print('Unity Technologies')
+        print('\n\n\tUnity Technologies\n')
 
     logger = logging.getLogger('mlagents.learn')
     _USAGE = '''


### PR DESCRIPTION
If an error is raised while attempting to print the big Unity logo, the `learn.py` script will instead print `Unity Technologies`.