### PR TITLE
Add a script to record videos every X seconds or academy steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@
 /UnitySDK/Assets/ML-Agents/Plugins/System.Numerics*
 /UnitySDK/Assets/ML-Agents/Plugins/System.ValueTuple*
 
+# Plugins
+/UnitySDK/Assets/ML-Agents/VideoRecorder*
+
 # Generated doc folders
 /docs/html
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -469,14 +469,25 @@ namespace MLAgents
         }
 
         /// <summary>
-        /// Returns the current step counter (within the current epside).
+        /// Returns the current step counter (within the current episode).
         /// </summary>
         /// <returns>
-        /// Current episode number.
+        /// Current step count.
         /// </returns>
         public int GetStepCount()
         {
             return stepCount;
+        }
+
+        /// <summary>
+        /// Returns the total step counter.
+        /// </summary>
+        /// <returns>
+        /// Total step count.
+        /// </returns>
+        public int GetTotalStepCount()
+        {
+            return GetStepCount() + GetEpisodeCount() * maxSteps;
         }
 
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -169,6 +169,10 @@ namespace MLAgents
         /// <see cref="AcademyReset"/>.
         int stepCount;
 
+        /// The number of total number of steps completed during the whole simulation. Incremented
+        /// each time a step is taken in the environment.
+        int totalStepCount;
+
         /// Flag that indicates whether the inference/training mode of the
         /// environment was switched by the external Brain. This impacts the
         /// engine settings at the next environment step.
@@ -487,7 +491,7 @@ namespace MLAgents
         /// </returns>
         public int GetTotalStepCount()
         {
-            return GetStepCount() + GetEpisodeCount() * maxSteps;
+            return totalStepCount;
         }
 
         /// <summary>
@@ -600,6 +604,7 @@ namespace MLAgents
             AgentAct();
 
             stepCount += 1;
+            totalStepCount += 1;
         }
 
         /// <summary>


### PR DESCRIPTION
So this is the contribution I briefly mentioned in issue  #1403 
This code uses the frame capturer repository https://github.com/unity3d-jp/FrameCapturer.

So to record videos:

1. Create a camera
2. Add the RecordVideos script to it
3. Choose the recording options on the RecordVideos script.

The frame capturer code was put in Scripts/FrameCapturer. Some parts of the code were removed/changed:

- Removed the examples
- Removed the AudioCapturer and GBufferRecorder
- Changed MovieRecorderEditor to hide all modifiable variables from the user.
- Removed BeginRecording and EndRecording logging from Movie Recorder
- Made it possible to specify the video name in the BeginRecording function

I tried to change as little as possible while removing unused code and making the interface simpler.

The code I actually created:

1. The RecordVideos and RecordVideosEditor scripts
2. A new function in the Academy to get the TotalStepCount

I can also create documentation for it but first I would like some feedback to make sure the current interface and the options make sense.

Testing:
- I tested this on Windows using the 3DBall tutorial, in the editor and with an executable running for 15 minutes.
Mostly made sure that the videos were indeed recording and that the agents were still learning.
- I also used the framework on my own project for 8-15 hours sessions.


