### PR TITLE
Fix failure on Academy Done() with parallel envs

### DIFF
--- a/ml-agents-envs/mlagents/envs/subprocess_environment.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_environment.py
@@ -62,7 +62,10 @@ def worker(parent_conn: Connection, pickled_env_factory: str, worker_id: int):
             cmd: EnvironmentCommand = parent_conn.recv()
             if cmd.name == "step":
                 vector_action, memory, text_action, value = cmd.payload
-                all_brain_info = env.step(vector_action, memory, text_action, value)
+                if env.global_done:
+                    all_brain_info = env.reset()
+                else:
+                    all_brain_info = env.step(vector_action, memory, text_action, value)
                 _send_response("step", all_brain_info)
             elif cmd.name == "external_brains":
                 _send_response("external_brains", env.external_brains)

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -394,30 +394,6 @@ def trainer_controller_with_take_step_mocks():
     return tc, trainer_mock
 
 
-def test_take_step_resets_env_on_global_done():
-    tc, trainer_mock = trainer_controller_with_take_step_mocks()
-
-    brain_info_mock = MagicMock()
-    trainer_mock.add_experiences = MagicMock()
-    trainer_mock.process_experiences = MagicMock()
-    trainer_mock.update_policy = MagicMock()
-    trainer_mock.write_summary = MagicMock()
-    trainer_mock.trainer.increment_step_and_update_last_reward = MagicMock()
-    env_mock = MagicMock()
-    step_data_mock_out = MagicMock()
-    env_mock.step = MagicMock(return_value=step_data_mock_out)
-    env_mock.close = MagicMock()
-    env_mock.reset = MagicMock(return_value=brain_info_mock)
-    env_mock.global_done = True
-
-    trainer_mock.get_action = MagicMock(
-        return_value=ActionInfo(None, None, None, None, None)
-    )
-
-    tc.take_step(env_mock, brain_info_mock)
-    env_mock.reset.assert_called_once()
-
-
 def test_take_step_adds_experiences_to_trainer_and_trains():
     tc, trainer_mock = trainer_controller_with_take_step_mocks()
 

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -286,10 +286,6 @@ class TrainerController(object):
             for brain_name, changed in lessons_incremented.items():
                 if changed:
                     self.trainers[brain_name].reward_buffer.clear()
-        elif env.global_done:
-            curr_info = self._reset_env(env)
-            for brain_name, trainer in self.trainers.items():
-                trainer.end_episode()
 
         # Decide and take an action
         take_action_vector = {}


### PR DESCRIPTION
When using parallel SubprocessUnityEnvironment instances along
with Academy Done(), a new step might be taken when reset should
have been called because some environments may have been done while
others were not (making "global done" less useful).

This change manages the reset on `global_done` at the level of the
environment worker, and removes the global reset from
TrainerController.