### PR TITLE
Move 'take_action' into Policy class

### DIFF
--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,7 +1,10 @@
+from .action_info import *
 from .buffer import *
 from .curriculum import *
 from .meta_curriculum import *
 from .models import *
+from .trainer import *
+from .policy import *
 from .trainer_controller import *
 from .bc.models import *
 from .bc.offline_trainer import *
@@ -11,5 +14,4 @@ from .ppo.models import *
 from .ppo.trainer import *
 from .ppo.policy import *
 from .exception import *
-from .policy import *
 from .demo_loader import *

--- a/ml-agents/mlagents/trainers/action_info.py
+++ b/ml-agents/mlagents/trainers/action_info.py
@@ -1,0 +1,9 @@
+from typing import NamedTuple, Any, Dict, Optional
+
+
+class ActionInfo(NamedTuple):
+    action: Any
+    memory: Any
+    text: Any
+    value: Any
+    outputs: Optional[Dict[str, Any]]

--- a/ml-agents/mlagents/trainers/bc/trainer.py
+++ b/ml-agents/mlagents/trainers/bc/trainer.py
@@ -86,23 +86,6 @@ class BCTrainer(Trainer):
         self.policy.increment_step()
         return
 
-    def take_action(self, all_brain_info: AllBrainInfo):
-        """
-        Decides actions using policy given current brain info.
-        :param all_brain_info: AllBrainInfo from environment.
-        :return: a tuple containing action, memories, values and an object
-        to be passed to add experiences
-        """
-        if len(all_brain_info[self.brain_name].agents) == 0:
-            return [], [], [], None, None
-
-        agent_brain = all_brain_info[self.brain_name]
-        run_out = self.policy.evaluate(agent_brain)
-        if self.policy.use_recurrent:
-            return run_out['action'], run_out['memory_out'], None, None, None
-        else:
-            return run_out['action'], None, None, None, None
-
     def add_experiences(self, curr_info: AllBrainInfo, next_info: AllBrainInfo,
                         take_action_outputs):
         """

--- a/ml-agents/mlagents/trainers/policy.py
+++ b/ml-agents/mlagents/trainers/policy.py
@@ -2,9 +2,10 @@ import logging
 import numpy as np
 import tensorflow as tf
 
-from mlagents.trainers import UnityException
+from mlagents.trainers import ActionInfo, UnityException
 from tensorflow.python.tools import freeze_graph
 from mlagents.trainers import tensorflow_to_barracuda as tf2bc
+from mlagents.envs import BrainInfo
 
 logger = logging.getLogger("mlagents.trainers")
 
@@ -79,13 +80,32 @@ class Policy(object):
                             .format(self.model_path))
             self.saver.restore(self.sess, ckpt.model_checkpoint_path)
 
-    def evaluate(self, brain_info):
+    def evaluate(self, brain_info: BrainInfo):
         """
         Evaluates policy for the agent experiences provided.
         :param brain_info: BrainInfo input to network.
         :return: Output from policy based on self.inference_dict.
         """
         raise UnityPolicyException("The evaluate function was not implemented.")
+
+    def get_action(self, brain_info: BrainInfo) -> ActionInfo:
+        """
+        Decides actions given observations information, and takes them in environment.
+        :param brain_info: A dictionary of brain names and BrainInfo from environment.
+        :return: an ActionInfo containing action, memories, values and an object
+        to be passed to add experiences
+        """
+        if len(brain_info.agents) == 0:
+            return ActionInfo([], [], [], None, None)
+
+        run_out = self.evaluate(brain_info)
+        return ActionInfo(
+            action=run_out.get('action'),
+            memory=run_out.get('memory_out'),
+            text=None,
+            value=run_out.get('value'),
+            outputs=run_out
+        )
 
     def update(self, mini_batch, num_sequences):
         """

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -338,12 +338,6 @@ class PPOTrainer(Trainer):
             self.stats['Losses/Inverse Loss'].append(np.mean(inverse_total))
         self.training_buffer.reset_update_buffer()
 
-    def curriculum_lesson_changed(self) -> None:
-        """
-        Clear the reward buffer if a curriculum lesson changes.
-        """
-        self.reward_buffer.clear()
-
 
 def discount_rewards(r, gamma=0.99, value_next=0.0):
     """

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -91,15 +91,6 @@ class Trainer(object):
         raise UnityTrainerException(
             "The increment_step_and_update_last_reward method was not implemented.")
 
-    def take_action(self, all_brain_info: AllBrainInfo):
-        """
-        Decides actions given state/observation information, and takes them in environment.
-        :param all_brain_info: A dictionary of brain names and BrainInfo from environment.
-        :return: a tuple containing action, memories, values and an object
-        to be passed to add experiences
-        """
-        raise UnityTrainerException("The take_action method was not implemented.")
-
     def add_experiences(self, curr_info: AllBrainInfo, next_info: AllBrainInfo,
                         take_action_outputs):
         """
@@ -138,6 +129,12 @@ class Trainer(object):
         Uses demonstration_buffer to update model.
         """
         raise UnityTrainerException("The update_model method was not implemented.")
+
+    def curriculum_lesson_changed(self) -> None:
+        """
+        Allows the trainer to update any intermediate state needed when a curriculum lesson changes.
+        """
+        pass
 
     def save_model(self):
         """

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -4,7 +4,8 @@ import logging
 import tensorflow as tf
 import numpy as np
 
-from mlagents.envs import UnityException, AllBrainInfo
+from mlagents.envs import UnityException, AllBrainInfo, BrainInfo
+from mlagents.trainers import ActionInfo
 
 logger = logging.getLogger("mlagents.trainers")
 
@@ -90,6 +91,14 @@ class Trainer(object):
         """
         raise UnityTrainerException(
             "The increment_step_and_update_last_reward method was not implemented.")
+
+    def get_action(self, curr_info: BrainInfo) -> ActionInfo:
+        """
+        Get an action using this trainer's current policy.
+        :param curr_info: Current BrainInfo.
+        :return: The ActionInfo given by the policy given the BrainInfo.
+        """
+        return self.policy.get_action(curr_info)
 
     def add_experiences(self, curr_info: AllBrainInfo, next_info: AllBrainInfo,
                         take_action_outputs):

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -139,12 +139,6 @@ class Trainer(object):
         """
         raise UnityTrainerException("The update_model method was not implemented.")
 
-    def curriculum_lesson_changed(self) -> None:
-        """
-        Allows the trainer to update any intermediate state needed when a curriculum lesson changes.
-        """
-        pass
-
     def save_model(self):
         """
         Saves the model

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -251,7 +251,7 @@ class TrainerController(object):
                 trainer.end_episode()
             for brain_name, changed in lessons_incremented.items():
                 if changed:
-                    self.trainers[brain_name].curriculum_lesson_changed()
+                    self.trainers[brain_name].reward_buffer.clear()
         elif env.global_done:
             curr_info = self._reset_env(env)
             for brain_name, trainer in self.trainers.items():

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -14,8 +14,9 @@ from typing import *
 import numpy as np
 import tensorflow as tf
 
-from mlagents.envs import BrainInfo
+from mlagents.envs import AllBrainInfo, BrainInfo
 from mlagents.envs.exception import UnityEnvironmentException
+from mlagents.trainers import Trainer, Policy
 from mlagents.trainers.ppo.trainer import PPOTrainer
 from mlagents.trainers.bc.offline_trainer import OfflineBCTrainer
 from mlagents.trainers.bc.online_trainer import OnlineBCTrainer
@@ -52,7 +53,7 @@ class TrainerController(object):
         self.load_model = load
         self.train_model = train
         self.keep_checkpoints = keep_checkpoints
-        self.trainers = {}
+        self.trainers: Dict[str, Trainer] = {}
         self.global_step = 0
         self.meta_curriculum = meta_curriculum
         self.seed = training_seed
@@ -193,10 +194,10 @@ class TrainerController(object):
 
         # Prevent a single session from taking all GPU memory.
         self.initialize_trainers(trainer_config)
+        policies = {brain_name: trainer.policy for brain_name, trainer in self.trainers.items()}
         for _, t in self.trainers.items():
             self.logger.info(t)
 
-        curr_info = self._reset_env(env)
         if self.train_model:
             for brain_name, trainer in self.trainers.items():
                 trainer.write_tensorboard_text('Hyperparameters',
@@ -205,10 +206,11 @@ class TrainerController(object):
                 # Add the _win_handler function to the windows console's handler function list
                 win32api.SetConsoleCtrlHandler(self._win_handler, True)
         try:
+            curr_info = self._reset_env(env)
             while any([t.get_step <= t.get_max_steps \
                        for k, t in self.trainers.items()]) \
                   or not self.train_model:
-                new_info = self.take_step(env, curr_info)
+                new_info = self.take_step(env, curr_info, policies)
                 self.global_step += 1
                 if self.global_step % self.save_freq == 0 and self.global_step != 0 \
                         and self.train_model:
@@ -227,10 +229,10 @@ class TrainerController(object):
         if self.train_model:
             self._export_graph()
 
-    def take_step(self, env, curr_info):
+    def take_step(self, env, curr_info: AllBrainInfo, policies: Dict[str, Policy]):
         if self.meta_curriculum:
             # Get the sizes of the reward buffers.
-            reward_buff_sizes = {k: len(t.reward_buffer) \
+            reward_buff_sizes = {k: len(t.reward_buffer)
                                  for (k, t) in self.trainers.items()}
             # Attempt to increment the lessons of the brains who
             # were ready.
@@ -238,6 +240,8 @@ class TrainerController(object):
                 self.meta_curriculum.increment_lessons(
                     self._get_measure_vals(),
                     reward_buff_sizes=reward_buff_sizes)
+        else:
+            lessons_incremented = {}
 
         # If any lessons were incremented or the environment is
         # ready to be reset
@@ -248,30 +252,32 @@ class TrainerController(object):
                 trainer.end_episode()
             for brain_name, changed in lessons_incremented.items():
                 if changed:
-                    self.trainers[brain_name].reward_buffer.clear()
+                    self.trainers[brain_name].curriculum_lesson_changed()
         elif env.global_done:
             curr_info = self._reset_env(env)
             for brain_name, trainer in self.trainers.items():
                 trainer.end_episode()
 
         # Decide and take an action
-        take_action_vector, \
-        take_action_memories, \
-        take_action_text, \
-        take_action_value, \
-        take_action_outputs \
-            = {}, {}, {}, {}, {}
-        for brain_name, trainer in self.trainers.items():
-            (take_action_vector[brain_name],
-             take_action_memories[brain_name],
-             take_action_text[brain_name],
-             take_action_value[brain_name],
-             take_action_outputs[brain_name]) = \
-                trainer.take_action(curr_info)
-        new_info = env.step(vector_action=take_action_vector,
-                            memory=take_action_memories,
-                            text_action=take_action_text,
-                            value=take_action_value)
+        take_action_vector = {}
+        take_action_memories = {}
+        take_action_text = {}
+        take_action_value = {}
+        take_action_outputs = {}
+        for brain_name, policy in policies.items():
+            action_info = policy.get_action(curr_info[brain_name])
+            take_action_vector[brain_name] = action_info.action
+            take_action_memories[brain_name] = action_info.memory
+            take_action_text[brain_name] = action_info.text
+            take_action_value[brain_name] = action_info.value
+            take_action_outputs[brain_name] = action_info.outputs
+        new_info = env.step(
+            vector_action=take_action_vector,
+            memory=take_action_memories,
+            text_action=take_action_text,
+            value=take_action_value
+        )
+
         for brain_name, trainer in self.trainers.items():
             trainer.add_experiences(curr_info, new_info,
                                     take_action_outputs[brain_name])

--- a/ml-agents/tests/trainers/test_policy.py
+++ b/ml-agents/tests/trainers/test_policy.py
@@ -1,0 +1,51 @@
+from mlagents.trainers.policy import *
+from unittest.mock import MagicMock
+
+def basic_mock_brain():
+    mock_brain = MagicMock()
+    mock_brain.vector_action_space_type = "continuous"
+    return mock_brain
+
+def basic_params():
+    return {
+        "use_recurrent": False,
+        "model_path": "my/path"
+    }
+
+
+def test_take_action_returns_empty_with_no_agents():
+    test_seed = 3
+    policy = Policy(test_seed, basic_mock_brain(), basic_params())
+    no_agent_brain_info = BrainInfo([], [], [], agents=[])
+    result = policy.get_action(no_agent_brain_info)
+    assert(result == ActionInfo([], [], [], None, None))
+
+
+def test_take_action_returns_nones_on_missing_values():
+    test_seed = 3
+    policy = Policy(test_seed, basic_mock_brain(), basic_params())
+    policy.evaluate = MagicMock(return_value={})
+    brain_info_with_agents = BrainInfo([], [], [], agents=['an-agent-id'])
+    result = policy.get_action(brain_info_with_agents)
+    assert(result == ActionInfo(None, None, None, None, {}))
+
+
+def test_take_action_returns_action_info_when_available():
+    test_seed = 3
+    policy = Policy(test_seed, basic_mock_brain(), basic_params())
+    policy_eval_out = {
+        'action': np.array([1.0]),
+        'memory_out': np.array([2.5]),
+        'value': np.array([1.1])
+    }
+    policy.evaluate = MagicMock(return_value=policy_eval_out)
+    brain_info_with_agents = BrainInfo([], [], [], agents=['an-agent-id'])
+    result = policy.get_action(brain_info_with_agents)
+    expected = ActionInfo(
+        policy_eval_out['action'],
+        policy_eval_out['memory_out'],
+        None,
+        policy_eval_out['value'],
+        policy_eval_out
+    )
+    assert (result == expected)

--- a/ml-agents/tests/trainers/test_trainer_controller.py
+++ b/ml-agents/tests/trainers/test_trainer_controller.py
@@ -5,6 +5,7 @@ from unittest.mock import *
 import yaml
 import pytest
 
+from mlagents.trainers import ActionInfo
 from mlagents.trainers.trainer_controller import TrainerController
 from mlagents.trainers.ppo.trainer import PPOTrainer
 from mlagents.trainers.bc.offline_trainer import OfflineBCTrainer
@@ -279,7 +280,7 @@ def trainer_controller_with_start_learning_mocks():
     tc.trainers = {'testbrain': trainer_mock}
     tc.take_step = MagicMock()
 
-    def take_step_sideeffect(env, curr_info):
+    def take_step_sideeffect(env, curr_info, policies):
         tc.trainers['testbrain'].get_step += 1
         if tc.trainers['testbrain'].get_step > 10:
             raise KeyboardInterrupt
@@ -369,7 +370,6 @@ def test_take_step_resets_env_on_global_done():
 
     brain_info_mock = MagicMock()
     action_data_mock_out = [None, None, None, None, None]
-    trainer_mock.take_action = MagicMock(return_value=action_data_mock_out)
     trainer_mock.add_experiences = MagicMock()
     trainer_mock.process_experiences = MagicMock()
     trainer_mock.update_policy = MagicMock()
@@ -382,7 +382,11 @@ def test_take_step_resets_env_on_global_done():
     env_mock.reset = MagicMock(return_value=brain_info_mock)
     env_mock.global_done = True
 
-    tc.take_step(env_mock, brain_info_mock)
+    policy_mock = MagicMock()
+    policy_mock.get_action = MagicMock(return_value = ActionInfo(None, None, None, None, None))
+    mock_policies = {'testbrain': policy_mock}
+
+    tc.take_step(env_mock, brain_info_mock, mock_policies)
     env_mock.reset.assert_called_once()
 
 
@@ -390,14 +394,8 @@ def test_take_step_adds_experiences_to_trainer_and_trains():
     tc, trainer_mock = trainer_controller_with_take_step_mocks()
 
     curr_info_mock = MagicMock()
-    trainer_action_output_mock = [
-        'action',
-        'memory',
-        'actiontext',
-        'value',
-        'output',
-    ]
-    trainer_mock.take_action = MagicMock(return_value=trainer_action_output_mock)
+    brain_info_mock = MagicMock()
+    curr_info_mock.__getitem__ = MagicMock(return_value=brain_info_mock)
     trainer_mock.is_ready_update = MagicMock(return_value=True)
 
     env_mock = MagicMock()
@@ -407,17 +405,28 @@ def test_take_step_adds_experiences_to_trainer_and_trains():
     env_mock.reset = MagicMock(return_value=curr_info_mock)
     env_mock.global_done = False
 
-    tc.take_step(env_mock, curr_info_mock)
+    policy_mock = MagicMock()
+    action_output_mock = ActionInfo(
+        'action',
+        'memory',
+        'actiontext',
+        'value',
+        {'some': 'output'}
+    )
+    policy_mock.get_action = MagicMock(return_value=action_output_mock)
+    mock_policies = {'testbrain': policy_mock}
+
+    tc.take_step(env_mock, curr_info_mock, mock_policies)
     env_mock.reset.assert_not_called()
-    trainer_mock.take_action.assert_called_once_with(curr_info_mock)
+    policy_mock.get_action.assert_called_once_with(brain_info_mock)
     env_mock.step.assert_called_once_with(
-        vector_action={'testbrain': trainer_action_output_mock[0]},
-        memory={'testbrain': trainer_action_output_mock[1]},
-        text_action={'testbrain': trainer_action_output_mock[2]},
-        value={'testbrain': trainer_action_output_mock[3]}
+        vector_action={'testbrain': action_output_mock.action},
+        memory={'testbrain': action_output_mock.memory},
+        text_action={'testbrain': action_output_mock.text},
+        value={'testbrain': action_output_mock.value}
     )
     trainer_mock.add_experiences.assert_called_once_with(
-        curr_info_mock, env_step_output_mock, trainer_action_output_mock[4]
+        curr_info_mock, env_step_output_mock, action_output_mock.outputs
     )
     trainer_mock.process_experiences.assert_called_once_with(curr_info_mock, env_step_output_mock)
     trainer_mock.update_policy.assert_called_once()

--- a/ml-agents/tests/trainers/test_trainer_controller.py
+++ b/ml-agents/tests/trainers/test_trainer_controller.py
@@ -369,7 +369,6 @@ def test_take_step_resets_env_on_global_done():
     tc, trainer_mock = trainer_controller_with_take_step_mocks()
 
     brain_info_mock = MagicMock()
-    action_data_mock_out = [None, None, None, None, None]
     trainer_mock.add_experiences = MagicMock()
     trainer_mock.process_experiences = MagicMock()
     trainer_mock.update_policy = MagicMock()

--- a/ml-agents/tests/trainers/test_trainer_controller.py
+++ b/ml-agents/tests/trainers/test_trainer_controller.py
@@ -280,7 +280,7 @@ def trainer_controller_with_start_learning_mocks():
     tc.trainers = {'testbrain': trainer_mock}
     tc.take_step = MagicMock()
 
-    def take_step_sideeffect(env, curr_info, policies):
+    def take_step_sideeffect(env, curr_info):
         tc.trainers['testbrain'].get_step += 1
         if tc.trainers['testbrain'].get_step > 10:
             raise KeyboardInterrupt
@@ -381,11 +381,9 @@ def test_take_step_resets_env_on_global_done():
     env_mock.reset = MagicMock(return_value=brain_info_mock)
     env_mock.global_done = True
 
-    policy_mock = MagicMock()
-    policy_mock.get_action = MagicMock(return_value = ActionInfo(None, None, None, None, None))
-    mock_policies = {'testbrain': policy_mock}
+    trainer_mock.get_action = MagicMock(return_value = ActionInfo(None, None, None, None, None))
 
-    tc.take_step(env_mock, brain_info_mock, mock_policies)
+    tc.take_step(env_mock, brain_info_mock)
     env_mock.reset.assert_called_once()
 
 
@@ -404,7 +402,6 @@ def test_take_step_adds_experiences_to_trainer_and_trains():
     env_mock.reset = MagicMock(return_value=curr_info_mock)
     env_mock.global_done = False
 
-    policy_mock = MagicMock()
     action_output_mock = ActionInfo(
         'action',
         'memory',
@@ -412,12 +409,11 @@ def test_take_step_adds_experiences_to_trainer_and_trains():
         'value',
         {'some': 'output'}
     )
-    policy_mock.get_action = MagicMock(return_value=action_output_mock)
-    mock_policies = {'testbrain': policy_mock}
+    trainer_mock.get_action = MagicMock(return_value=action_output_mock)
 
-    tc.take_step(env_mock, curr_info_mock, mock_policies)
+    tc.take_step(env_mock, curr_info_mock)
     env_mock.reset.assert_not_called()
-    policy_mock.get_action.assert_called_once_with(brain_info_mock)
+    trainer_mock.get_action.assert_called_once_with(brain_info_mock)
     env_mock.step.assert_called_once_with(
         vector_action={'testbrain': action_output_mock.action},
         memory={'testbrain': action_output_mock.memory},


### PR DESCRIPTION
This refactor is part of Actor-Trainer separation. Since policies
will be distributed across actors in separate processes which share
a single trainer, taking an action should be the responsibility of
the policy.

This change makes a few smaller changes:
* Combines `take_action` logic between trainers, making it more
  generic
* Adds an `ActionInfo` data class to be more explicit about the
  data returned by the policy, only used by TrainerController and
  policy for now.
* Moves trainer stats logic out of `take_action` and into
  `add_experiences`
* Fixes a minor issue where `reward_buffer` was being referred to
  on generic Trainers during curriculum learning even though this
  property doesn't exist on the base Trainer class.