### PR TITLE
Fix the CSV file reward lagging way behind the actual rewards

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -422,6 +422,7 @@ class PPOTrainer(Trainer):
             number_experiences=len(self.training_buffer.update_buffer["actions"]),
             mean_return=float(np.mean(self.cumulative_returns_since_policy_update)),
         )
+        self.cumulative_returns_since_policy_update = []
         n_sequences = max(
             int(self.trainer_parameters["batch_size"] / self.policy.sequence_length), 1
         )


### PR DESCRIPTION
We aren't clearing the List called `self.cumulative_returns_since_policy_update` when we update the policy. This is used to compute the mean rewards to write to CSV, and it just gets longer and longer through training. 

This PR clears it when we update the policy. 