### PR TITLE
Doc clarification and typo fix for offline BC

### DIFF
--- a/config/offline_bc_config.yaml
+++ b/config/offline_bc_config.yaml
@@ -10,7 +10,7 @@ default:
     num_layers: 2
     sequence_length: 32
     memory_size: 256
-    demo_path: ./UnitySDK/Assets/Demonstrations/<Your_Demon_File>.demo
+    demo_path: ./UnitySDK/Assets/Demonstrations/<Your_Demo_File>.demo
 
 HallwayLearning:
     trainer: offline_bc

--- a/docs/Training-Imitation-Learning.md
+++ b/docs/Training-Imitation-Learning.md
@@ -48,7 +48,7 @@ With offline behavioral cloning, we can use demonstrations (`.demo` files) gener
 3. Build the scene, assigning the agent a Learning Brain, and set the Brain to Control in the Broadcast Hub. For more information on Brains, see [here](Learning-Environment-Design-Brains.md).
 4. Open the `config/offline_bc_config.yaml` file. 
 5. Modify the `demo_path` parameter in the file to reference the path to the demonstration file recorded in step 2. In our case this is: `./UnitySDK/Assets/Demonstrations/AgentRecording.demo`
-6. Launch `mlagent-learn`, and providing `./config/offline_bc_config.yaml` as the config parameter, and your environment as the `--env` parameter.
+6. Launch `mlagent-learn`, providing `./config/offline_bc_config.yaml` as the config parameter, and include the `--run-id` and `--train` as usual. Provide your environment as the `--env` parameter if it has been compiled as standalone, or omit to train in the editor.
 7. (Optional) Observe training performance using Tensorboard.
 
 This will use the demonstration file to train a neural network driven agent to directly imitate the actions provided in the demonstration. The environment will launch and be used for evaluating the agent's performance during training.


### PR DESCRIPTION
Clarified the params for the mlagents-learn command in offline BC tutorial.

Also removed the Demon from the offline BC config yaml.