### PR TITLE
A couple fixes for recording demonstrations

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/DemonstrationTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/DemonstrationTests.cs
@@ -14,9 +14,9 @@ namespace MLAgents.Tests
         [Test]
         public void TestSanitization()
         {
-            const string dirtyString = "abc123&!@";
+            const string dirtyString = "abc1234567&!@";
             const string knownCleanString = "abc123";
-            var cleanString = DemonstrationRecorder.SanitizeName(dirtyString);
+            var cleanString = DemonstrationRecorder.SanitizeName(dirtyString, 6);
             Assert.AreNotEqual(dirtyString, cleanString);
             Assert.AreEqual(cleanString, knownCleanString);
         }

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -133,6 +133,7 @@ namespace MLAgents
     public struct AgentAction
     {
         public float[] vectorActions;
+        public float[] lastActions;
         public string textActions;
         public List<float> memories;
         public float value;
@@ -531,6 +532,7 @@ namespace MLAgents
 
             BrainParameters param = brain.brainParameters;
             actionMasker = new ActionMasker(param);
+            action.lastActions = action.vectorActions;
             if (param.vectorActionSpaceType == SpaceType.continuous)
             {
                 action.vectorActions = new float[param.vectorActionSize[0]];
@@ -584,7 +586,15 @@ namespace MLAgents
             }
 
             info.memories = action.memories;
-            info.storedVectorActions = action.vectorActions;
+            if(done)
+            {
+                info.storedVectorActions = action.lastActions;
+            }
+            else
+            {
+                info.storedVectorActions = action.vectorActions;
+            }
+            
             info.storedTextActions = action.textActions;
             info.vectorObservation.Clear();
             actionMasker.ResetMask();

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -532,6 +532,8 @@ namespace MLAgents
 
             BrainParameters param = brain.brainParameters;
             actionMasker = new ActionMasker(param);
+            // Store the last action taken, so that when we call SendInfoToBrain after reset
+            // it will record the last action and not the newly zero'ed action.vectorActions.
             action.lastActions = action.vectorActions;
             if (param.vectorActionSpaceType == SpaceType.continuous)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -596,7 +596,7 @@ namespace MLAgents
             {
                 info.storedVectorActions = action.vectorActions;
             }
-
+            
             info.storedTextActions = action.textActions;
             info.vectorObservation.Clear();
             actionMasker.ResetMask();
@@ -1023,8 +1023,6 @@ namespace MLAgents
                             // as it is done
                             _AgentReset();
                             hasAlreadyReset = true;
-                            requestDecision = false;
-                            requestAction = false;
                         }
                     }
                     else if (requestDecision)

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -594,7 +594,7 @@ namespace MLAgents
             {
                 info.storedVectorActions = action.vectorActions;
             }
-            
+
             info.storedTextActions = action.textActions;
             info.vectorObservation.Clear();
             actionMasker.ResetMask();
@@ -1021,6 +1021,8 @@ namespace MLAgents
                             // as it is done
                             _AgentReset();
                             hasAlreadyReset = true;
+                            requestDecision = false;
+                            requestAction = false;
                         }
                     }
                     else if (requestDecision)

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -36,6 +36,7 @@ namespace MLAgents
 
         /// <summary>
         /// Removes all characters except alphanumerics from demonstration name.
+        /// Shorten name if it is too long for the metadata header.
         /// </summary>
         public static string SanitizeName(string demoName, int maxNameLength = 16)
         {

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -36,7 +36,7 @@ namespace MLAgents
 
         /// <summary>
         /// Removes all characters except alphanumerics from demonstration name.
-        /// Shorten name if it is too long for the metadata header.
+        /// Shorten name if it is longer than the maxNameLength.
         /// </summary>
         public static string SanitizeName(string demoName, int maxNameLength)
         {

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -14,7 +14,7 @@ namespace MLAgents
         private Agent recordingAgent;
         private string filePath;
         private DemonstrationStore demoStore;
-        private int maxNameLength = 16;
+        public const int MAX_NAME_LENGTH = 16;
 
         /// <summary>
         /// Initializes Demonstration store.
@@ -25,7 +25,7 @@ namespace MLAgents
             {
                 recordingAgent = GetComponent<Agent>();
                 demoStore = new DemonstrationStore();
-                demonstrationName = SanitizeName(demonstrationName, maxNameLength);
+                demonstrationName = SanitizeName(demonstrationName, MAX_NAME_LENGTH);
                 demoStore.Initialize(
                     demonstrationName, 
                     recordingAgent.brain.brainParameters, 
@@ -38,7 +38,7 @@ namespace MLAgents
         /// Removes all characters except alphanumerics from demonstration name.
         /// Shorten name if it is too long for the metadata header.
         /// </summary>
-        public static string SanitizeName(string demoName, int maxNameLength = 16)
+        public static string SanitizeName(string demoName, int maxNameLength)
         {
             var rgx = new Regex("[^a-zA-Z0-9 -]");
             demoName = rgx.Replace(demoName, "");

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -41,7 +41,6 @@ namespace MLAgents
         {
             var rgx = new Regex("[^a-zA-Z0-9 -]");
             demoName = rgx.Replace(demoName, "");
-
             // If the string is too long, it will overflow the metadata. 
             if (demoName.Length > maxNameLength)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -14,6 +14,7 @@ namespace MLAgents
         private Agent recordingAgent;
         private string filePath;
         private DemonstrationStore demoStore;
+        private int maxNameLength = 16;
 
         /// <summary>
         /// Initializes Demonstration store.
@@ -24,7 +25,7 @@ namespace MLAgents
             {
                 recordingAgent = GetComponent<Agent>();
                 demoStore = new DemonstrationStore();
-                demonstrationName = SanitizeName(demonstrationName);
+                demonstrationName = SanitizeName(demonstrationName, maxNameLength);
                 demoStore.Initialize(
                     demonstrationName, 
                     recordingAgent.brain.brainParameters, 
@@ -36,10 +37,16 @@ namespace MLAgents
         /// <summary>
         /// Removes all characters except alphanumerics from demonstration name.
         /// </summary>
-        public static string SanitizeName(string demoName)
+        public static string SanitizeName(string demoName, int maxNameLength = 16)
         {
             var rgx = new Regex("[^a-zA-Z0-9 -]");
             demoName = rgx.Replace(demoName, "");
+
+            // If the string is too long, it will overflow the metadata. 
+            if (demoName.Length > maxNameLength)
+            {
+                demoName = demoName.Substring(0, maxNameLength);
+            }
             return demoName;
         }
 


### PR DESCRIPTION
- During sanitation of demo filename, cut the string if it is too long. A long name may exceed the 32-bytes reserved for metadata, and cause corruption.
- Store lastActions[] in Agent.cs so that we can write it to the demonstration on Done(). Previously, the last action recorded was always 0. 
- Fix for on demand actions to prevent the Agent from taking an additional action after Done() is called. This is problematic for some games where the reset causes the scene to be in a state where taking an action causes undesirable behavior. 