### PR TITLE
Fixes agent infinite resetting bug

### DIFF
--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -242,10 +242,10 @@ public class RollerAgent : Agent
     public Transform Target;
     public override void AgentReset()
     {
-        if (this.transform.position.y < -1.0)
+        if (this.transform.position.y < 0)
         {
             // The Agent fell
-            this.transform.position = Vector3.zero;
+            this.transform.position = new Vector3(0, 0.5f, 0);
             this.rBody.angularVelocity = Vector3.zero;
             this.rBody.velocity = Vector3.zero;
         }
@@ -415,7 +415,7 @@ in the next step:
 
 ```csharp
 // Fell off platform
-if (this.transform.position.y < -1.0)
+if (this.transform.position.y < 0)
 {
     AddReward(-1.0f);
     Done();
@@ -448,7 +448,7 @@ public override void AgentAction(float[] vectorAction, string textAction)
     AddReward(-0.05f);
 
     // Fell off platform
-    if (this.transform.position.y < -1.0)
+    if (this.transform.position.y < 0)
     {
         AddReward(-1.0f);
         Done();


### PR DESCRIPTION
The check for wether an agent has fallen off the platform was using a wrong value of 1 instead of 0. 
This meant that the agent immediately started in a falling state and entered a thrashing cycle of resetting itself.