### PR TITLE
Relax the cloudpickle version restriction

### DIFF
--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -24,7 +24,7 @@ setup(
         "pytest>=3.2.2,<4.0.0",
         "protobuf>=3.6,<3.7",
         "grpcio>=1.11.0,<1.12.0",
-        "cloudpickle==0.8.1",
+        "cloudpickle",
     ],
     python_requires=">=3.5,<3.8",
 )


### PR DESCRIPTION
The previous version conflicts with the one in newer versions of `gym` (https://github.com/openai/gym/blob/cc6ff414aefe669cc8d221a482ebe211816f60fe/setup.py#L34). Any version should be fine, since we’re only sending stuff between the subprocess env manager and the worker.