### PR TITLE
Fix brain name bug in offline bc

### DIFF
--- a/ml-agents/mlagents/trainers/bc/offline_trainer.py
+++ b/ml-agents/mlagents/trainers/bc/offline_trainer.py
@@ -41,9 +41,11 @@ class OfflineBCTrainer(BCTrainer):
             trainer_parameters['demo_path'],
             self.policy.sequence_length)
 
-        print(brain.__dict__)
-        print(brain_params.__dict__)
-        if brain.__dict__ != brain_params.__dict__:
+        policy_brain = brain.__dict__
+        expert_brain = brain_params.__dict__
+        policy_brain.pop('brain_name')
+        expert_brain.pop('brain_name')
+        if expert_brain != policy_brain:
             raise UnityTrainerException("The provided demonstration is not compatible with the "
                                         "brain being used for performance evaluation.")
 


### PR DESCRIPTION
Since brain name can now be arbitrary, it should not be a limiting factor for using demonstrations.