### PR TITLE
Make Gym interface work with grayscale and RGB visual observations

### DIFF
--- a/gym-unity/gym_unity/envs/unity_env.py
+++ b/gym-unity/gym_unity/envs/unity_env.py
@@ -218,16 +218,14 @@ class UnityEnv(gym.Env):
     def _single_step(self, info):
         if self.use_visual:
             visual_obs = info.visual_observations
-            if isinstance(visual_obs, list):
-                visual_obs = np.array(visual_obs)
 
             if self._allow_multiple_visual_obs:
                 visual_obs_list = []
                 for obs in visual_obs:
-                    visual_obs_list.append(self._preprocess_single(obs[0, :, :, :]))
+                    visual_obs_list.append(self._preprocess_single(obs[0]))
                 self.visual_obs = visual_obs_list
             else:
-                self.visual_obs = self._preprocess_single(visual_obs[0][0, :, :, :])
+                self.visual_obs = self._preprocess_single(visual_obs[0][0])
 
             default_observation = self.visual_obs
         else:


### PR DESCRIPTION
Hi everybody, 
I recently ran into issues when processing multiple visual observations that contain both, RGB and grayscale images, with the OpenAI Gym interface. 

I edited the `_single_step` function accordingly and now it should work. 

What do you think?