### PR TITLE
Enforce min coverage percentage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@
 .DS_Store
 .ipynb_checkpoints
 
-# pytest cache 
+# pytest cache
 *.pytest_cache/
 
 # Ignore compiled protobuf files.
@@ -99,3 +99,6 @@ build/
 # Python virtual environment
 venv/
 .mypy_cache/
+
+# Code coverage report
+.coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [coverage:report]
+# Run "pytest --cov=mlagents" to see the current coverage percentage.
+# Run "pytest --cov=mlagents --cov-report html" to get a nice visualization of what is/isn't coverge in html format.
 fail_under = 60

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[coverage:report]
+fail_under = 60


### PR DESCRIPTION
This is pretty lenient to start - we currently have about 66% coverage and it sets the min to 60%. I don't think we should target a fixed % in general, just try to avoid submitting large blocks of uncovered code (or accidentally reducing coverage).