### PR TITLE
Self play: Add a ghost trainer and track agents elo rating 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@
 # VSCode hidden files
 *.vscode/
 
+# PyCharm hidden files
+*.idea/
+
 .DS_Store
 .ipynb_checkpoints
 

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Brains/TennisGhost.asset
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Brains/TennisGhost.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b23992c8eb17439887f5e944bf04a40, type: 3}
+  m_Name: TennisGhost
+  m_EditorClassIdentifier: 
+  brainParameters:
+    vectorObservationSize: 8
+    numStackedVectorObservations: 3
+    vectorActionSize: 02000000
+    cameraResolutions: []
+    vectorActionDescriptions:
+    - 
+    - 
+    vectorActionSpaceType: 1
+  model: {fileID: 0}

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Brains/TennisGhost.asset.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Brains/TennisGhost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8b9fd7eb42d7c746a68aa157c29a901
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Prefabs/TennisArea.prefab
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Prefabs/TennisArea.prefab
@@ -8,15 +8,15 @@ Prefab:
     m_TransformParent: {fileID: 0}
     m_Modifications: []
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
+  m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1541947554534326}
-  m_IsPrefabParent: 1
+  m_IsPrefabAsset: 1
 --- !u!1 &1059130078069486
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4928324314505656}
   - component: {fileID: 33996804732502440}
@@ -32,9 +32,9 @@ GameObject:
 --- !u!1 &1152213550744012
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4211600048733070}
   - component: {fileID: 33659424616741360}
@@ -49,9 +49,9 @@ GameObject:
 --- !u!1 &1170495812642400
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4576079212954380}
   - component: {fileID: 33869133160533440}
@@ -68,9 +68,9 @@ GameObject:
 --- !u!1 &1249640109736648
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4180954244824896}
   - component: {fileID: 33735860223680188}
@@ -86,9 +86,9 @@ GameObject:
 --- !u!1 &1299636753784036
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4732304271615694}
   - component: {fileID: 33738318791350608}
@@ -104,9 +104,9 @@ GameObject:
 --- !u!1 &1478722160813726
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4522776505819358}
   - component: {fileID: 33373422117485718}
@@ -122,9 +122,9 @@ GameObject:
 --- !u!1 &1485570486708108
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4733128113887812}
   - component: {fileID: 33851606214172574}
@@ -140,9 +140,9 @@ GameObject:
 --- !u!1 &1541947554534326
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4172342666475122}
   - component: {fileID: 114965703901356864}
@@ -156,9 +156,9 @@ GameObject:
 --- !u!1 &1573817391095622
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4859823443517042}
   - component: {fileID: 33076605640816118}
@@ -173,9 +173,9 @@ GameObject:
 --- !u!1 &1600389029549348
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4471539065941630}
   m_Layer: 0
@@ -188,9 +188,9 @@ GameObject:
 --- !u!1 &1730923431341952
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4535263776590958}
   - component: {fileID: 33626294071478236}
@@ -206,9 +206,9 @@ GameObject:
 --- !u!1 &1763823636170630
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4162117758034460}
   - component: {fileID: 33374851918158766}
@@ -223,9 +223,9 @@ GameObject:
 --- !u!1 &1766663729253338
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4759636389763608}
   - component: {fileID: 33007165429471998}
@@ -243,9 +243,9 @@ GameObject:
 --- !u!1 &1882383181950958
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4893760344154248}
   - component: {fileID: 33721938831138212}
@@ -262,9 +262,9 @@ GameObject:
 --- !u!1 &1969551055586186
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4275308033819996}
   m_Layer: 0
@@ -277,7 +277,7 @@ GameObject:
 --- !u!4 &4162117758034460
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1763823636170630}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
@@ -290,7 +290,7 @@ Transform:
 --- !u!4 &4172342666475122
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1541947554534326}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -308,7 +308,7 @@ Transform:
 --- !u!4 &4180954244824896
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1249640109736648}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -321,7 +321,7 @@ Transform:
 --- !u!4 &4211600048733070
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1152213550744012}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
@@ -334,7 +334,7 @@ Transform:
 --- !u!4 &4275308033819996
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1969551055586186}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -351,7 +351,7 @@ Transform:
 --- !u!4 &4471539065941630
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1600389029549348}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -367,7 +367,7 @@ Transform:
 --- !u!4 &4522776505819358
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1478722160813726}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -380,7 +380,7 @@ Transform:
 --- !u!4 &4535263776590958
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1730923431341952}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -393,7 +393,7 @@ Transform:
 --- !u!4 &4576079212954380
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1170495812642400}
   m_LocalRotation: {x: -0, y: -0, z: 0.46174863, w: 0.8870109}
@@ -407,7 +407,7 @@ Transform:
 --- !u!4 &4732304271615694
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1299636753784036}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -420,7 +420,7 @@ Transform:
 --- !u!4 &4733128113887812
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1485570486708108}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -433,7 +433,7 @@ Transform:
 --- !u!4 &4759636389763608
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -446,7 +446,7 @@ Transform:
 --- !u!4 &4859823443517042
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1573817391095622}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -459,7 +459,7 @@ Transform:
 --- !u!4 &4893760344154248
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882383181950958}
   m_LocalRotation: {x: -0, y: -0, z: -0.46174863, w: 0.8870109}
@@ -473,7 +473,7 @@ Transform:
 --- !u!4 &4928324314505656
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1059130078069486}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -486,7 +486,7 @@ Transform:
 --- !u!23 &23027053290669866
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1059130078069486}
   m_Enabled: 1
@@ -496,6 +496,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 214660f4189b04cada2137381f5c3607, type: 2}
   m_StaticBatchInfo:
@@ -520,7 +521,7 @@ MeshRenderer:
 --- !u!23 &23040340621383062
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1152213550744012}
   m_Enabled: 1
@@ -530,6 +531,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 6cac5d0b9689c45b8809b67eb2c95f86, type: 2}
   m_StaticBatchInfo:
@@ -554,7 +556,7 @@ MeshRenderer:
 --- !u!23 &23335368383156264
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1299636753784036}
   m_Enabled: 0
@@ -564,6 +566,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 7b8d9f163db3b438c9577737f468e0a2, type: 2}
   m_StaticBatchInfo:
@@ -588,7 +591,7 @@ MeshRenderer:
 --- !u!23 &23409105759282306
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1763823636170630}
   m_Enabled: 1
@@ -598,6 +601,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 4df2264df8daf450d82b3584d732c8aa, type: 2}
   m_StaticBatchInfo:
@@ -622,7 +626,7 @@ MeshRenderer:
 --- !u!23 &23463515535297014
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1249640109736648}
   m_Enabled: 1
@@ -632,6 +636,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: e875dae9102374b76b5e8a26d06478a0, type: 2}
   m_StaticBatchInfo:
@@ -656,7 +661,7 @@ MeshRenderer:
 --- !u!23 &23472577311732864
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1730923431341952}
   m_Enabled: 0
@@ -666,6 +671,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 7b8d9f163db3b438c9577737f468e0a2, type: 2}
   m_StaticBatchInfo:
@@ -690,7 +696,7 @@ MeshRenderer:
 --- !u!23 &23513810942247584
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1485570486708108}
   m_Enabled: 0
@@ -700,6 +706,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 7b8d9f163db3b438c9577737f468e0a2, type: 2}
   m_StaticBatchInfo:
@@ -724,7 +731,7 @@ MeshRenderer:
 --- !u!23 &23541294213234022
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   m_Enabled: 1
@@ -734,6 +741,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: edd958d75ed1448138de86f3335ea4fa, type: 2}
   m_StaticBatchInfo:
@@ -758,7 +766,7 @@ MeshRenderer:
 --- !u!23 &23863670214526506
 MeshRenderer:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1478722160813726}
   m_Enabled: 0
@@ -768,6 +776,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 7b8d9f163db3b438c9577737f468e0a2, type: 2}
   m_StaticBatchInfo:
@@ -792,91 +801,91 @@ MeshRenderer:
 --- !u!33 &33007165429471998
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33076605640816118
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1573817391095622}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33373422117485718
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1478722160813726}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33374851918158766
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1763823636170630}
   m_Mesh: {fileID: 4300000, guid: 17d4dad0a373442b1b5d3e6ac481e5c8, type: 3}
 --- !u!33 &33626294071478236
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1730923431341952}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33659424616741360
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1152213550744012}
   m_Mesh: {fileID: 4300000, guid: 17d4dad0a373442b1b5d3e6ac481e5c8, type: 3}
 --- !u!33 &33721938831138212
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882383181950958}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33735860223680188
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1249640109736648}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33738318791350608
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1299636753784036}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33851606214172574
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1485570486708108}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33869133160533440
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1170495812642400}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &33996804732502440
 MeshFilter:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1059130078069486}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54459681652844648
 Rigidbody:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882383181950958}
   serializedVersion: 2
@@ -891,7 +900,7 @@ Rigidbody:
 --- !u!54 &54602203932868002
 Rigidbody:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   serializedVersion: 2
@@ -906,7 +915,7 @@ Rigidbody:
 --- !u!54 &54815576193067388
 Rigidbody:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1170495812642400}
   serializedVersion: 2
@@ -921,7 +930,7 @@ Rigidbody:
 --- !u!65 &65071342415854582
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1059130078069486}
   m_Material: {fileID: 0}
@@ -933,7 +942,7 @@ BoxCollider:
 --- !u!65 &65249295636387450
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1573817391095622}
   m_Material: {fileID: 0}
@@ -945,7 +954,7 @@ BoxCollider:
 --- !u!65 &65276341973995358
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1170495812642400}
   m_Material: {fileID: 13400000, guid: 81bc1938a128a417eae63a8d644e3baf, type: 2}
@@ -957,7 +966,7 @@ BoxCollider:
 --- !u!65 &65280384434867516
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882383181950958}
   m_Material: {fileID: 13400000, guid: 81bc1938a128a417eae63a8d644e3baf, type: 2}
@@ -969,7 +978,7 @@ BoxCollider:
 --- !u!65 &65381719258232090
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1249640109736648}
   m_Material: {fileID: 0}
@@ -981,7 +990,7 @@ BoxCollider:
 --- !u!65 &65593217352137886
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1485570486708108}
   m_Material: {fileID: 0}
@@ -993,7 +1002,7 @@ BoxCollider:
 --- !u!65 &65640199598103162
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1730923431341952}
   m_Material: {fileID: 0}
@@ -1005,7 +1014,7 @@ BoxCollider:
 --- !u!65 &65691977659257876
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1478722160813726}
   m_Material: {fileID: 0}
@@ -1017,7 +1026,7 @@ BoxCollider:
 --- !u!65 &65739890147049780
 BoxCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1299636753784036}
   m_Material: {fileID: 0}
@@ -1029,7 +1038,7 @@ BoxCollider:
 --- !u!114 &114800310164848628
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1882383181950958}
   m_Enabled: 1
@@ -1040,18 +1049,20 @@ MonoBehaviour:
   brain: {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
   agentParameters:
     agentCameras: []
+    agentRenderTextures: []
     maxStep: 5000
     resetOnDone: 1
     onDemandDecision: 0
     numberOfActionsBetweenDecisions: 5
   ball: {fileID: 1766663729253338}
   invertX: 1
-  score: 0
+  isLearning: 0
+  matchState: play
   myArea: {fileID: 1541947554534326}
 --- !u!114 &114915946461826994
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1170495812642400}
   m_Enabled: 1
@@ -1062,18 +1073,20 @@ MonoBehaviour:
   brain: {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
   agentParameters:
     agentCameras: []
+    agentRenderTextures: []
     maxStep: 5000
     resetOnDone: 1
     onDemandDecision: 0
     numberOfActionsBetweenDecisions: 5
   ball: {fileID: 1766663729253338}
   invertX: 0
-  score: 0
+  isLearning: 0
+  matchState: play
   myArea: {fileID: 1541947554534326}
 --- !u!114 &114959127241806892
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   m_Enabled: 1
@@ -1086,7 +1099,7 @@ MonoBehaviour:
 --- !u!114 &114965703901356864
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1541947554534326}
   m_Enabled: 1
@@ -1094,13 +1107,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc15854a4efe14dceb84a3183ca4c896, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  learningBrain: {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
+  ghostBrain: {fileID: 11400000, guid: f8b9fd7eb42d7c746a68aa157c29a901, type: 2}
   ball: {fileID: 1766663729253338}
-  agentA: {fileID: 1170495812642400}
-  agentB: {fileID: 1882383181950958}
+  agentA: {fileID: 114915946461826994}
+  agentB: {fileID: 114800310164848628}
 --- !u!135 &135352518081610988
 SphereCollider:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1766663729253338}
   m_Material: {fileID: 13400000, guid: 422ac22c624b247749ec84410e5d3462, type: 2}

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,6 +39,7 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -54,11 +55,10 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 40
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -116,9 +116,9 @@ NavMeshSettings:
 --- !u!1 &32822935
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 32822938}
   - component: {fileID: 32822937}
@@ -133,7 +133,7 @@ GameObject:
 --- !u!114 &32822936
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 32822935}
   m_Enabled: 1
@@ -151,7 +151,7 @@ MonoBehaviour:
 --- !u!114 &32822937
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 32822935}
   m_Enabled: 1
@@ -165,7 +165,7 @@ MonoBehaviour:
 --- !u!4 &32822938
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 32822935}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -218,9 +218,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (17)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &285785127
 Prefab:
   m_ObjectHideFlags: 0
@@ -264,9 +268,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (9)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &393884112
 Prefab:
   m_ObjectHideFlags: 0
@@ -310,9 +318,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (12)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &530994421
 Prefab:
   m_ObjectHideFlags: 0
@@ -356,9 +368,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (15)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &570952279
 Prefab:
   m_ObjectHideFlags: 0
@@ -402,9 +418,88 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
+--- !u!1 &615421381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 615421384}
+  - component: {fileID: 615421383}
+  - component: {fileID: 615421382}
+  m_Layer: 5
+  m_Name: BrainWinrate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &615421382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 615421381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 58e2b2715aaee4686a912897f823f8f5, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 15
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Recent Winrate: '
+--- !u!222 &615421383
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 615421381}
+  m_CullTransparentMesh: 0
+--- !u!224 &615421384
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 615421381}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1184319693}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 154.2, y: -90.3}
+  m_SizeDelta: {x: 300, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &667349971
 Prefab:
   m_ObjectHideFlags: 0
@@ -448,9 +543,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &699067963
 Prefab:
   m_ObjectHideFlags: 0
@@ -494,9 +593,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (7)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &861437242
 Prefab:
   m_ObjectHideFlags: 0
@@ -540,15 +643,19 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (10)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &957430531
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 957430536}
   - component: {fileID: 957430535}
@@ -562,13 +669,17 @@ GameObject:
 --- !u!20 &957430535
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 957430531}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0.39609292, g: 0.49962592, b: 0.6509434, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -598,7 +709,7 @@ Camera:
 --- !u!4 &957430536
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 957430531}
   m_LocalRotation: {x: 0.13052616, y: 0, z: 0, w: 0.9914449}
@@ -651,15 +762,19 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (11)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &1022397856
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1022397857}
   - component: {fileID: 1022397858}
@@ -673,7 +788,7 @@ GameObject:
 --- !u!4 &1022397857
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1022397856}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -686,7 +801,7 @@ Transform:
 --- !u!114 &1022397858
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1022397856}
   m_Enabled: 1
@@ -697,8 +812,12 @@ MonoBehaviour:
   broadcastHub:
     broadcastingBrains:
     - {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
-    _brainsToControl: []
-  maxSteps: 25000
+    - {fileID: 11400000, guid: f8b9fd7eb42d7c746a68aa157c29a901, type: 2}
+    _brainsToControl:
+    - {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
+    - {fileID: 0}
+    - {fileID: 11400000, guid: f8b9fd7eb42d7c746a68aa157c29a901, type: 2}
+  maxSteps: 1000
   trainingConfiguration:
     width: 300
     height: 200
@@ -756,9 +875,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &1093755623
 Prefab:
   m_ObjectHideFlags: 0
@@ -802,9 +925,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &1104802083
 Prefab:
   m_ObjectHideFlags: 0
@@ -848,9 +975,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &1180609771
 Prefab:
   m_ObjectHideFlags: 0
@@ -894,20 +1025,25 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (8)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &1184319689
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1184319693}
   - component: {fileID: 1184319692}
   - component: {fileID: 1184319691}
   - component: {fileID: 1184319690}
+  - component: {fileID: 1184319694}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -918,7 +1054,7 @@ GameObject:
 --- !u!114 &1184319690
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1184319689}
   m_Enabled: 1
@@ -934,7 +1070,7 @@ MonoBehaviour:
 --- !u!114 &1184319691
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1184319689}
   m_Enabled: 1
@@ -955,7 +1091,7 @@ MonoBehaviour:
 --- !u!223 &1184319692
 Canvas:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1184319689}
   m_Enabled: 1
@@ -975,7 +1111,7 @@ Canvas:
 --- !u!224 &1184319693
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1184319689}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -984,6 +1120,8 @@ RectTransform:
   m_Children:
   - {fileID: 2073469451}
   - {fileID: 1871669622}
+  - {fileID: 615421384}
+  - {fileID: 1874305709}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -992,6 +1130,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1184319694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1184319689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18c3299d1cb39464c89a910bb0278ce4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  recentBlueWinrate: {fileID: 1874305707}
+  recentLearnWinrate: {fileID: 615421382}
+  scoreGhost: {fileID: 1871669623}
+  scoreLearn: {fileID: 2073469452}
 --- !u!1001 &1193061827
 Prefab:
   m_ObjectHideFlags: 0
@@ -1035,9 +1188,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (13)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &1667694556
 Prefab:
   m_ObjectHideFlags: 0
@@ -1078,14 +1235,14 @@ Prefab:
       value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &1749132593
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1749132595}
   - component: {fileID: 1749132594}
@@ -1099,7 +1256,7 @@ GameObject:
 --- !u!108 &1749132594
 Light:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1749132593}
   m_Enabled: 1
@@ -1126,6 +1283,7 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 10
   m_ColorTemperature: 6570
@@ -1135,7 +1293,7 @@ Light:
 --- !u!4 &1749132595
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1749132593}
   m_LocalRotation: {x: 0.48296294, y: 0.22414392, z: -0.12940955, w: 0.8365163}
@@ -1188,21 +1346,25 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (14)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &1871669621
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1871669622}
   - component: {fileID: 1871669624}
   - component: {fileID: 1871669623}
   m_Layer: 5
-  m_Name: ScoreB
+  m_Name: ScoreGhost
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1211,7 +1373,7 @@ GameObject:
 --- !u!224 &1871669622
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1871669621}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -1223,13 +1385,13 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -20, y: -50}
+  m_AnchoredPosition: {x: -49.7, y: -64.4}
   m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1871669623
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1871669621}
   m_Enabled: 1
@@ -1247,10 +1409,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 40
+    m_FontSize: 15
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 2
+    m_MinSize: 1
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -1258,13 +1420,89 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 0
+  m_Text: 'Ghost: 0'
 --- !u!222 &1871669624
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1871669621}
+  m_CullTransparentMesh: 0
+--- !u!1 &1874305706
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1874305709}
+  - component: {fileID: 1874305708}
+  - component: {fileID: 1874305707}
+  m_Layer: 5
+  m_Name: AgentWinrate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1874305707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1874305706}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 58e2b2715aaee4686a912897f823f8f5, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 15
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Recent Winrate: '
+--- !u!222 &1874305708
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1874305706}
+  m_CullTransparentMesh: 0
+--- !u!224 &1874305709
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1874305706}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1184319693}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 154.2, y: -116.78}
+  m_SizeDelta: {x: 300, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1913269664
 Prefab:
   m_ObjectHideFlags: 0
@@ -1308,9 +1546,13 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (6)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1001 &1965335106
 Prefab:
   m_ObjectHideFlags: 0
@@ -1354,21 +1596,25 @@ Prefab:
       propertyPath: m_Name
       value: TennisArea (16)
       objectReference: {fileID: 0}
+    - target: {fileID: 1541947554534326, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 812997c7bc2544b6f927ff684c03450f, type: 2}
+  m_IsPrefabAsset: 0
 --- !u!1 &2073469450
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 2073469451}
   - component: {fileID: 2073469453}
   - component: {fileID: 2073469452}
   m_Layer: 5
-  m_Name: ScoreA
+  m_Name: ScoreLearn
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1377,7 +1623,7 @@ GameObject:
 --- !u!224 &2073469451
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2073469450}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
@@ -1389,13 +1635,13 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -50}
+  m_AnchoredPosition: {x: 100, y: -64.7}
   m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2073469452
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2073469450}
   m_Enabled: 1
@@ -1413,10 +1659,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 40
+    m_FontSize: 15
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 2
+    m_MinSize: 1
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
@@ -1424,10 +1670,11 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 0
+  m_Text: 'Learn: 0'
 --- !u!222 &2073469453
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2073469450}
+  m_CullTransparentMesh: 0

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/HitWall.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/HitWall.cs
@@ -11,6 +11,8 @@ public class HitWall : MonoBehaviour
     private TennisAgent agentA;
     private TennisAgent agentB;
 
+    private int nbPasses = 0;
+
     // Use this for initialization
     void Start()
     {
@@ -23,16 +25,7 @@ public class HitWall : MonoBehaviour
     {
         if (other.name == "over")
         {
-            if (lastAgentHit == 0)
-            {
-                agentA.AddReward( 0.1f);
-            }
-            else
-            {
-                agentB.AddReward(0.1f);
-            }
-            lastAgentHit = 0;
-
+            nbPasses +=1;
         }
     }
 
@@ -44,81 +37,48 @@ public class HitWall : MonoBehaviour
             {
                 if (lastAgentHit == 0)
                 {
-                    agentA.AddReward( -0.01f);
-                    agentB.SetReward(0);
-                    agentB.score += 1;
+                    agentB.Score += 1;
                 }
                 else
                 {
-                    agentA.SetReward(0);
-                    agentB.AddReward(-0.01f);
-                    agentA.score += 1;
+                    agentA.Score += 1;
                 }
             }
             else if (collision.gameObject.name == "wallB")
             {
                 if (lastAgentHit == 0)
                 {
-                    agentA.AddReward( -0.01f);
-                    agentB.SetReward(0);
-                    agentB.score += 1;
+                    agentB.Score += 1;
                 }
                 else
                 {
-                    agentA.SetReward(0);
-                    agentB.AddReward( -0.01f);
-                    agentA.score += 1;
+                    agentA.Score += 1;
                 }
             }
             else if (collision.gameObject.name == "floorA")
             {
-                if (lastAgentHit == 0 || lastAgentHit == -1)
-                {
-                    agentA.AddReward( -0.01f);
-                    agentB.SetReward(0);
-                    agentB.score += 1;
-                }
-                else
-                {
-                    agentA.AddReward( -0.01f);
-                    agentB.SetReward(0);
-                    agentB.score += 1;
-
-                }
+                agentB.Score += 1;
             }
             else if (collision.gameObject.name == "floorB")
             {
-                if (lastAgentHit == 1 || lastAgentHit == -1)
-                {
-                    agentA.SetReward(0);
-                    agentB.AddReward( -0.01f);
-                    agentA.score += 1;
-                }
-                else
-                {
-                    agentA.SetReward(0);
-                    agentB.AddReward( -0.01f);
-                    agentA.score += 1;
-                }
+                agentA.Score += 1;
             }
             else if (collision.gameObject.name == "net")
             {
                 if (lastAgentHit == 0)
                 {
-                    agentA.AddReward( -0.01f);
-                    agentB.SetReward(0);
-                    agentB.score += 1;
+                    agentB.Score += 1;
                 }
                 else
                 {
-                    agentA.SetReward(0);
-                    agentB.AddReward( -0.01f);
-                    agentA.score += 1;
+                    agentA.Score += 1;
                 }
             }
             agentA.Done();
             agentB.Done();
             area.MatchReset();
+            TennisArea.AddPasses(nbPasses);
+            nbPasses = 0;
         }
 
         if (collision.gameObject.CompareTag("agent"))

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAcademy.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAcademy.cs
@@ -9,6 +9,9 @@ public class TennisAcademy : Academy
 
     public override void AcademyReset()
     {
+        Debug.Log("Learn WR: " + TennisCanvas.learnWinrate());
+        Debug.Log("Blue WR: " + TennisCanvas.blueWinrate());
+        Debug.Log("Average Passes: " + TennisCanvas.averagePasses());
     }
 
     public override void AcademyStep()

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
@@ -8,36 +8,60 @@ public class TennisAgent : Agent
 {
     [Header("Specific to Tennis")]
     public GameObject ball;
+
+    private bool IsAgentA
+    {
+        get
+        {
+            return !invertX;
+        }
+    }
     public bool invertX;
-    public int score;
+
+    public bool isLearning;
+    public string matchState = "play";
+    private int score;
+    public int Score
+    {
+        get
+        {
+            return score;
+        }
+        set
+        {
+            int scoreChange = value - score;
+            if (scoreChange == 1)
+            {
+                matchState = "win";
+                opponent.matchState = "loss";
+                TennisArea.AddResult(isLearning, IsAgentA);
+            }
+            SetReward(1f);
+            score = value;
+        }
+    }
     public GameObject myArea;
 
-    private Text textComponent;
+    private TennisAgent opponent;
+
     private Rigidbody agentRb;
     private Rigidbody ballRb;
     private float invertMult;
 
     // Looks for the scoreboard based on the name of the gameObjects.
     // Do not modify the names of the Score GameObjects
-    private const string CanvasName = "Canvas";
-    private const string ScoreBoardAName = "ScoreA";
-    private const string ScoreBoardBName = "ScoreB";
-
     public override void InitializeAgent()
     {
         agentRb = GetComponent<Rigidbody>();
         ballRb = ball.GetComponent<Rigidbody>();
-        var canvas = GameObject.Find(CanvasName);
-        GameObject scoreBoard;
-        if (invertX)
+        if (IsAgentA)
         {
-            scoreBoard = canvas.transform.Find(ScoreBoardBName).gameObject;
+            opponent = myArea.GetComponent<TennisArea>().agentB;
         }
         else
         {
-            scoreBoard = canvas.transform.Find(ScoreBoardAName).gameObject;
+            opponent = myArea.GetComponent<TennisArea>().agentA;
         }
-        textComponent = scoreBoard.GetComponent<Text>();
     }
 
     public override void CollectObservations()
@@ -51,6 +75,10 @@ public class TennisAgent : Agent
         AddVectorObs(ball.transform.position.y - myArea.transform.position.y);
         AddVectorObs(invertMult * ballRb.velocity.x);
         AddVectorObs(ballRb.velocity.y);
+
+        //Results of the match (opponent|play/win/loss)
+        SetTextObs(opponent.Id + "|" + matchState);
+        matchState = "play";
     }
 
 
@@ -58,7 +86,7 @@ public class TennisAgent : Agent
     {
         var moveX = Mathf.Clamp(vectorAction[0], -1f, 1f) * invertMult;
         var moveY = Mathf.Clamp(vectorAction[1], -1f, 1f);
-        
+
         if (moveY > 0.5 && transform.position.y - transform.parent.transform.position.y < -1.5f)
         {
             agentRb.velocity = new Vector3(agentRb.velocity.x, 7f, 0f);
@@ -66,15 +94,13 @@ public class TennisAgent : Agent
 
         agentRb.velocity = new Vector3(moveX * 30f, agentRb.velocity.y, 0f);
 
-        if (invertX && transform.position.x - transform.parent.transform.position.x < -invertMult || 
+        if (invertX && transform.position.x - transform.parent.transform.position.x < -invertMult ||
             !invertX && transform.position.x - transform.parent.transform.position.x > -invertMult)
         {
-                transform.position = new Vector3(-invertMult + transform.parent.transform.position.x, 
-                                                            transform.position.y, 
+                transform.position = new Vector3(-invertMult + transform.parent.transform.position.x,
+                                                            transform.position.y,
                                                             transform.position.z);
         }
-
-        textComponent.text = score.ToString();
     }
 
     public override void AgentReset()
@@ -83,5 +109,11 @@ public class TennisAgent : Agent
 
         transform.position = new Vector3(-invertMult * Random.Range(6f, 8f), -1.5f, 0f) + transform.parent.transform.position;
         agentRb.velocity = new Vector3(0f, 0f, 0f);
+    }
+
+    public void SetBrain(Brain brain, bool isLearning)
+    {
+        this.brain = brain;
+        this.isLearning = isLearning;
     }
 }

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisCanvas.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisCanvas.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using System.Linq;
+
+public class TennisCanvas : MonoBehaviour
+{
+
+    public Text recentBlueWinrate;
+    public Text recentLearnWinrate;
+    public Text scoreGhost;
+    public Text scoreLearn;
+
+    public static string learnWinrate(){
+        int recentLearnWins = TennisArea.last1000BrainResults.Where(result => result == 'L').Count();
+        int recentGhostWins = TennisArea.last1000BrainResults.Where(result => result == 'G').Count();
+        float winrate = recentLearnWins / (float)(recentLearnWins + recentGhostWins);
+        return "Learn Winrate:" + winrate.ToString("F3");
+    }
+
+    public static string blueWinrate(){
+        int recentAWins = TennisArea.last1000AgentResults.Where(result => result == 'A').Count();
+        int recentBWins = TennisArea.last1000AgentResults.Where(result => result == 'B').Count();
+        float winrate = recentAWins / (float)(recentAWins + recentBWins);
+        return "Blue Winrate:" + winrate.ToString("F3");
+    }
+
+    public static double averagePasses(){
+        if (TennisArea.last1000Passes.Count == 0)
+            return -1;
+        return TennisArea.last1000Passes.Average();
+    }
+
+    void Update()
+    {
+        scoreGhost.text = "Ghost:" + TennisArea.ghostScore;
+        scoreLearn.text = "Learn:" + TennisArea.learningScore;
+
+        recentLearnWinrate.text = learnWinrate();
+        recentBlueWinrate.text = blueWinrate();
+    }
+}

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisCanvas.cs.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scripts/TennisCanvas.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18c3299d1cb39464c89a910bb0278ce4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -310,6 +310,11 @@ namespace MLAgents
         /// Unique identifier each agent receives at initialization. It is used
         /// to separate between different agents in the environment.
         int id;
+        public int Id{
+            get{
+                return id;
+            }
+        }
 
         /// Keeps track of the actions that are masked at each step.
         private ActionMasker actionMasker;

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -18,6 +18,7 @@ default:
     summary_freq: 1000
     use_recurrent: false
     use_curiosity: false
+    use_elo_rating: false
     curiosity_strength: 0.01
     curiosity_enc_size: 128
 
@@ -143,6 +144,14 @@ VisualPyramidsLearning:
 TennisLearning:
     normalize: true
     max_steps: 2e5
+    use_elo_rating: true
+
+TennisGhost:
+    trainer: ghost
+    ghost_master_brain: TennisLearning
+    ghost_num_policies: 3
+    ghost_recent_ckpts_threshold: 10
+    ghost_prob_sample_only_recent: 0.5
 
 CrawlerStaticLearning:
     normalize: true

--- a/ml-agents-envs/mlagents/envs/brain.py
+++ b/ml-agents-envs/mlagents/envs/brain.py
@@ -17,6 +17,7 @@ class BrainInfo:
         memory=None,
         reward=None,
         agents=None,
+        agent_ids=None,
         local_done=None,
         vector_action=None,
         text_action=None,
@@ -35,6 +36,7 @@ class BrainInfo:
         self.local_done = local_done
         self.max_reached = max_reached
         self.agents = agents
+        self.agent_ids = agent_ids
         self.previous_vector_actions = vector_action
         self.previous_text_actions = text_action
         self.action_masks = action_mask
@@ -164,6 +166,7 @@ class BrainInfo:
             memory=memory,
             reward=[x.reward if not np.isnan(x.reward) else 0 for x in agent_info_list],
             agents=[x.id for x in agent_info_list],
+            agent_ids=[x.id for x in agent_info_list],
             local_done=[x.done for x in agent_info_list],
             vector_action=np.array([x.stored_vector_actions for x in agent_info_list]),
             text_action=[list(x.stored_text_actions) for x in agent_info_list],
@@ -171,6 +174,21 @@ class BrainInfo:
             custom_observations=[x.custom_observation for x in agent_info_list],
             action_mask=mask_actions,
         )
+        return brain_info
+
+    def get_agent_brain_info(self, agent):
+        agent_idx = self.agent_ids.index(agent)
+        brain_info = BrainInfo(None, None, None)
+        for key in self.__dict__:
+            array_or_list = self.__dict__[key]
+            if type(array_or_list) is np.ndarray:
+                brain_info.__dict__[key] = np.array([]) if array_or_list is None or array_or_list.size == 0 \
+                    else np.array([array_or_list[agent_idx]])
+            elif type(array_or_list) is list:
+                brain_info.__dict__[key] = [] if not array_or_list else [array_or_list[agent_idx]]
+            else:
+                raise Exception('The get_agent_brain_info function can only handle list and numpy arrays '
+                                'but the type of {0} was {1}'.format(key, type(array_or_list)))
         return brain_info
 
 

--- a/ml-agents-envs/mlagents/envs/subprocess_environment.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_environment.py
@@ -208,7 +208,7 @@ class SubprocessUnityEnvironment(BaseUnityEnvironment):
             for brain_name, brain_info in all_brain_info.items():
                 for i in range(len(brain_info.agents)):
                     brain_info.agents[i] = (
-                        str(env_step.worker_id) + "-" + str(brain_info.agents[i])
+                        str(env_step.worker_id) + "-" + str(brain_info.agent_ids[i])
                     )
                 if accumulated_brain_info:
                     accumulated_brain_info[brain_name].merge(brain_info)

--- a/ml-agents/mlagents/trainers/action_info.py
+++ b/ml-agents/mlagents/trainers/action_info.py
@@ -1,4 +1,5 @@
-from typing import NamedTuple, Any, Dict, Optional
+import numpy as np
+from typing import NamedTuple, Any, Dict, Optional, List
 
 
 class ActionInfo(NamedTuple):
@@ -7,3 +8,23 @@ class ActionInfo(NamedTuple):
     text: Any
     value: Any
     outputs: Optional[Dict[str, Any]]
+
+
+def combine(action_infos: List[ActionInfo]):
+    run_outs = [ai.outputs for ai in action_infos]
+
+    run_out = {key: np.array([r[key][0] for r in run_outs]) for key in run_outs[0]
+               if type(run_outs[0][key]) is np.ndarray}
+
+    other_keys = [key for key in run_outs[0] if type(run_outs[0][key]) is not np.ndarray]
+
+    for key in other_keys:
+        run_out[key] = run_outs[0][key]
+
+    return ActionInfo(
+        action=run_out.get('action'),
+        memory=run_out.get('memory_out'),
+        text=None,
+        value=run_out.get('value'),
+        outputs=run_out
+    )

--- a/ml-agents/mlagents/trainers/bc/policy.py
+++ b/ml-agents/mlagents/trainers/bc/policy.py
@@ -31,7 +31,7 @@ class BCPolicy(Policy):
                 )
 
         if load:
-            self._load_graph()
+            self.load_graph()
         else:
             self._initialize_graph()
 

--- a/ml-agents/mlagents/trainers/elo_rating.py
+++ b/ml-agents/mlagents/trainers/elo_rating.py
@@ -1,0 +1,76 @@
+from mlagents.envs import AllBrainInfo, Dict
+from mlagents.trainers.trainer import Trainer
+
+K = 1 # Constant for rating changes, higher is less stable but converges faster
+
+
+# Derived from https://metinmediamath.wordpress.com/2013/11/27/how-to-calculate-the-elo-rating-including-example/
+def compute_elo_rating_changes(rating1, rating2, result):
+    r1 = pow(10, rating1 / 400)
+    r2 = pow(10, rating2 / 400)
+
+    sum = r1 + r2
+    e1 = r1 / sum
+
+    s1 = 1 if result == "win" else 0
+
+    change = K * (s1 - e1)
+
+    return change
+
+
+class EloTracker(object):
+
+    def __init__(self, run_id):
+        self.run_id = run_id
+        self.previous_agent_brains = {}
+
+    def update_elo_ratings(self, info: AllBrainInfo, trainers: Dict[str, Trainer]):
+        agent_policies = {}
+        should_update_rating = {}
+        processed_agents = []
+        for brain_name, brain_info in info.items():
+            for agent in brain_info.agent_ids:
+                """
+                The match result we get at Frame F(n) is the result of the match played during the previous frames F(n-1), F(n-2), ...
+                The brain of agents could have changed between F(n) and F(n-1) 
+                    and we want to make sure to assign the victory to the brain that the winning agent was using during the match.
+                So we assign the match results we got at F(n) to the brains that the agents had at F(n-1)
+                """
+                if agent in self.previous_agent_brains:
+                    trainer = trainers[self.previous_agent_brains[agent]]
+                    if hasattr(trainer, 'agent_policies'):
+                        agent_policies[agent] = trainer.agent_policies[agent]
+                    else:
+                        agent_policies[agent] = trainer.policy
+                    should_update_rating[agent] = trainer.should_update_elo_rating()
+                else:
+                    # If the agent didn't exist on the last frame he can't have been part of a match so we ignore him.
+                    processed_agents.append(agent)
+                self.previous_agent_brains[agent] = brain_name
+
+        for brain_name, brain_info in info.items():
+            for idx, agent in enumerate(brain_info.agent_ids):
+                if agent in processed_agents:
+                    continue
+
+                text = brain_info.text_observations[idx]
+                split = text.split('|')
+
+                if len(split) == 2:
+                    opponent = int(split[0])
+                    result = split[1]
+
+                    if result != "play":
+                        agent_rating = agent_policies[agent].get_elo_rating()
+                        opponent_rating = agent_policies[opponent].get_elo_rating()
+                        change = compute_elo_rating_changes(agent_rating, opponent_rating, result)
+
+                        if should_update_rating[agent]:
+                            agent_policies[agent].increment_elo_rating(change)
+                        if should_update_rating[opponent]:
+                            agent_policies[opponent].increment_elo_rating(-change)
+
+                        processed_agents.append(agent)
+                        processed_agents.append(opponent)
+                        

--- a/ml-agents/mlagents/trainers/ghost/__init__.py
+++ b/ml-agents/mlagents/trainers/ghost/__init__.py
@@ -1,0 +1,1 @@
+from .trainer import *

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 from typing import List
 
-from mlagents.envs import BrainInfo
+from mlagents.envs import AllBrainInfo, BrainInfo
 from mlagents.trainers.ppo.policy import PPOPolicy
 from mlagents.trainers.ppo.trainer import PPOTrainer
 from mlagents.trainers.trainer import UnityTrainerException
@@ -50,6 +50,24 @@ class GhostTrainer(PPOTrainer):
         :return: True if not ghost else False
         """
         return False
+
+    
+    def add_experiences(
+        self,
+        curr_all_info: AllBrainInfo,
+        next_all_info: AllBrainInfo,
+        take_action_outputs,
+    ):
+        """
+        No need to collect experiences since we don't update the ghost brain
+        """
+        pass
+
+    def process_experiences(self, current_info: AllBrainInfo, new_info: AllBrainInfo):
+        """
+        No need to collect experiences since we don't update the ghost brain
+        """
+        pass
 
     def get_elo_rating(self):
         return np.mean([policy.get_elo_rating() for policy in self.agent_policies.values()])

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -1,0 +1,116 @@
+# # Unity ML-Agents Toolkit
+# ## ML-Agent Learning (Ghost)
+
+import logging
+import random
+
+import numpy as np
+import tensorflow as tf
+from typing import List
+
+from mlagents.envs import BrainInfo
+from mlagents.trainers.ppo.policy import PPOPolicy
+from mlagents.trainers.ppo.trainer import PPOTrainer
+from mlagents.trainers.trainer import UnityTrainerException
+from mlagents.trainers import ActionInfo, combine
+
+logger = logging.getLogger("mlagents.trainers")
+
+
+class GhostTrainer(PPOTrainer):
+
+    def __init__(self, brain, reward_buff_cap, trainer_parameters, seed, run_id):
+        """
+        Responsible for loading models saved by his master trainer and assigning different policies to its agents .
+        :param trainer_parameters: The parameters for the trainer (dictionary). Those are based on his master trainer parameters.
+        :param seed: The seed the model will be initialized with
+        :param run_id: The The identifier of the current run
+        """
+        super(GhostTrainer, self).__init__(brain, reward_buff_cap,
+                                           trainer_parameters, False, False, seed, run_id)
+        self.agent_policies = {}
+        self.ghost_recent_ckpts_threshold = trainer_parameters['ghost_recent_ckpts_threshold']
+        self.ghost_prob_sample_only_recent = trainer_parameters['ghost_prob_sample_only_recent']
+        self.policies = []
+        for _ in range(trainer_parameters['ghost_num_policies']):
+            self.policies.append(
+                PPOPolicy(
+                    seed,
+                    brain,
+                    trainer_parameters,
+                    self.is_training,
+                    False
+                )
+            )
+
+    @staticmethod
+    def should_update_elo_rating():
+        """
+        Should the elo rating be updated
+        :return: True if not ghost else False
+        """
+        return False
+
+    def get_elo_rating(self):
+        return np.mean([policy.get_elo_rating() for policy in self.agent_policies.values()])
+
+    def get_action(self, curr_info: BrainInfo) -> ActionInfo:
+        """
+        Get an action using this trainer's current policy.
+        :param curr_info: Current BrainInfo.
+        :return: The ActionInfo given by the policy given the BrainInfo.
+        """
+        self.trainer_metrics.start_experience_collection_timer()
+        if len(curr_info.agents) == 0:
+            return self.policy.get_action(curr_info)
+
+        action_infos: List[ActionInfo] = [None] * len(curr_info.agents)
+        for idx, agent in enumerate(curr_info.agent_ids):
+            if agent not in self.agent_policies:
+                self.agent_policies[agent] = random.choice(self.policies)
+
+            agent_brain_info = curr_info.get_agent_brain_info(agent)
+            action_infos[idx] = self.agent_policies[agent].get_action(agent_brain_info)
+
+        result = combine(action_infos)
+        self.trainer_metrics.end_experience_collection_timer()
+        return result
+
+    def is_ready_update(self):
+        """
+        Ghost trainers are never updating
+        """
+        return False
+
+    def update_policy(self):
+        """
+        Ghost trainers are never updating
+        """
+        raise UnityTrainerException("The ghost trainer's policy shouldn't get updated.")
+
+    def save_model(self):
+        """
+        Don't save the model for ghost trainers
+        """
+        pass
+
+    def end_episode(self):
+        """
+        Get called when the academy resets.
+        Loads a random saved model for each policy
+        """
+        # Model path is the same as the master trainer's model path
+        ckpt_state = tf.train.get_checkpoint_state(self.policy.model_path)
+        if ckpt_state:
+            all_ckpts = tf.train.get_checkpoint_state(self.policy.model_path).all_model_checkpoint_paths
+
+            if all_ckpts:
+                for policy in self.policies:
+                    policy_used_ckpts = all_ckpts
+
+                    # There is a 1-p_load_from_all_checkpoints probability that we sample the policy only from the last load_from_last_N_checkpoints policies
+                    if random.random() > self.ghost_prob_sample_only_recent:
+                        policy_used_ckpts = policy_used_ckpts[-self.ghost_recent_ckpts_threshold:]
+
+                    checkpoint_path = random.sample(policy_used_ckpts, 1)[0]
+                    policy.load_graph(checkpoint_path)

--- a/ml-agents/mlagents/trainers/policy.py
+++ b/ml-agents/mlagents/trainers/policy.py
@@ -82,7 +82,8 @@ class Policy(object):
 
     def load_graph(self, checkpoint_path=None):
         with self.graph.as_default():
-            self.saver = tf.train.Saver(max_to_keep=self.keep_checkpoints)
+            if not self.saver:
+                self.saver = tf.train.Saver(max_to_keep=self.keep_checkpoints)
             logger.info("Loading Model for brain {}".format(self.brain.brain_name))
             if checkpoint_path is None:
                 ckpt = tf.train.get_checkpoint_state(self.model_path)

--- a/ml-agents/mlagents/trainers/policy.py
+++ b/ml-agents/mlagents/trainers/policy.py
@@ -80,18 +80,20 @@ class Policy(object):
             init = tf.global_variables_initializer()
             self.sess.run(init)
 
-    def _load_graph(self):
+    def load_graph(self, checkpoint_path=None):
         with self.graph.as_default():
             self.saver = tf.train.Saver(max_to_keep=self.keep_checkpoints)
             logger.info("Loading Model for brain {}".format(self.brain.brain_name))
-            ckpt = tf.train.get_checkpoint_state(self.model_path)
-            if ckpt is None:
-                logger.info(
-                    "The model {0} could not be found. Make "
-                    "sure you specified the right "
-                    "--run-id".format(self.model_path)
-                )
-            self.saver.restore(self.sess, ckpt.model_checkpoint_path)
+            if checkpoint_path is None:
+                ckpt = tf.train.get_checkpoint_state(self.model_path)
+                if ckpt is None:
+                    logger.info(
+                        "The model {0} could not be found. Make "
+                        "sure you specified the right "
+                        "--run-id".format(self.model_path)
+                    )
+                checkpoint_path = ckpt.checkpoint_path
+            self.saver.restore(self.sess, checkpoint_path)
 
     def evaluate(self, brain_info: BrainInfo):
         """

--- a/ml-agents/mlagents/trainers/policy.py
+++ b/ml-agents/mlagents/trainers/policy.py
@@ -92,7 +92,7 @@ class Policy(object):
                         "sure you specified the right "
                         "--run-id".format(self.model_path)
                     )
-                checkpoint_path = ckpt.checkpoint_path
+                checkpoint_path = ckpt.model_checkpoint_path
             self.saver.restore(self.sess, checkpoint_path)
 
     def evaluate(self, brain_info: BrainInfo):

--- a/ml-agents/mlagents/trainers/ppo/models.py
+++ b/ml-agents/mlagents/trainers/ppo/models.py
@@ -42,6 +42,9 @@ class PPOModel(LearningModel):
         """
         LearningModel.__init__(self, m_size, normalize, use_recurrent, brain, seed)
         self.use_curiosity = use_curiosity
+
+        self.elo_rating, self.rating_change, self.increment_elo_rating = self.create_elo_rating()
+
         if num_layers < 1:
             num_layers = 1
         self.last_reward, self.new_reward, self.update_reward = (
@@ -68,6 +71,14 @@ class PPOModel(LearningModel):
             lr,
             max_step,
         )
+
+    @staticmethod
+    def create_elo_rating():
+        elo_rating = tf.Variable(1200, name="elo_rating", trainable=False, dtype=tf.float32)
+        rating_change = tf.placeholder(shape=[], name="rating_change", dtype=tf.float32)
+
+        increment_elo_rating = tf.assign(elo_rating, tf.add(elo_rating, rating_change))
+        return elo_rating, rating_change, increment_elo_rating
 
     @staticmethod
     def create_reward_encoder():

--- a/ml-agents/mlagents/trainers/ppo/policy.py
+++ b/ml-agents/mlagents/trainers/ppo/policy.py
@@ -40,7 +40,7 @@ class PPOPolicy(Policy):
             )
 
         if load:
-            self._load_graph()
+            self.load_graph()
         else:
             self._initialize_graph()
 
@@ -249,3 +249,17 @@ class PPOPolicy(Policy):
         self.sess.run(
             self.model.update_reward, feed_dict={self.model.new_reward: new_reward}
         )
+
+    def get_elo_rating(self):
+        """
+        Gets current elo rating.
+        :return: current elo rating.
+        """
+        elo_rating = self.sess.run(self.model.elo_rating)
+        return elo_rating
+
+    def increment_elo_rating(self, rating_change):
+        """
+        Increments elo rating.
+        """
+        self.sess.run(self.model.increment_elo_rating, feed_dict={self.model.rating_change: rating_change})

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -71,6 +71,9 @@ class PPOTrainer(Trainer):
             "Losses/Policy Loss": [],
             "Policy/Learning Rate": [],
         }
+
+        if self.use_elo_rating:
+            stats['Policy/Elo Rating'] = []
         if self.use_curiosity:
             stats["Losses/Forward Loss"] = []
             stats["Losses/Inverse Loss"] = []
@@ -126,6 +129,14 @@ class PPOTrainer(Trainer):
         :return: the reward buffer.
         """
         return self._reward_buffer
+
+    @staticmethod
+    def should_update_elo_rating():
+        """
+        Should the elo rating be updated
+        :return: True if not ghost else False
+        """
+        return True
 
     def increment_step_and_update_last_reward(self):
         """
@@ -222,6 +233,8 @@ class PPOTrainer(Trainer):
             self.stats["Policy/Learning Rate"].append(
                 take_action_outputs["learning_rate"]
             )
+        if self.use_elo_rating:
+            self.stats['Policy/Elo Rating'].append(self.get_elo_rating())
 
         curr_info = curr_all_info[self.brain_name]
         next_info = next_all_info[self.brain_name]

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -38,6 +38,7 @@ class Trainer(object):
         if not os.path.exists(self.summary_path):
             os.makedirs(self.summary_path)
         self.cumulative_returns_since_policy_update = []
+        self.use_elo_rating = bool(trainer_parameters['use_elo_rating'])
         self.is_training = training
         self.stats = {}
         self.trainer_metrics = TrainerMetrics(
@@ -198,13 +199,14 @@ class Trainer(object):
                     "Time Elapsed: {:0.3f} s "
                     "Mean "
                     "Reward: {"
-                    ":0.3f}. Std of Reward: {:0.3f}. {}".format(
+                    ":0.3f}. Std of Reward: {:0.3f}. {} {}".format(
                         self.run_id,
                         self.brain_name,
                         min(self.get_step, self.get_max_steps),
                         delta_train_start,
                         mean_reward,
                         np.std(self.stats["Environment/Cumulative Reward"]),
+                        'Elo Rating: {:0.1f}'.format(self.get_elo_rating()) if self.use_elo_rating else '',
                         is_training,
                     )
                 )
@@ -246,3 +248,6 @@ class Trainer(object):
                 "Cannot write text summary for Tensorboard. Tensorflow version must be r1.2 or above."
             )
             pass
+
+    def get_elo_rating(self):
+        return self.policy.get_elo_rating()


### PR DESCRIPTION
See #1070 for more context around this pull-request.

### Ghost trainer

This pull request adds a new type of trainer, the ghost, which allows an agent to play against past versions of himself.
The ghost manages several policies, each with a different past version of the agent.
The ghost brain doesn't update his weights, he is assigned to a master ppo trainer and use the master trainer's past checkpoints. On academy resets, the ghost randomly samples the ppo trainer's checkpoints and load them into its policies.

Ghost configuration in trainer_config.yaml:

TennisLearning:
    normalize: true
    max_steps: 2e5
    use_elo_rating: true

TennisGhost:
    trainer: ghost
    ghost_master_brain: TennisLearning
    ghost_num_policies: 3
    ghost_prob_sample_only_recent: 0.6
    ghost_recent_ckpts_threshold: 10
    

- ghost_master_brain: The brain from which the ghost loads past checkpoints
- ghost_num_policies: Number of policies that the ghost manages at the same time

I also wanted to give some control around the sampling of checkpoints so I added those parameters:

- ghost_prob_sample_only_recent: Probability that the ghost will only sample recent checkpoints instead of the whole history. 0.6 means 60% chance to sample recent and 40% to sample the whole history.
- ghost_recent_ckpts_threshold: Number of checkpoints that are considered recent.

The unity side can decide which agent is using the ghost brain and which agent is using the learning brain. Changing those assignments is also supported

### Elo rating:

When using self-play, measuring rewards is not very helpful because better agents might be good at preventing each other from getting rewards.
One way to measure progression then is elo rating. 
Each agent has an elo rating and agents will play matches against each other. The winner of the match gains rating and the loser loses rating, the amount they win/lose depends on their respective ratings before the match.

Elo rating is stored in the models, allowing each policy to know its own elo rating when loading a graph.

The match results are sent by agents in the CollectObservations method in this form
"opponent_agent_id|match_result".
So for example: "1234|win", "1234|loss" or "4321|playing".

### Tennis Environment
What I just described was implemented on the python side and I also modified the Tennis Example to use self-play.
I added the TennisGhost, some winrate metrics to help me debug and I changed the reward settings to encourage winning matches instead of encouraging as many passes as possible.
So you can test this on the Tennis Environment. The results are a bit noisy, but it usually gets around 1240-1270 elo rating at 25000 steps with `trainer_config.yaml` and  `--save-freq=5000`.

There are a few things I am not sure about:

- At the moment, the match results are passed through text observations. This would make it hard for users to use text observations while using self-play. Should I add a field to the agent_info protobuf message instead?
- I built self-play to work with two agents but the match results will need a different format in team vs team format. (Maybe add a match ID)
- I modified the Tennis Environment to add self-play and put some additional metrics there to help me debug it. Not sure if it should stay like that or if there should be a self-play and non-self-play version.

So this pull-request might not be complete enough yet, but I felt like I should ask for feedback to make sure that this is something that should be in ML agents before proceeding.
If anything doesn't make sense feel free to ask me :)