### PR TITLE
Fix get_value_estimate and buffer append

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/policy.py
+++ b/ml-agents/mlagents/trainers/ppo/policy.py
@@ -190,7 +190,7 @@ class PPOPolicy(TFPolicy):
         run_out = self._execute_model(feed_dict, self.update_dict)
         return run_out
 
-    def get_value_estimates(self, brain_info, idx):
+    def get_value_estimates(self, brain_info, idx, done):
         """
         Generates value estimates for bootstrapping.
         :param brain_info: BrainInfo to be used for bootstrapping.
@@ -214,6 +214,12 @@ class PPOPolicy(TFPolicy):
                 idx
             ].reshape([-1, len(self.model.act_size)])
         value_estimates = self.sess.run(self.model.value_heads, feed_dict)
+
+        for reward_signal in value_estimates:
+            value_estimates[reward_signal] = (
+                0.0 if done else value_estimates[reward_signal][0]
+            )
+
         return value_estimates
 
     def get_action(self, brain_info: BrainInfo) -> ActionInfo:

--- a/ml-agents/mlagents/trainers/ppo/policy.py
+++ b/ml-agents/mlagents/trainers/ppo/policy.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
-from typing import Dict
+from typing import Any, Dict
+import tensorflow as tf
 
 from mlagents.envs.timers import timed
 from mlagents.trainers import BrainInfo, ActionInfo
@@ -205,7 +206,10 @@ class PPOPolicy(TFPolicy):
         if done:
             return {k: 0.0 for k in self.model.value_heads.keys()}
 
-        feed_dict = {self.model.batch_size: 1, self.model.sequence_length: 1}
+        feed_dict: Dict[tf.Tensor, Any] = {
+            self.model.batch_size: 1,
+            self.model.sequence_length: 1,
+        }
         for i in range(len(brain_info.visual_observations)):
             feed_dict[self.model.visual_in[i]] = [
                 brain_info.visual_observations[i][idx]

--- a/ml-agents/mlagents/trainers/ppo/policy.py
+++ b/ml-agents/mlagents/trainers/ppo/policy.py
@@ -1,5 +1,6 @@
 import logging
 import numpy as np
+from typing import Dict
 
 from mlagents.envs.timers import timed
 from mlagents.trainers import BrainInfo, ActionInfo
@@ -190,7 +191,9 @@ class PPOPolicy(TFPolicy):
         run_out = self._execute_model(feed_dict, self.update_dict)
         return run_out
 
-    def get_value_estimates(self, brain_info, idx, done):
+    def get_value_estimates(
+        self, brain_info: BrainInfo, idx: int, done: bool
+    ) -> Dict[str, float]:
         """
         Generates value estimates for bootstrapping.
         :param brain_info: BrainInfo to be used for bootstrapping.

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -346,9 +346,12 @@ class PPOTrainer(Trainer):
                 else:
                     bootstrapping_info = info
                     idx = l
-                value_next = self.policy.get_value_estimates(bootstrapping_info, idx)
-                if info.local_done[l] and not info.max_reached[l]:
-                    value_next["extrinsic"] = 0.0
+                value_next = self.policy.get_value_estimates(
+                    bootstrapping_info,
+                    idx,
+                    info.local_done[l] and not info.max_reached[l],
+                )
+
                 tmp_advantages = []
                 tmp_returns = []
                 for name in self.policy.reward_signals:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -510,7 +510,7 @@ def get_gae(rewards, value_estimates, value_next=0.0, gamma=0.99, lambd=0.95):
     :param lambd: GAE weighing factor.
     :return: list of advantage estimates for time-steps t to T.
     """
-    value_estimates = np.asarray(value_estimates.tolist() + [value_next])
+    value_estimates = np.append(value_estimates, value_next)
     delta_t = rewards + gamma * value_estimates[1:] - value_estimates[:-1]
     advantage = discount_rewards(r=delta_t, gamma=gamma * lambd)
     return advantage


### PR DESCRIPTION
In newer versions of numpy (>1.14), the fact that we convert a np array into a list, append an np array, and convert it back to a list in `get_gae` causes problems. 

This commit changes `get_value_estimates` to output a `dict` of floats rather than np arrays, and uses np.append rather than converting to a list and back to resolve this issue. 