### PR TITLE
Fix bug where reward buffer always appended 0

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -405,8 +405,8 @@ class PPOTrainer(Trainer):
                             self.stats["Environment/Cumulative Reward"].append(
                                 rewards.get(agent_id, 0)
                             )
-                            rewards[agent_id] = 0
                             self.reward_buffer.appendleft(rewards.get(agent_id, 0))
+                            rewards[agent_id] = 0
                         else:
                             self.stats[
                                 self.policy.reward_signals[name].stat_name


### PR DESCRIPTION
Set reward to 0 after append, not before. 