### PR TITLE
Patch communicator in test to prevent port reservation

### DIFF
--- a/ml-agents/tests/envs/test_envs.py
+++ b/ml-agents/tests/envs/test_envs.py
@@ -8,8 +8,8 @@ from mlagents.envs import UnityEnvironment, UnityEnvironmentException, UnityActi
     BrainInfo
 from tests.mock_communicator import MockCommunicator
 
-
-def test_handles_bad_filename():
+@mock.patch('mlagents.envs.UnityEnvironment.get_communicator')
+def test_handles_bad_filename(get_communicator):
     with pytest.raises(UnityEnvironmentException):
         UnityEnvironment(' ')
 


### PR DESCRIPTION
A test in `test_envs.py` launched a UnityEnvironment without mocking
the created communicator, leading to a port being reserved during the
test run.  This in turn caused failures in later tests of
RpcCommunicator.  This commit fixes that issue.