### PR TITLE
Remove "external_brains" arg for TrainerController

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -97,7 +97,6 @@ def run_training(
         train_model,
         keep_checkpoints,
         lesson,
-        env.external_brains,
         run_seed,
         fast_simulation,
     )

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -50,7 +50,6 @@ def test_run_training(load_config, create_environment_factory, subproc_env_mock)
                 False,
                 5,
                 0,
-                subproc_env_mock.return_value.external_brains,
                 0,
                 True,
             )

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -148,7 +148,7 @@ def dummy_bad_config():
 
 
 @pytest.fixture
-def basic_trainer_controller(brain_info):
+def basic_trainer_controller():
     return TrainerController(
         model_path="test_model_path",
         summaries_dir="test_summaries_dir",
@@ -159,7 +159,6 @@ def basic_trainer_controller(brain_info):
         train=True,
         keep_checkpoints=False,
         lesson=None,
-        external_brains={"testbrain": brain_info},
         training_seed=99,
         fast_simulation=True,
     )
@@ -169,16 +168,18 @@ def basic_trainer_controller(brain_info):
 @patch("tensorflow.set_random_seed")
 def test_initialization_seed(numpy_random_seed, tensorflow_set_seed):
     seed = 27
-    TrainerController("", "", "1", 1, None, True, False, False, None, {}, seed, True)
+    TrainerController("", "", "1", 1, None, True, False, False, None, seed, True)
     numpy_random_seed.assert_called_with(seed)
     tensorflow_set_seed.assert_called_with(seed)
 
 
 def assert_bc_trainer_constructed(
-    trainer_cls, input_config, tc, expected_brain_info, expected_config
+    trainer_cls, input_config, tc, expected_brain_params, expected_config
 ):
+    external_brains = {"testbrain": expected_brain_params}
+
     def mock_constructor(self, brain, trainer_params, training, load, seed, run_id):
-        assert brain == expected_brain_info
+        assert brain == expected_brain_params
         assert trainer_params == expected_config
         assert training == tc.train_model
         assert load == tc.load_model
@@ -186,19 +187,21 @@ def assert_bc_trainer_constructed(
         assert run_id == tc.run_id
 
     with patch.object(trainer_cls, "__init__", mock_constructor):
-        tc.initialize_trainers(input_config)
+        tc.initialize_trainers(input_config, external_brains)
         assert "testbrain" in tc.trainers
         assert isinstance(tc.trainers["testbrain"], trainer_cls)
 
 
 def assert_ppo_trainer_constructed(
-    input_config, tc, expected_brain_info, expected_config, expected_reward_buff_cap=0
+    input_config, tc, expected_brain_params, expected_config, expected_reward_buff_cap=0
 ):
+    external_brains = {"testbrain": expected_brain_params}
+
     def mock_constructor(
         self, brain, reward_buff_cap, trainer_parameters, training, load, seed, run_id
     ):
         self.trainer_metrics = TrainerMetrics("", "")
-        assert brain == expected_brain_info
+        assert brain == expected_brain_params
         assert trainer_parameters == expected_config
         assert reward_buff_cap == expected_reward_buff_cap
         assert training == tc.train_model
@@ -207,15 +210,15 @@ def assert_ppo_trainer_constructed(
         assert run_id == tc.run_id
 
     with patch.object(PPOTrainer, "__init__", mock_constructor):
-        tc.initialize_trainers(input_config)
+        tc.initialize_trainers(input_config, external_brains)
         assert "testbrain" in tc.trainers
         assert isinstance(tc.trainers["testbrain"], PPOTrainer)
 
 
-@patch("mlagents.envs.BrainInfo")
-def test_initialize_trainer_parameters_uses_defaults(BrainInfoMock):
-    brain_info_mock = BrainInfoMock()
-    tc = basic_trainer_controller(brain_info_mock)
+@patch("mlagents.envs.BrainParameters")
+def test_initialize_trainer_parameters_uses_defaults(BrainParametersMock):
+    brain_params_mock = BrainParametersMock()
+    tc = basic_trainer_controller()
 
     full_config = dummy_offline_bc_config()
     expected_config = full_config["default"]
@@ -224,14 +227,14 @@ def test_initialize_trainer_parameters_uses_defaults(BrainInfoMock):
     expected_config["keep_checkpoints"] = tc.keep_checkpoints
 
     assert_bc_trainer_constructed(
-        OfflineBCTrainer, full_config, tc, brain_info_mock, expected_config
+        OfflineBCTrainer, full_config, tc, brain_params_mock, expected_config
     )
 
 
-@patch("mlagents.envs.BrainInfo")
-def test_initialize_trainer_parameters_override_defaults(BrainInfoMock):
-    brain_info_mock = BrainInfoMock()
-    tc = basic_trainer_controller(brain_info_mock)
+@patch("mlagents.envs.BrainParameters")
+def test_initialize_trainer_parameters_override_defaults(BrainParametersMock):
+    brain_params_mock = BrainParametersMock()
+    tc = basic_trainer_controller()
 
     full_config = dummy_offline_bc_config_with_override()
     expected_config = full_config["default"]
@@ -243,14 +246,14 @@ def test_initialize_trainer_parameters_override_defaults(BrainInfoMock):
     expected_config["normalize"] = False
 
     assert_bc_trainer_constructed(
-        OfflineBCTrainer, full_config, tc, brain_info_mock, expected_config
+        OfflineBCTrainer, full_config, tc, brain_params_mock, expected_config
     )
 
 
-@patch("mlagents.envs.BrainInfo")
-def test_initialize_online_bc_trainer(BrainInfoMock):
-    brain_info_mock = BrainInfoMock()
-    tc = basic_trainer_controller(brain_info_mock)
+@patch("mlagents.envs.BrainParameters")
+def test_initialize_online_bc_trainer(BrainParametersMock):
+    brain_params_mock = BrainParametersMock()
+    tc = basic_trainer_controller()
 
     full_config = dummy_online_bc_config()
     expected_config = full_config["default"]
@@ -259,14 +262,14 @@ def test_initialize_online_bc_trainer(BrainInfoMock):
     expected_config["keep_checkpoints"] = tc.keep_checkpoints
 
     assert_bc_trainer_constructed(
-        OnlineBCTrainer, full_config, tc, brain_info_mock, expected_config
+        OnlineBCTrainer, full_config, tc, brain_params_mock, expected_config
     )
 
 
-@patch("mlagents.envs.BrainInfo")
-def test_initialize_ppo_trainer(BrainInfoMock):
-    brain_info_mock = BrainInfoMock()
-    tc = basic_trainer_controller(brain_info_mock)
+@patch("mlagents.envs.BrainParameters")
+def test_initialize_ppo_trainer(BrainParametersMock):
+    brain_params_mock = BrainParametersMock()
+    tc = basic_trainer_controller()
 
     full_config = dummy_config()
     expected_config = full_config["default"]
@@ -274,17 +277,17 @@ def test_initialize_ppo_trainer(BrainInfoMock):
     expected_config["model_path"] = tc.model_path + "/testbrain"
     expected_config["keep_checkpoints"] = tc.keep_checkpoints
 
-    assert_ppo_trainer_constructed(full_config, tc, brain_info_mock, expected_config)
+    assert_ppo_trainer_constructed(full_config, tc, brain_params_mock, expected_config)
 
 
-@patch("mlagents.envs.BrainInfo")
-def test_initialize_invalid_trainer_raises_exception(BrainInfoMock):
-    brain_info_mock = BrainInfoMock()
-    tc = basic_trainer_controller(brain_info_mock)
+@patch("mlagents.envs.BrainParameters")
+def test_initialize_invalid_trainer_raises_exception(BrainParametersMock):
+    tc = basic_trainer_controller()
     bad_config = dummy_bad_config()
+    external_brains = {"testbrain": BrainParametersMock()}
 
     with pytest.raises(UnityEnvironmentException):
-        tc.initialize_trainers(bad_config)
+        tc.initialize_trainers(bad_config, external_brains)
 
 
 def trainer_controller_with_start_learning_mocks():
@@ -294,8 +297,7 @@ def trainer_controller_with_start_learning_mocks():
     trainer_mock.parameters = {"some": "parameter"}
     trainer_mock.write_tensorboard_text = MagicMock()
 
-    brain_info_mock = MagicMock()
-    tc = basic_trainer_controller(brain_info_mock)
+    tc = basic_trainer_controller()
     tc.initialize_trainers = MagicMock()
     tc.trainers = {"testbrain": trainer_mock}
     tc.take_step = MagicMock()
@@ -323,10 +325,13 @@ def test_start_learning_trains_forever_if_no_train_model(tf_reset_graph):
     env_mock = MagicMock()
     env_mock.close = MagicMock()
     env_mock.reset = MagicMock()
+    env_mock.external_brains = MagicMock()
 
     tc.start_learning(env_mock, trainer_config)
     tf_reset_graph.assert_called_once()
-    tc.initialize_trainers.assert_called_once_with(trainer_config)
+    tc.initialize_trainers.assert_called_once_with(
+        trainer_config, env_mock.external_brains
+    )
     env_mock.reset.assert_called_once()
     assert tc.take_step.call_count == 11
     tc._export_graph.assert_not_called()
@@ -344,10 +349,13 @@ def test_start_learning_trains_until_max_steps_then_saves(tf_reset_graph):
     env_mock = MagicMock()
     env_mock.close = MagicMock()
     env_mock.reset = MagicMock(return_value=brain_info_mock)
+    env_mock.external_brains = MagicMock()
 
     tc.start_learning(env_mock, trainer_config)
     tf_reset_graph.assert_called_once()
-    tc.initialize_trainers.assert_called_once_with(trainer_config)
+    tc.initialize_trainers.assert_called_once_with(
+        trainer_config, env_mock.external_brains
+    )
     env_mock.reset.assert_called_once()
     assert tc.take_step.call_count == trainer_mock.get_max_steps + 1
     env_mock.close.assert_called_once()
@@ -381,8 +389,7 @@ def trainer_controller_with_take_step_mocks():
     trainer_mock.parameters = {"some": "parameter"}
     trainer_mock.write_tensorboard_text = MagicMock()
 
-    brain_info_mock = MagicMock()
-    tc = basic_trainer_controller(brain_info_mock)
+    tc = basic_trainer_controller()
     tc.trainers = {"testbrain": trainer_mock}
 
     return tc, trainer_mock

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -47,7 +47,6 @@ class TrainerController(object):
         :param train: Whether to train model, or only run inference.
         :param keep_checkpoints: How many model checkpoints to keep.
         :param lesson: Start learning from this lesson.
-        :param external_brains: dictionary of external brain names to BrainInfo objects.
         :param training_seed: Seed to use for Numpy and Tensorflow random number generation.
         """
 


### PR DESCRIPTION
TrainerController depended on an external_brains dictionary with
brain params in its constructor but only used it in a single function
call.  The same function call (start_learning) takes the environment
as an argument, which is the source of the external_brains.

This change removes the dependency of TrainerController on external
brains and removes the two class members related to external_brains
and retrieves the brains directly from the environment.