### PR TITLE
Documentation tweaks and updates

### DIFF
--- a/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/Getting-Started-with-Balance-Ball.md
@@ -224,6 +224,10 @@ The `--train` flag tells the ML-Agents toolkit to run in training mode.
 follow the instructions in
 [Using an Executable](Learning-Environment-Executable.md).
 
+**Note**: Re-running this command will start training from scratch again. To resume
+a previous training run, append the `--load` flag and give the same `--run-id` as the
+run you want to resume.
+
 ### Observing Training Progress
 
 Once you start training using `mlagents-learn` in the way described in the

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -548,6 +548,46 @@ you pass to the `mlagents-learn` command for each training run. If you use
 the same id value, the statistics for multiple runs are combined and become 
 difficult to interpret.
 
+## Optional: Multiple Training Areas within the Same Scene
+
+In many of the [example environments](Learning-Environment-Examples.md), many copies of 
+the training area are instantiated in the scene. This generally speeds up training,
+allowing the environment to gather many experiences in parallel. This can be achieved
+simply by instantiating many Agents which share the same Brain. Use the following steps to
+parallelize your RollerBall environment.  
+
+### Instantiating Multiple Training Areas
+
+1. Right-click on your Project Hierarchy and create a new empty GameObject. 
+   Name it TrainingArea. 
+2. Reset the TrainingArea’s Transform so that it is at (0,0,0) with Rotation (0,0,0) 
+   and Scale (1,1,1). 
+3. Drag the Floor, Target, and RollerAgent GameObjects in the Hierarchy into the 
+   TrainingArea GameObject. 
+4. Drag the TrainingArea GameObject, along with its attached GameObjects, into your 
+   Assets browser, turning it into a prefab.
+5. You can now instantiate copies of the TrainingArea prefab. Drag them into your scene, 
+   positioning them so that they do not overlap. 
+
+
+### Editing the Scripts 
+
+You will notice that in the previous section, we wrote our scripts assuming that our 
+TrainingArea was at (0,0,0), performing checks such as `this.transform.position.y < 0` 
+to determine whether our agent has fallen off the platform. We will need to change 
+this if we are to use multiple TrainingAreas throughout the scene. 
+
+A quick way to adapt our current code is to use 
+localPosition rather than position, so that our position reference is in reference 
+to the prefab TrainingArea's location, and not global coordinates. 
+
+1. Replace all references of this.transform.position in RollerAgent.cs with `this.transform.localPosition`.
+2. Replace all references of Target.position in RollerAgent.cs with Target.localPosition.
+
+This is only one way to achieve this objective. Refer to the 
+[example environments](Learning-Environment-Examples.md) for other ways we can achieve relative
+positioning.
+
 ## Review: Scene Layout
 
 This section briefly reviews how to organize your scene when using Agents in

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -569,7 +569,6 @@ parallelize your RollerBall environment.
 5. You can now instantiate copies of the TrainingArea prefab. Drag them into your scene, 
    positioning them so that they do not overlap. 
 
-
 ### Editing the Scripts 
 
 You will notice that in the previous section, we wrote our scripts assuming that our 
@@ -581,12 +580,11 @@ A quick way to adapt our current code is to use
 localPosition rather than position, so that our position reference is in reference 
 to the prefab TrainingArea's location, and not global coordinates. 
 
-1. Replace all references of this.transform.position in RollerAgent.cs with `this.transform.localPosition`.
-2. Replace all references of Target.position in RollerAgent.cs with Target.localPosition.
+1. Replace all references of `this.transform.position` in RollerAgent.cs with `this.transform.localPosition`.
+2. Replace all references of `Target.position` in RollerAgent.cs with `Target.localPosition`.
 
 This is only one way to achieve this objective. Refer to the 
-[example environments](Learning-Environment-Examples.md) for other ways we can achieve relative
-positioning.
+[example environments](Learning-Environment-Examples.md) for other ways we can achieve relative positioning.
 
 ## Review: Scene Layout
 

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -154,7 +154,8 @@ public class RollerAcademy : Academy { }
 
 The default settings for the Academy properties are also fine for this
 environment, so we don't need to change anything for the RollerAcademy component
-in the Inspector window.
+in the Inspector window. You may not have the RollerBrain in the Broadcast Hub yet, 
+more on that later. 
 
 ![The Academy properties](images/mlagents-NewTutAcademy.png)
 

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -475,6 +475,10 @@ if ((ball.transform.position.y - gameObject.transform.position.y) < -2f ||
 The `Ball3DAgent` also assigns a negative penalty when the ball falls off the
 platform.
 
+Note that all of these environments make use of the `Done()` method, which manually
+terminates an episode when a termination condition is reached. This can be 
+called independently of the `Max Step` property.
+
 ## Agent Properties
 
 ![Agent Inspector](images/agent.png)

--- a/docs/Learning-Environment-Design.md
+++ b/docs/Learning-Environment-Design.md
@@ -158,15 +158,16 @@ Brain assigned to this Agent must be set.
 
 You must also determine how an Agent finishes its task or times out. You can
 manually set an Agent to done in your `AgentAction()` function when the Agent
-has finished (or irrevocably failed) its task. You can also set the Agent's `Max
-Steps` property to a positive value and the Agent will consider itself done
-after it has taken that many steps. When the Academy reaches its own `Max Steps`
-count, it starts the next episode. If you set an Agent's `ResetOnDone` property
-to true, then the Agent can attempt its task several times in one episode. (Use
-the `Agent.AgentReset()` function to prepare the Agent to start again.)
+has finished (or irrevocably failed) its task by calling the `Done()` function. 
+You can also set the Agent's `Max Steps` property to a positive value and the 
+Agent will consider itself done after it has taken that many steps. When the 
+Academy reaches its own `Max Steps` count, it starts the next episode. If you 
+set an Agent's `ResetOnDone` property to true, then the Agent can attempt its 
+task several times in one episode. (Use the `Agent.AgentReset()` function to 
+prepare the Agent to start again.)
 
 See [Agents](Learning-Environment-Design-Agents.md) for detailed information
-about programing your own Agents.
+about programming your own Agents.
 
 ## Environments
 

--- a/docs/Training-PPO.md
+++ b/docs/Training-PPO.md
@@ -43,7 +43,7 @@ Typical Range: `0.8` - `0.995`
 
 ### Lambda
 
-`lambd` corresponds to the `lambda` parameter used when calculating the
+`lambda` corresponds to the `lambda` parameter used when calculating the
 Generalized Advantage Estimate ([GAE](https://arxiv.org/abs/1506.02438)). This
 can be thought of as how much the agent relies on its current value estimate
 when calculating an updated value estimate. Low values correspond to relying

--- a/docs/Training-PPO.md
+++ b/docs/Training-PPO.md
@@ -43,7 +43,7 @@ Typical Range: `0.8` - `0.995`
 
 ### Lambda
 
-`lambda` corresponds to the `lambda` parameter used when calculating the
+`lambd` corresponds to the `lambda` parameter used when calculating the
 Generalized Advantage Estimate ([GAE](https://arxiv.org/abs/1506.02438)). This
 can be thought of as how much the agent relies on its current value estimate
 when calculating an updated value estimate. Low values correspond to relying


### PR DESCRIPTION
Small changes to the documentation, mostly wording and formatting tweaks, and mentioning things that were not obvious going through the Create New Learning Environment and Getting Started with Balance Ball tutorials.

Only major change is an additional tutorial section in Create New Learning Environment that describes how to turn the single RollerBall scene to a multiple environment (many Agents, one Brain) scene. 