### PR TITLE
Add link to notebook in python-api page

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -16,8 +16,7 @@ imitation learning.
 The ML-Agents Toolkit provides a Python API for controlling the Agent simulation
 loop of an environment or game built with Unity. This API is used by the
 training algorithms inside the ML-Agent Toolkit, but you can also write your own
-Python programs using this API. Go 
-[here](../notebooks/getting-started.ipynb) 
+Python programs using this API. Go [here](../notebooks/getting-started.ipynb) 
 for a Jupyter Notebook walking through the functionality of the API.
 
 The key objects in the Python API include:

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -16,7 +16,9 @@ imitation learning.
 The ML-Agents Toolkit provides a Python API for controlling the Agent simulation
 loop of an environment or game built with Unity. This API is used by the
 training algorithms inside the ML-Agent Toolkit, but you can also write your own
-Python programs using this API.
+Python programs using this API. Go 
+[here](https://github.com/Unity-Technologies/ml-agents/blob/master/notebooks/getting-started.ipynb) 
+for a Jupyter Notebook walking through the functionality of the API.
 
 The key objects in the Python API include:
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -17,7 +17,7 @@ The ML-Agents Toolkit provides a Python API for controlling the Agent simulation
 loop of an environment or game built with Unity. This API is used by the
 training algorithms inside the ML-Agent Toolkit, but you can also write your own
 Python programs using this API. Go 
-[here](https://github.com/Unity-Technologies/ml-agents/blob/master/notebooks/getting-started.ipynb) 
+[here](../notebooks/getting-started.ipynb) 
 for a Jupyter Notebook walking through the functionality of the API.
 
 The key objects in the Python API include:


### PR DESCRIPTION
Adds a link to the getting started notebook on the Python-API page.