### PR TITLE
[Documentation] Clarify Create-New.md

### DIFF
--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -433,7 +433,7 @@ setting the Brain properties so that they are compatible with our Agent code.
     Brains to the **Broadcast Hub**.
 2. Select the **RollerAgent** GameObject to show its properties in the Inspector
     window.
-3. Drag the Brain **RollerBallBrain** from the Project window to the 
+3. Drag the Brain **RollerBallPlayer** from the Project window to the 
     RollerAgent **Brain** field.
 4. Change **Decision Interval** from `1` to `10`.
 5. Drag the Target GameObject from the Hierarchy window to the RollerAgent
@@ -499,11 +499,12 @@ Now you can train the Agent. To get ready for training, you must first to change
 the `Brain` of the agent to be the Learning Brain `RollerBallBrain`.
 Then, select the Academy GameObject and check the `Control` checkbox for 
 the RollerBallBrain item in the **Broadcast Hub** list. From there, the process is
-the same as described in [Training ML-Agents](Training-ML-Agents.md).
+the same as described in [Training ML-Agents](Training-ML-Agents.md). Note that the config
+files and models will be created in the original ml-agents project folder.
 
-The hyperparameters for training are specified in the configuration file that you ls
+The hyperparameters for training are specified in the configuration file that you
 pass to the `mlagents-learn` program. Using the default settings specified 
-in the `config/trainer_config.yaml` file (in your ml-agents folder), the
+in the `config/trainer_config.yaml` file (in your ml-agents project folder), the
 RollerAgent takes about 300,000 steps to train. However, you can change the 
 following hyperparameters  to speed up training considerably (to under 20,000 steps):
 

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -499,12 +499,12 @@ Now you can train the Agent. To get ready for training, you must first to change
 the `Brain` of the agent to be the Learning Brain `RollerBallBrain`.
 Then, select the Academy GameObject and check the `Control` checkbox for 
 the RollerBallBrain item in the **Broadcast Hub** list. From there, the process is
-the same as described in [Training ML-Agents](Training-ML-Agents.md). Note that the config
-files and models will be created in the original ml-agents project folder.
+the same as described in [Training ML-Agents](Training-ML-Agents.md). Note that the 
+models will be created in the original ml-agents project folder, `ml-agents/models`.
 
 The hyperparameters for training are specified in the configuration file that you
 pass to the `mlagents-learn` program. Using the default settings specified 
-in the `config/trainer_config.yaml` file (in your ml-agents project folder), the
+in the original `ml-agents/config/trainer_config.yaml` file, the
 RollerAgent takes about 300,000 steps to train. However, you can change the 
 following hyperparameters  to speed up training considerably (to under 20,000 steps):
 


### PR DESCRIPTION
- Clarify that training is done in the original ml-agents project folder
- Remove mistype
- In the future it could help to show the user that they can copy the config folder and run training in a new project folder so they don't have to mix project settings in the original config folder
-Fix mis-statement about which brain to use (looks like this was already fixed in master)