### PR TITLE
Check that worker port is available in RpcCommunicator

### DIFF
--- a/ml-agents/mlagents/envs/exception.py
+++ b/ml-agents/mlagents/envs/exception.py
@@ -44,6 +44,20 @@ class UnityTimeOutException(UnityException):
                         "You can check the logfile for more information at {}".format(log_file_path))
             except:
                 logger.error("An error might have occured in the environment. "
-               "No UnitySDK.log file could be found.") 
+                             "No UnitySDK.log file could be found.")
         super(UnityTimeOutException, self).__init__(message)
 
+
+class UnityWorkerInUseException(UnityException):
+    """
+    This error occurs when the port for a certain worker ID is already reserved.
+    """
+
+    MESSAGE_TEMPLATE = (
+        "Couldn't start socket communication because worker number {} is still in use. "
+        "You may need to manually close a previously opened environment "
+        "or use a different worker number.")
+
+    def __init__(self, worker_id):
+        message = self.MESSAGE_TEMPLATE.format(str(worker_id))
+        super(UnityWorkerInUseException, self).__init__(message)

--- a/ml-agents/mlagents/envs/rpc_communicator.py
+++ b/ml-agents/mlagents/envs/rpc_communicator.py
@@ -60,7 +60,7 @@ class RpcCommunicator(Communicator):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             s.bind(("127.0.0.1", port))
-        except socket.error as e:
+        except socket.error:
             raise UnityWorkerInUseException(self.worker_id)
         finally:
             s.close()

--- a/ml-agents/mlagents/envs/rpc_communicator.py
+++ b/ml-agents/mlagents/envs/rpc_communicator.py
@@ -43,7 +43,9 @@ class RpcCommunicator(Communicator):
         self.create_server()
 
     def create_server(self):
-        # Attempt to open a socket, failing if the port is in use.
+        """
+        Creates the GRPC server.
+        """
         self.check_port(self.port)
 
         try:
@@ -51,7 +53,7 @@ class RpcCommunicator(Communicator):
             self.server = grpc.server(ThreadPoolExecutor(max_workers=10))
             self.unity_to_external = UnityToExternalServicerImplementation()
             add_UnityToExternalServicer_to_server(self.unity_to_external, self.server)
-            self.server.add_insecure_port('[::]:' + str(self.port))
+            self.server.add_insecure_port('localhost:' + str(self.port))
             self.server.start()
         except:
             raise UnityWorkerInUseException(self.worker_id)
@@ -62,7 +64,7 @@ class RpcCommunicator(Communicator):
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            s.bind(("127.0.0.1", port))
+            s.bind(("localhost", port))
         except socket.error:
             raise UnityWorkerInUseException(self.worker_id)
         finally:

--- a/ml-agents/mlagents/envs/rpc_communicator.py
+++ b/ml-agents/mlagents/envs/rpc_communicator.py
@@ -57,6 +57,9 @@ class RpcCommunicator(Communicator):
             raise UnityWorkerInUseException(self.worker_id)
 
     def check_port(self, port):
+        """
+        Attempts to bind to the requested communicator port, checking if it is already in use.
+        """
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             s.bind(("127.0.0.1", port))

--- a/ml-agents/mlagents/envs/rpc_communicator.py
+++ b/ml-agents/mlagents/envs/rpc_communicator.py
@@ -1,14 +1,14 @@
 import logging
 import grpc
 
+import socket
 from multiprocessing import Pipe
 from concurrent.futures import ThreadPoolExecutor
 
 from .communicator import Communicator
 from .communicator_objects import UnityToExternalServicer, add_UnityToExternalServicer_to_server
 from .communicator_objects import UnityMessage, UnityInput, UnityOutput
-from .exception import UnityTimeOutException
-
+from .exception import UnityTimeOutException, UnityWorkerInUseException
 
 logger = logging.getLogger("mlagents.envs")
 
@@ -27,8 +27,7 @@ class UnityToExternalServicerImplementation(UnityToExternalServicer):
 
 
 class RpcCommunicator(Communicator):
-    def __init__(self, worker_id=0,
-                 base_port=5005):
+    def __init__(self, worker_id=0, base_port=5005):
         """
         Python side of the grpc communication. Python is the server and Unity the client
 
@@ -41,20 +40,32 @@ class RpcCommunicator(Communicator):
         self.server = None
         self.unity_to_external = None
         self.is_open = False
+        self.create_server()
 
-    def initialize(self, inputs: UnityInput) -> UnityOutput:
+    def create_server(self):
+        # Attempt to open a socket, failing if the port is in use.
+        self.check_port(self.port)
+
         try:
             # Establish communication grpc
             self.server = grpc.server(ThreadPoolExecutor(max_workers=10))
             self.unity_to_external = UnityToExternalServicerImplementation()
             add_UnityToExternalServicer_to_server(self.unity_to_external, self.server)
-            self.server.add_insecure_port('[::]:'+str(self.port))
+            self.server.add_insecure_port('[::]:' + str(self.port))
             self.server.start()
-        except :
-            raise UnityTimeOutException(
-                "Couldn't start socket communication because worker number {} is still in use. "
-                "You may need to manually close a previously opened environment "
-                "or use a different worker number.".format(str(self.worker_id)))
+        except:
+            raise UnityWorkerInUseException(self.worker_id)
+
+    def check_port(self, port):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.bind(("127.0.0.1", port))
+        except socket.error as e:
+            raise UnityWorkerInUseException(self.worker_id)
+        finally:
+            s.close()
+
+    def initialize(self, inputs: UnityInput) -> UnityOutput:
         if not self.unity_to_external.parent_conn.poll(30):
             raise UnityTimeOutException(
                 "The Unity environment took too long to respond. Make sure that :\n"
@@ -91,7 +102,3 @@ class RpcCommunicator(Communicator):
             self.unity_to_external.parent_conn.close()
             self.server.stop(False)
             self.is_open = False
-
-
-
-

--- a/ml-agents/tests/envs/test_rpc_communicator.py
+++ b/ml-agents/tests/envs/test_rpc_communicator.py
@@ -1,7 +1,5 @@
 import pytest
 
-import numpy as np
-
 from mlagents.envs import RpcCommunicator
 from mlagents.envs import UnityWorkerInUseException
 
@@ -11,6 +9,7 @@ def test_rpc_communicator_checks_port_on_create():
 
     with pytest.raises(UnityWorkerInUseException):
         second_comm = RpcCommunicator()
+        second_comm.close()
 
     first_comm.close()
 

--- a/ml-agents/tests/envs/test_rpc_communicator.py
+++ b/ml-agents/tests/envs/test_rpc_communicator.py
@@ -1,0 +1,23 @@
+import pytest
+
+import numpy as np
+
+from mlagents.envs import RpcCommunicator
+from mlagents.envs import UnityWorkerInUseException
+
+
+def test_rpc_communicator_checks_port_on_create():
+    first_comm = RpcCommunicator()
+
+    with pytest.raises(UnityWorkerInUseException):
+        second_comm = RpcCommunicator()
+
+    first_comm.close()
+
+def test_rpc_communicator_create_multiple_workers():
+    # Ensures multiple RPC communicators can be created with
+    # different worker_ids without causing an error.
+    first_comm = RpcCommunicator()
+    second_comm = RpcCommunicator(worker_id=1)
+    first_comm.close()
+    second_comm.close()

--- a/ml-agents/tests/envs/test_rpc_communicator.py
+++ b/ml-agents/tests/envs/test_rpc_communicator.py
@@ -6,12 +6,11 @@ from mlagents.envs import UnityWorkerInUseException
 
 def test_rpc_communicator_checks_port_on_create():
     first_comm = RpcCommunicator()
-
     with pytest.raises(UnityWorkerInUseException):
         second_comm = RpcCommunicator()
         second_comm.close()
-
     first_comm.close()
+
 
 def test_rpc_communicator_create_multiple_workers():
     # Ensures multiple RPC communicators can be created with
@@ -20,3 +19,4 @@ def test_rpc_communicator_create_multiple_workers():
     second_comm = RpcCommunicator(worker_id=1)
     first_comm.close()
     second_comm.close()
+


### PR DESCRIPTION
Previously the RpcCommunicator did not check the port or create the
RPC server until `initialize()` was called.  Since initialize
requires the environment to be available, this means we might create
a new environment which connects to an existing RPC server running
in another process.  This causes both training runs to fail.

As a remedy to this issue, this commit moves the server creation into
the RpcCommunicator constructor and adds an explicit socket binding
check to the requested port.