### PR TITLE
v0.6 docs minor updates

### DIFF
--- a/docs/Background-Machine-Learning.md
+++ b/docs/Background-Machine-Learning.md
@@ -2,7 +2,7 @@
 
 Given that a number of users of the ML-Agents toolkit might not have a formal
 machine learning background, this page provides an overview to facilitate the
-understanding of the ML-Agents toolkit. However, We will not attempt to provide
+understanding of the ML-Agents toolkit. However, we will not attempt to provide
 a thorough treatment of machine learning as there are fantastic resources
 online.
 

--- a/docs/Background-TensorFlow.md
+++ b/docs/Background-TensorFlow.md
@@ -33,8 +33,8 @@ training which can be helpful in both building intuitions for the different
 hyperparameters and setting the optimal values for your Unity environment. We
 provide more details on setting the hyperparameters in later parts of the
 documentation, but, in the meantime, if you are unfamiliar with TensorBoard we
-recommend this
-[tutorial](https://github.com/dandelionmane/tf-dev-summit-tensorboard-tutorial).
+recommend our guide on [using Tensorboard with ML-Agents](Using-Tensorboard.md) or
+this [tutorial](https://github.com/dandelionmane/tf-dev-summit-tensorboard-tutorial).
 
 ## Tensorflow Model Inference
 

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -39,7 +39,7 @@ using the search bar of the `Hierarchy` window with the word `Agent`.
     in the `Brain` GameObjects.
   * Agents have a `Brain` field in the Inspector, you need to drag the
     appropriate Brain ScriptableObject in it.
-  * Academies have a `Broadcast Hub` field in the inspector, which is
+  * The Academy has a `Broadcast Hub` field in the inspector, which is
     list of brains used in the scene.  You need to drag all `Brain`
     ScriptableObjects used in your scene into entries in this list.
 * You will need to delete the previous TensorFlowSharp package

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -2,7 +2,7 @@
 
 ## Migrating from ML-Agents toolkit v0.5 to v0.6
 
-### Important
+### Important Changes
 
 * Brains are now Scriptable Objects instead of MonoBehaviors. 
 * You can no longer modify the type of a Brain. If you want to switch
@@ -11,22 +11,7 @@
   __Note:__ You can pass the same Brain to multiple agents in a scene by 
 leveraging Unity's prefab system or look for all the agents in a scene
 using the search bar of the `Hierarchy` window with the word `Agent`.
-* To update a scene from v0.5 to v0.6, you must:
-  *  Remove the `Brain` GameObjects in the scene. (Delete all of the 
-  Brain GameObjects under Academy in the scene.)
-  *  Create new `Brain` Scriptable Objects using `Assets -> Create ->
-     ML-Agents` for each type of the Brain you plan to use, and put
-     the created files under a folder called Brains within your project.
-  *  Edit their `Brain Parameters` to be the same as the parameters used 
-     in the `Brain` GameObjects.
-  *  Agents have a `Brain` field in the Inspector, you need to drag the
-  appropriate Brain ScriptableObject in it.
-  
-  __Note:__ You will need to delete the previous TensorFlowSharp package 
-  and install the new one to do inference. To correctly delete the previous 
-  TensorFlowSharp package, Delete all of the files under `ML-Agents/Plugins`
-  folder except the files under `ML-Agents/Plugins/ProtoBuffer`.
-  
+
 * We replaced the **Internal** and **External** Brain with **Learning Brain**.
   When you need to train a model, you need to drag it into the `Training Hub`
   inside the `Academy` and check the `Control` checkbox.
@@ -42,6 +27,25 @@ using the search bar of the `Hierarchy` window with the word `Agent`.
   [Inference Engine](Inference-Engine.md).
 * To use a `.tf` model, drag it inside the `Model` property of the `Learning Brain`
 
+#### Steps to Migrate
+
+* To update a scene from v0.5 to v0.6, you must:
+  * Remove the `Brain` GameObjects in the scene. (Delete all of the
+    Brain GameObjects under Academy in the scene.)
+  * Create new `Brain` Scriptable Objects using `Assets -> Create ->
+    ML-Agents` for each type of the Brain you plan to use, and put
+    the created files under a folder called Brains within your project.
+  * Edit their `Brain Parameters` to be the same as the parameters used
+    in the `Brain` GameObjects.
+  * Agents have a `Brain` field in the Inspector, you need to drag the
+    appropriate Brain ScriptableObject in it.
+  * Academies have a `Broadcast Hub` field in the inspector, which is
+    list of brains used in the scene.  You need to drag all `Brain`
+    ScriptableObjects used in your scene into entries in this list.
+* You will need to delete the previous TensorFlowSharp package
+  and install the new one to do inference. To correctly delete the previous
+  TensorFlowSharp package, Delete all of the files under `ML-Agents/Plugins`
+  folder except the files under `ML-Agents/Plugins/ProtoBuffer`.
 
 
 ## Migrating from ML-Agents toolkit v0.4 to v0.5

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -40,8 +40,10 @@ using the search bar of the `Hierarchy` window with the word `Agent`.
   * Agents have a `Brain` field in the Inspector, you need to drag the
     appropriate Brain ScriptableObject in it.
   * The Academy has a `Broadcast Hub` field in the inspector, which is
-    list of brains used in the scene.  You need to drag all `Brain`
-    ScriptableObjects used in your scene into entries in this list.
+    list of brains used in the scene.  To train or control your Brain 
+    from the `mlagents-learn` Python script, you need to drag the relevant 
+    `LearningBrain` ScriptableObjects used in your scene into entries 
+    into this list.
 * You will need to delete the previous TensorFlowSharp package
   and install the new one to do inference. To correctly delete the previous
   TensorFlowSharp package, Delete all of the files under `ML-Agents/Plugins`


### PR DESCRIPTION
This PR fixes a few minor issues with documentation from the `release-v0.6` branch:

- In `Migrating.md`, the steps to migrate and change log were combined.  I separated them and added a step on migrating the Academy.
- In `Background-Tensorflow.md` we referred to an external tutorial on Tensorflow but didn't mention our own guide, which I've linked.
- Minor capitalization fix in `Background-Machine-Learning.md`