### PR TITLE
Anaconda installation requires OpenSSL libraries available on path

### DIFF
--- a/docs/Installation-Windows.md
+++ b/docs/Installation-Windows.md
@@ -63,6 +63,7 @@ following new paths.
 %UserProfile%\Anaconda3\Scripts\conda.exe
 %UserProfile%\Anaconda3
 %UserProfile%\Anaconda3\python.exe
+%UserProfile%\Anaconda3\Library\bin
 ```
 
 ## Step 2: Setup and Activate a New Conda Environment


### PR DESCRIPTION
without adding this path, a fresh install can encounter SSLError