### PR TITLE
Allow multiple visual observations

### DIFF
--- a/gym-unity/README.md
+++ b/gym-unity/README.md
@@ -53,16 +53,22 @@ env = UnityEnv(environment_filename, worker_id, use_visual, uint8_visual, multia
 *  `flatten_branched` will flatten a branched discrete action space into a Gym Discrete. 
    Otherwise, it will be converted into a MultiDiscrete. Defaults to `False`.
 
+*  `allow_multiple_visual_obs` will return a list of observation instead of only
+   one if disabled. Defaults to `False`.
+
 The returned environment `env` will function as a gym.
 
 For more on using the gym interface, see our
 [Jupyter Notebook tutorial](../notebooks/getting-started-gym.ipynb).
 
-## Limitation
+## Limitations
 
 * It is only possible to use an environment with a single Brain.
-* By default the first visual observation is provided as the `observation`, if
-  present. Otherwise vector observations are provided.
+* By default, the first visual observation is provided as the `observation`, if 
+  present. Otherwise, vector observations are provided. You can receive all visual
+  observations by using the `allow_multiple_visual_obs=True` option in the gym
+  parameters. If set to `True`, you will receive a list of `observation` instead
+  of only the first one.
 * All `BrainInfo` output from the environment can still be accessed from the
   `info` provided by `env.step(action)`.
 * Stacked vector observations are not supported.

--- a/gym-unity/gym_unity/envs/unity_env.py
+++ b/gym-unity/gym_unity/envs/unity_env.py
@@ -34,6 +34,7 @@ class UnityEnv(gym.Env):
         multiagent=False,
         flatten_branched=False,
         no_graphics=False,
+        allow_multiple_visual_obs=False,
     ):
         """
         Environment initialization
@@ -44,6 +45,7 @@ class UnityEnv(gym.Env):
         :param multiagent: Whether to run in multi-agent mode (lists of obs, reward, done).
         :param flatten_branched: If True, turn branched discrete action spaces into a Discrete space rather than MultiDiscrete.
         :param no_graphics: Whether to run the Unity simulator in no-graphics mode
+        :param allow_multiple_visual_obs: If True, return a list of visual observations instead of only one.
         """
         self._env = UnityEnvironment(
             environment_filename, worker_id, no_graphics=no_graphics
@@ -57,6 +59,7 @@ class UnityEnv(gym.Env):
         self.game_over = (
             False
         )  # Hidden flag used by Atari environments to determine if the game is over
+        self._allow_multiple_visual_obs = allow_multiple_visual_obs
 
         # Check brain configuration
         if len(self._env.brains) != 1:
@@ -87,10 +90,11 @@ class UnityEnv(gym.Env):
         else:
             self.uint8_visual = uint8_visual
 
-        if brain.number_visual_observations > 1:
+        if brain.number_visual_observations > 1 and not self._allow_multiple_visual_obs:
             logger.warning(
                 "The environment contains more than one visual observation. "
-                "Please note that only the first will be provided in the observation."
+                "You must define allow_multiple_visual_obs=True to received them all. "
+                "Otherwise, please note that only the first will be provided in the observation."
             )
 
         if brain.num_stacked_vector_observations != 1:
@@ -216,7 +220,15 @@ class UnityEnv(gym.Env):
             visual_obs = info.visual_observations
             if isinstance(visual_obs, list):
                 visual_obs = np.array(visual_obs)
-            self.visual_obs = self._preprocess_single(visual_obs[0][0, :, :, :])
+
+            if self._allow_multiple_visual_obs:
+                visual_obs_list = []
+                for obs in visual_obs:
+                    visual_obs_list.append(self._preprocess_single(obs[0, :, :, :]))
+                self.visual_obs = visual_obs_list
+            else:
+                self.visual_obs = self._preprocess_single(visual_obs[0][0, :, :, :])
+           
             default_observation = self.visual_obs
         else:
             default_observation = info.vector_observations[0, :]


### PR DESCRIPTION
Our objective is to be able to receive multiple visual observations when needed without breaking existing solutions.

When you initialize the UnityEnv class with the `allow_multiple_visual_obs` param set to **True**, the `observation` output will be a list instead of a single observation.

## Examples:

### With multiples visual observations:

    import matplotlib.pyplot as plt
    from gym_unity.envs import UnityEnv
    env_name = "path_to_your_unity_project_output"
    env = UnityEnv(env_name, worker_id=0, use_visual=True, allow_multiple_visual_obs=True)
    observation, reward, done, info = env.step(env.action_space.sample())
    plt.imshow(observation[0][:,:,:])
    env.close()

### Single observation:

    import matplotlib.pyplot as plt
    from gym_unity.envs import UnityEnv
    env_name = "path_to_your_unity_project_output"
    env = UnityEnv(env_name, worker_id=0, use_visual=True, allow_multiple_visual_obs=False) # You will have the same result by not providing the last parameter
    observation, reward, done, info = env.step(env.action_space.sample())
    plt.imshow(observation[:,:,:])
    env.close()

**Note:**

If your Unity project returns more than one visual observation and you don't use the new `allow` parameter, you will receive this updated message:

`WARNING:gym_unity: The environment contains more than one visual observation. You must define allow_multiple_visual_obs=True to received them all. Otherwise, please note that only the first will be provided in the observation.`