### PR TITLE
Barracuda : Removed OpenGL from Player Settings

### DIFF
--- a/UnitySDK/ProjectSettings/ProjectSettings.asset
+++ b/UnitySDK/ProjectSettings/ProjectSettings.asset
@@ -261,7 +261,7 @@ PlayerSettings:
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: MacStandaloneSupport
-    m_APIs: 1000000011000000
+    m_APIs: 10000000
     m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_BuildTargetEnableVuforiaSettings: []


### PR DESCRIPTION
In order for the `ProjectSettings.asset` to be saved after modifications, you must close Unity.