### PR TITLE
Fix for concurrent sessions on GPU

### DIFF
--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -291,7 +291,10 @@ class TrainerController(object):
 
         tf.reset_default_graph()
 
-        with tf.Session() as sess:
+        # Prevent a single session from taking all GPU memory.
+        config = tf.ConfigProto()
+        config.gpu_options.allow_growth = True
+        with tf.Session(config=config) as sess:
             self._initialize_trainers(trainer_config, sess)
             for _, t in self.trainers.items():
                 self.logger.info(t)


### PR DESCRIPTION
* Prevents one training session from taking all GPU memory when training with a GPU.