### PR TITLE
Add exception for external brains and array-ify

### DIFF
--- a/gym-unity/gym_unity/envs/unity_env.py
+++ b/gym-unity/gym_unity/envs/unity_env.py
@@ -62,7 +62,7 @@ class UnityEnv(gym.Env):
             )
         if len(self._env.external_brain_names) <= 0:
             raise UnityGymException(
-                "There are any external brain in the UnityEnvironment"
+                "There are not any external brain in the UnityEnvironment"
             )
 
         self.brain_name = self._env.external_brain_names[0]

--- a/gym-unity/gym_unity/envs/unity_env.py
+++ b/gym-unity/gym_unity/envs/unity_env.py
@@ -60,6 +60,11 @@ class UnityEnv(gym.Env):
                 "There can only be one brain in a UnityEnvironment "
                 "if it is wrapped in a gym."
             )
+        if len(self._env.external_brain_names) <= 0:
+            raise UnityGymException(
+                "There are any external brain in the UnityEnvironment"
+            )
+
         self.brain_name = self._env.external_brain_names[0]
         brain = self._env.brains[self.brain_name]
 
@@ -204,8 +209,11 @@ class UnityEnv(gym.Env):
 
     def _single_step(self, info):
         if self.use_visual:
+            visual_obs = info.visual_observations
+            if isinstance(visual_obs, list):
+                visual_obs = np.array(visual_obs)
             self.visual_obs = self._preprocess_single(
-                info.visual_observations[0][0, :, :, :]
+                visual_obs[0][0, :, :, :]
             )
             default_observation = self.visual_obs
         else:


### PR DESCRIPTION
We're covering two simple fixes:
- Make sure that at least one external Brain is defined (we experienced an array index error when forgotten defining a learning brain for at least an agent in Unity Editor)
- Enforce that we have visual observations as an Numpy array before trying to slice it