### PR TITLE
use yaml.safe_load instead of yaml.load

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -154,7 +154,7 @@ def prepare_for_docker_run(docker_target_name, env_path):
 def load_config(trainer_config_path):
     try:
         with open(trainer_config_path) as data_file:
-            trainer_config = yaml.load(data_file)
+            trainer_config = yaml.safe_load(data_file)
             return trainer_config
     except IOError:
         raise UnityEnvironmentException(

--- a/ml-agents/mlagents/trainers/tests/test_bc.py
+++ b/ml-agents/mlagents/trainers/tests/test_bc.py
@@ -13,7 +13,7 @@ from mlagents.envs.mock_communicator import MockCommunicator
 
 @pytest.fixture
 def dummy_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
             hidden_units: 128
             learning_rate: 3.0e-4

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -14,7 +14,7 @@ from mlagents.envs.mock_communicator import MockCommunicator
 
 @pytest.fixture
 def dummy_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
         trainer: ppo
         batch_size: 32

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -16,7 +16,7 @@ from mlagents.envs.exception import UnityEnvironmentException
 
 @pytest.fixture
 def dummy_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
         default:
             trainer: ppo
@@ -46,7 +46,7 @@ def dummy_config():
 
 @pytest.fixture
 def dummy_online_bc_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
         default:
             trainer: online_bc
@@ -78,7 +78,7 @@ def dummy_online_bc_config():
 
 @pytest.fixture
 def dummy_offline_bc_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
         default:
             trainer: offline_bc
@@ -120,7 +120,7 @@ def dummy_offline_bc_config_with_override():
 
 @pytest.fixture
 def dummy_bad_config():
-    return yaml.load(
+    return yaml.safe_load(
         """
         default:
             trainer: incorrect_trainer


### PR DESCRIPTION
This gets rid of these warnings

> /.../ml-agents/ml-agents/mlagents/trainers/learn.py:157: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
>   trainer_config = yaml.load(data_file)
> 

when running `mlagents-learn`. It's also just a generally good idea; see the link for more info.