### PR TITLE
Make SubprocessEnvManager take asynchronous steps

### DIFF
--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -42,7 +42,7 @@ class UnityEnvWorker:
         try:
             response: EnvironmentResponse = self.conn.recv()
             return response
-        except (BrokenPipeError, EOFError) as e:
+        except (BrokenPipeError, EOFError):
             raise KeyboardInterrupt
 
     def close(self):

--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -167,6 +167,10 @@ class SubprocessEnvManager(EnvManager):
     def reset(
         self, config=None, train_mode=True, custom_reset_parameters=None
     ) -> List[StepInfo]:
+        while any([ew.waiting for ew in self.env_workers]):
+            if not self.step_queue.empty():
+                step = self.step_queue.get_nowait()
+                self.env_workers[step.worker_id].waiting = False
         # First enqueue reset commands for all workers so that they reset in parallel
         for ew in self.env_workers:
             ew.send("reset", (config, train_mode, custom_reset_parameters))

--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -4,7 +4,7 @@ import cloudpickle
 from mlagents.envs import UnityEnvironment
 from multiprocessing import Process, Pipe, Queue
 from multiprocessing.connection import Connection
-from queue import Empty as EmptyQueue
+from queue import Empty as EmptyQueueException
 from mlagents.envs.base_unity_environment import BaseUnityEnvironment
 from mlagents.envs.env_manager import EnvManager, StepInfo
 from mlagents.envs.timers import timed
@@ -158,7 +158,7 @@ class SubprocessEnvManager(EnvManager):
                     if step.worker_id not in step_workers:
                         worker_steps.append(step)
                         step_workers.add(step.worker_id)
-            except EmptyQueue:
+            except EmptyQueueException:
                 pass
 
         step_infos = self._postprocess_steps(worker_steps)

--- a/ml-agents-envs/mlagents/envs/tests/test_subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/tests/test_subprocess_env_manager.py
@@ -2,7 +2,7 @@ import unittest.mock as mock
 from unittest.mock import Mock, MagicMock
 import unittest
 import cloudpickle
-from mlagents.envs.subprocess_env_manager import StepInfo
+from queue import Empty as EmptyQueue
 
 from mlagents.envs.subprocess_env_manager import (
     SubprocessEnvManager,
@@ -24,6 +24,7 @@ class MockEnvWorker:
         self.conn = None
         self.send = Mock()
         self.recv = Mock(return_value=resp)
+        self.waiting = False
 
 
 class SubprocessEnvManagerTest(unittest.TestCase):
@@ -32,7 +33,10 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         env = SubprocessEnvManager(mock_env_factory, 2)
         # Creates two processes
         env.create_worker.assert_has_calls(
-            [mock.call(0, mock_env_factory), mock.call(1, mock_env_factory)]
+            [
+                mock.call(0, env.step_queue, mock_env_factory),
+                mock.call(1, env.step_queue, mock_env_factory),
+            ]
         )
         self.assertEqual(len(env.env_workers), 2)
 
@@ -45,31 +49,38 @@ class SubprocessEnvManagerTest(unittest.TestCase):
             return env_mock
 
         mock_parent_connection = Mock()
+        mock_step_queue = Mock()
         step_command = EnvironmentCommand("step", (None, None, None, None))
         close_command = EnvironmentCommand("close")
         mock_parent_connection.recv.side_effect = [step_command, close_command]
         mock_parent_connection.send = Mock()
 
         worker(
-            mock_parent_connection, cloudpickle.dumps(mock_global_done_env_factory), 0
+            mock_parent_connection,
+            mock_step_queue,
+            cloudpickle.dumps(mock_global_done_env_factory),
+            0,
         )
 
         # recv called twice to get step and close command
         self.assertEqual(mock_parent_connection.recv.call_count, 2)
 
         # worker returns the data from the reset
-        mock_parent_connection.send.assert_called_with(
+        mock_step_queue.put.assert_called_with(
             EnvironmentResponse("step", 0, "reset_data")
         )
 
     def test_reset_passes_reset_params(self):
+        SubprocessEnvManager.create_worker = lambda em, worker_id, step_queue, env_factory: MockEnvWorker(
+            worker_id, EnvironmentResponse("reset", worker_id, worker_id)
+        )
         manager = SubprocessEnvManager(mock_env_factory, 1)
         params = {"test": "params"}
         manager.reset(params, False)
         manager.env_workers[0].send.assert_called_with("reset", (params, False, None))
 
     def test_reset_collects_results_from_all_envs(self):
-        SubprocessEnvManager.create_worker = lambda em, worker_id, env_factory: MockEnvWorker(
+        SubprocessEnvManager.create_worker = lambda em, worker_id, step_queue, env_factory: MockEnvWorker(
             worker_id, EnvironmentResponse("reset", worker_id, worker_id)
         )
         manager = SubprocessEnvManager(mock_env_factory, 4)
@@ -85,26 +96,38 @@ class SubprocessEnvManagerTest(unittest.TestCase):
             )
         assert res == list(map(lambda ew: ew.previous_step, manager.env_workers))
 
-    def test_step_takes_steps_for_all_envs(self):
-        SubprocessEnvManager.create_worker = lambda em, worker_id, env_factory: MockEnvWorker(
+    def test_step_takes_steps_for_all_non_waiting_envs(self):
+        SubprocessEnvManager.create_worker = lambda em, worker_id, step_queue, env_factory: MockEnvWorker(
             worker_id, EnvironmentResponse("step", worker_id, worker_id)
         )
-        manager = SubprocessEnvManager(mock_env_factory, 2)
+        manager = SubprocessEnvManager(mock_env_factory, 3)
+        manager.step_queue = Mock()
+        manager.step_queue.get_nowait.side_effect = [
+            EnvironmentResponse("step", 0, 0),
+            EnvironmentResponse("step", 1, 1),
+            EmptyQueue(),
+        ]
         step_mock = Mock()
-        last_steps = [Mock(), Mock()]
+        last_steps = [Mock(), Mock(), Mock()]
         manager.env_workers[0].previous_step = last_steps[0]
         manager.env_workers[1].previous_step = last_steps[1]
+        manager.env_workers[2].previous_step = last_steps[2]
+        manager.env_workers[2].waiting = True
         manager._take_step = Mock(return_value=step_mock)
         res = manager.step()
         for i, env in enumerate(manager.env_workers):
-            env.send.assert_called_with("step", step_mock)
-            env.recv.assert_called()
-            # Check that the "last steps" are set to the value returned for each step
-            self.assertEqual(
-                manager.env_workers[i].previous_step.current_all_brain_info, i
-            )
-            self.assertEqual(
-                manager.env_workers[i].previous_step.previous_all_brain_info,
-                last_steps[i].current_all_brain_info,
-            )
-        assert res == list(map(lambda ew: ew.previous_step, manager.env_workers))
+            if i < 2:
+                env.send.assert_called_with("step", step_mock)
+                manager.step_queue.get_nowait.assert_called()
+                # Check that the "last steps" are set to the value returned for each step
+                self.assertEqual(
+                    manager.env_workers[i].previous_step.current_all_brain_info, i
+                )
+                self.assertEqual(
+                    manager.env_workers[i].previous_step.previous_all_brain_info,
+                    last_steps[i].current_all_brain_info,
+                )
+        assert res == [
+            manager.env_workers[0].previous_step,
+            manager.env_workers[1].previous_step,
+        ]


### PR DESCRIPTION
SubprocessEnvManager takes steps synchronously to reproduce old
behavior, meaning all parallel environments will need to wait for
the slowest environment to take a step.  If some steps take much
longer than others, this can lead to a substantial overall slowdown
in practice.  We've seen extreme cases where we see almost a 2x
speedup from using asynchronous stepping, with no downside for our
faster environments.

This PR changes the SubprocessEnvManager to use async stepping.
This means on the "step" call the environment manager will enqueue
step requests to workers, and then only wait until at least one
step has been completed before returning.

**Testing**

_Reacher_ environment on GCP with 8 parallel environments.  15000 steps.  16.5% improvement in overall time for Async EnvManager, comparable reward.

_Walker_ environment on GCP with 8 parallel environments.  30000 steps.  14.2% improvement in overall time for Async EnvManager, comparable reward.