### PR TITLE
fix subprocess test and style checks on develop

### DIFF
--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -84,7 +84,9 @@ def worker(parent_conn: Connection, pickled_env_factory: str, worker_id: int):
             elif cmd.name == "reset_parameters":
                 _send_response("reset_parameters", env.reset_parameters)
             elif cmd.name == "reset":
-                all_brain_info = env.reset(cmd.payload[0], cmd.payload[1], cmd.payload[2])
+                all_brain_info = env.reset(
+                    cmd.payload[0], cmd.payload[1], cmd.payload[2]
+                )
                 _send_response("reset", all_brain_info)
             elif cmd.name == "global_done":
                 _send_response("global_done", env.global_done)
@@ -145,7 +147,9 @@ class SubprocessEnvManager(EnvManager):
             steps.append(step_info)
         return steps
 
-    def reset(self, config=None, train_mode=True, custom_reset_parameters=None) -> List[StepInfo]:
+    def reset(
+        self, config=None, train_mode=True, custom_reset_parameters=None
+    ) -> List[StepInfo]:
         self._broadcast_message("reset", (config, train_mode, custom_reset_parameters))
         reset_results = [
             self.env_workers[i].recv().payload for i in range(len(self.env_workers))

--- a/ml-agents-envs/mlagents/envs/tests/test_subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/tests/test_subprocess_env_manager.py
@@ -66,7 +66,7 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         manager = SubprocessEnvManager(mock_env_factory, 1)
         params = {"test": "params"}
         manager.reset(params, False)
-        manager.env_workers[0].send.assert_called_with("reset", (params, False))
+        manager.env_workers[0].send.assert_called_with("reset", (params, False, None))
 
     def test_reset_collects_results_from_all_envs(self):
         SubprocessEnvManager.create_worker = lambda em, worker_id, env_factory: MockEnvWorker(
@@ -77,7 +77,7 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         params = {"test": "params"}
         res = manager.reset(params)
         for i, env in enumerate(manager.env_workers):
-            env.send.assert_called_with("reset", (params, True))
+            env.send.assert_called_with("reset", (params, True, None))
             env.recv.assert_called()
             # Check that the "last steps" are set to the value returned for each step
             self.assertEqual(


### PR DESCRIPTION
CI didn't run on https://github.com/Unity-Technologies/ml-agents/pull/2242 so we missed this.