### PR TITLE
Fixes to container workflow for GCP

### DIFF
--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -3,7 +3,9 @@
 """Launches trainers for each External Brains in a Unity Environment."""
 
 import os
+import glob
 import logging
+import shutil
 
 import yaml
 import re
@@ -71,8 +73,31 @@ class TrainerController(object):
                 docker_target_name=docker_target_name,
                 run_id=run_id)
             if env_path is not None:
-                env_path = '/{docker_target_name}/{env_name}'.format(
-                    docker_target_name=docker_target_name, env_name=env_path)
+                """
+                Comments for future maintenance:
+                    Some OS/VM instances (e.g. COS GCP Image) mount filesystems 
+                    with COS flag which prevents execution of the Unity scene, 
+                    to get around this, we will copy the executable into the 
+                    container.
+                """
+                # Navigate in docker path and find env_path and copy it.
+                for f in glob.glob('/{docker_target_name}/*'.format(
+                        docker_target_name=docker_target_name)):
+                    if env_path in f:
+                        try:
+                            b = os.path.basename(f)
+                            if os.path.isdir(f):
+                                shutil.copytree(f,
+                                                '/ml-agents/{b}'.format(b=b))
+                            else:
+                                src_f = '/{docker_target_name}/{b}'.format(
+                                    docker_target_name=docker_target_name, b=b)
+                                dst_f = '/ml-agents/{b}'.format(b=b)
+                                shutil.copyfile(src_f, dst_f)
+                                os.chmod(dst_f, 0o775)  # Make executable
+                        except Exception as e:
+                            self.logger.info(e)
+                env_path = '/ml-agents/{env_name}'.format(env_name=env_path)
             if curriculum_folder is not None:
                 self.curriculum_folder = \
                     '/{docker_target_name}/{curriculum_folder}'.format(


### PR DESCRIPTION
Fix to handle running our containers on VMs (or bare machines) that have file systems with `noexec` flag set, e.g. [GCP Container OS](https://stackoverflow.com/questions/49037720/cannot-run-executable-shell-script-on-google-container-optimized-os). This copies the Unity executable inside the container before executing. 