### PR TITLE
Barracuda - remove unused private variable

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/GeneratorImpl.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/GeneratorImpl.cs
@@ -123,9 +123,8 @@ namespace MLAgents.InferenceBrain
         private int memoriesCount;
         private int memoryIndex;
         
-        public BarracudaRecurrentInputGenerator(int memoriesCount, int memoryIndex)
+        public BarracudaRecurrentInputGenerator(int memoryIndex)
         {
-            this.memoriesCount = memoriesCount;
             this.memoryIndex = memoryIndex;
         }
         

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorGenerator.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorGenerator.cs
@@ -51,7 +51,7 @@ namespace MLAgents.InferenceBrain
             Barracuda.Model model = (Barracuda.Model) barracudaModel;
             for (var i = 0; i < model?.memories.Length; i++)
             {
-                _dict[model.memories[i].input] = new BarracudaRecurrentInputGenerator(model.memories.Length, i);
+                _dict[model.memories[i].input] = new BarracudaRecurrentInputGenerator(i);
             }
             #endif
             


### PR DESCRIPTION
Follow up from https://github.com/Unity-Technologies/ml-agents/pull/2049

Fixes a warning:

> Assets/ML-Agents/Scripts/InferenceBrain/GeneratorImpl.cs(123,21): warning CS0414: The private field `MLAgents.InferenceBrain.BarracudaRecurrentInputGenerator.memoriesCount' is assigned but its value is never used

@mantasp Can you confirm this is correct? Not sure if it's supposed to be used instead of e.g. `memory.Count` in `Generate()`