### PR TITLE
added a more generic AddVectorObs(IEnumerable<float>)

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -755,21 +755,11 @@ namespace MLAgents
         }
 
         /// <summary>
-        /// Adds a float array observation to the vector observations of the agent.
-        /// Increases the size of the agents vector observation by size of array.
+        /// Adds a collection of float observations to the vector observations of the agent.
+        /// Increases the size of the agents vector observation by size of the collection.
         /// </summary>
         /// <param name="observation">Observation.</param>
-        protected void AddVectorObs(float[] observation)
-        {
-            info.vectorObservation.AddRange(observation);
-        }
-
-        /// <summary>
-        /// Adds a float list observation to the vector observations of the agent.
-        /// Increases the size of the agents vector observation by size of list.
-        /// </summary>
-        /// <param name="observation">Observation.</param>
-        protected void AddVectorObs(List<float> observation)
+        protected void AddVectorObs(IEnumerable<float> observation)
         {
             info.vectorObservation.AddRange(observation);
         }


### PR DESCRIPTION
Replaced `AddVectorObs(float[])` and `AddVectorObs(List<float>)` with a more generic `AddVectorObs(IEnumerable<float>)`.