### PR TITLE
.gitignor *.xml breaks MarathonEnvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@
 *.idea/misc.xml
 *.idea/modules.xml
 *.iml
-*.xml
 *.cache
 */build/
 */dist/


### PR DESCRIPTION
MarathonEnvs uses .xml files. If a developer takes the ML-Agents .gitignor when working with MarathonEnvs their .xml files will not be added to git and they will not be aware of this.

From what I see there is no need to aggressively ignore all *.xml files (and if there is, it would be better to limit this to those paths)

To test I... 
1) created a new ML-Agent repro on MacOS
2) removed the *.xml from .gitignot
3) ran ML-Agents in the Editor
4) created a ran a build environment

No new .xml files where generated/needed to be ignored