### PR TITLE
Fix subprocess model saving on Windows

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -41,7 +41,7 @@ def test_run_training(load_config, create_environment_factory, subproc_env_mock)
         with patch.object(TrainerController, "start_learning", MagicMock()):
             learn.run_training(0, 0, basic_options(), MagicMock())
             mock_init.assert_called_once_with(
-                './models/ppo',
+                './models/ppo-0',
                 './summaries',
                 'ppo-0',
                 50000,
@@ -74,5 +74,5 @@ def test_docker_target_path(load_config, create_environment_factory, subproc_env
         with patch.object(TrainerController, "start_learning", MagicMock()):
             learn.run_training(0, 0, options_with_docker_target, MagicMock())
             mock_init.assert_called_once()
-            assert(mock_init.call_args[0][0] == '/dockertarget/models/ppo')
+            assert(mock_init.call_args[0][0] == '/dockertarget/models/ppo-0')
             assert(mock_init.call_args[0][1] == '/dockertarget/summaries')

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -6,9 +6,6 @@ import os
 import logging
 import shutil
 import sys
-if sys.platform.startswith('win'):
-    import win32api
-    import win32con
 from typing import *
 
 import numpy as np
@@ -103,18 +100,6 @@ class TrainerController(object):
         self.logger.info('Learning was interrupted. Please wait '
                          'while the graph is generated.')
         self._save_model(steps)
-
-    def _win_handler(self, event):
-        """
-        This function gets triggered after ctrl-c or ctrl-break is pressed
-        under Windows platform.
-        """
-        if event in (win32con.CTRL_C_EVENT, win32con.CTRL_BREAK_EVENT):
-            self._save_model_when_interrupted(self.global_step)
-            self._export_graph()
-            sys.exit()
-            return True
-        return False
 
     def _write_training_metrics(self):
         """
@@ -223,9 +208,6 @@ class TrainerController(object):
             for brain_name, trainer in self.trainers.items():
                 trainer.write_tensorboard_text('Hyperparameters',
                                                trainer.parameters)
-            if sys.platform.startswith('win'):
-                # Add the _win_handler function to the windows console's handler function list
-                win32api.SetConsoleCtrlHandler(self._win_handler, True)
         try:
             curr_info = self._reset_env(env)
             while any([t.get_step <= t.get_max_steps \


### PR DESCRIPTION
On Windows the interrupt for subprocesses works in a different
way from OSX/Linux. The result is that child subprocesses and
their pipes may close while the parent process is still running
during a keyboard (ctrl+C) interrupt.

To handle this, this change adds handling for EOFError and
BrokenPipeError exceptions when interacting with subprocess
environments. Additional management is also added to be sure
when using parallel runs using the "num-runs" option that
the threads for each run are joined and KeyboardInterrupts are
handled.

These changes made the "_win_handler" we used to specially
manage interrupts on Windows unnecessary, so they have been
removed.

Brought up in #1389, follow up to #1912.