### PR TITLE
Changing learn.py log messages.

### DIFF
--- a/ml-agents/mlagents/learn.py
+++ b/ml-agents/mlagents/learn.py
@@ -80,7 +80,7 @@ def main():
 
     Options:
       --env=<file>               Name of the Unity executable [default: None].
-      --curriculum=<file>        Curriculum json file for environment [default: None].
+      --curriculum=<directory>   Curriculum json directory for environment [default: None].
       --keep-checkpoints=<n>     How many model checkpoints to keep [default: 5].
       --lesson=<n>               Start learning from this lesson [default: 0].
       --load                     Whether to load the model or randomly initialize [default: False].

--- a/ml-agents/mlagents/learn.py
+++ b/ml-agents/mlagents/learn.py
@@ -75,8 +75,8 @@ def main():
     logger = logging.getLogger('mlagents.learn')
     _USAGE = '''
     Usage:
-      learn <trainer-config-path> [options]
-      learn --help
+      mlagents-learn <trainer-config-path> [options]
+      mlagents-learn --help
 
     Options:
       --env=<file>               Name of the Unity executable [default: None].

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -241,8 +241,7 @@ class TrainerController(object):
                 return trainer_config
         except IOError:
             raise UnityEnvironmentException('Parameter file could not be found '
-                                            'here {}. Will use default Hyper '
-                                            'parameters.'
+                                            'at {}.'
                                             .format(self.trainer_config_path))
         except UnicodeDecodeError:
             raise UnityEnvironmentException('There was an error decoding '


### PR DESCRIPTION
- learn.py refers to the mlagents-learn script now.
- If a non-existant trainer config is passed, the log message
  correctly points that out now.