### PR TITLE
fix bug in RandomNormal

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/RandomNormalTest.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/RandomNormalTest.cs
@@ -13,16 +13,17 @@ namespace MLAgents.Tests
 
     public class RandomNormalTest
     {
-        private const float first = -1.19580f;
-        private const float second = -0.97345f;
+        private const float firstValue = -1.19580f;
+        private const float secondValue = -0.97345f;
+        private const double epsilon = 0.0001;
 
         [Test]
         public void RandomNormalTestTwoDouble ()
         {
             RandomNormal rn = new RandomNormal (2018);
 
-            Assert.AreEqual (first, rn.NextDouble (), 0.0001);
-            Assert.AreEqual (second, rn.NextDouble (), 0.0001);
+            Assert.AreEqual (firstValue, rn.NextDouble (), epsilon);
+            Assert.AreEqual (secondValue, rn.NextDouble (), epsilon);
         }
 
         [Test]
@@ -30,8 +31,8 @@ namespace MLAgents.Tests
         {
             RandomNormal rn = new RandomNormal (2018, 5.0f);
 
-            Assert.AreEqual (first + 5.0, rn.NextDouble (), 0.0001);
-            Assert.AreEqual (second + 5.0, rn.NextDouble (), 0.0001);
+            Assert.AreEqual (firstValue + 5.0, rn.NextDouble (), epsilon);
+            Assert.AreEqual (secondValue + 5.0, rn.NextDouble (), epsilon);
         }
 
         [Test]
@@ -39,8 +40,8 @@ namespace MLAgents.Tests
         {
             RandomNormal rn = new RandomNormal (2018, 0.0f, 4.2f);
 
-            Assert.AreEqual (first * 4.2, rn.NextDouble (), 0.0001);
-            Assert.AreEqual (second * 4.2, rn.NextDouble (), 0.0001);
+            Assert.AreEqual (firstValue * 4.2, rn.NextDouble (), epsilon);
+            Assert.AreEqual (secondValue * 4.2, rn.NextDouble (), epsilon);
         }
 
         [Test]
@@ -50,8 +51,8 @@ namespace MLAgents.Tests
             float stddev = 2.2f;
             RandomNormal rn = new RandomNormal (2018, mean, stddev);
 
-            Assert.AreEqual (first * stddev + mean, rn.NextDouble (), 0.0001);
-            Assert.AreEqual (second * stddev + mean, rn.NextDouble (), 0.0001);
+            Assert.AreEqual (firstValue * stddev + mean, rn.NextDouble (), epsilon);
+            Assert.AreEqual (secondValue * stddev + mean, rn.NextDouble (), epsilon);
         }
 
         [Test]
@@ -86,27 +87,28 @@ namespace MLAgents.Tests
             int numSamples = 100000;
             // Adapted from https://www.johndcook.com/blog/standard_deviation/
             // Computes stddev and mean without losing precision
-            double m_oldM = 0.0, m_newM = 0.0, m_oldS = 0.0, m_newS = 0.0;
+            double oldM = 0.0, newM = 0.0, oldS = 0.0, newS = 0.0;
 
             for (int i = 0; i < numSamples; i++) {
                 double x = rn.NextDouble ();
                 if (i == 0) {
-                    m_oldM = m_newM = x;
-                    m_oldS = 0.0;
+                    oldM = newM = x;
+                    oldS = 0.0;
                 } else {
-                    m_newM = m_oldM + (x - m_oldM) / i;
-                    m_newS = m_oldS + (x - m_oldM) * (x - m_newM);
+                    newM = oldM + (x - oldM) / i;
+                    newS = oldS + (x - oldM) * (x - newM);
 
                     // set up for next iteration
-                    m_oldM = m_newM;
-                    m_oldS = m_newS;
+                    oldM = newM;
+                    oldS = newS;
                 }
             }
 
-            double sampleMean = m_newM;
-            double sampleVariance = m_newS / (numSamples - 1);
+            double sampleMean = newM;
+            double sampleVariance = newS / (numSamples - 1);
             double sampleStddev = Math.Sqrt (sampleVariance);
 
+            // Note a larger epsilon here. We could get closer to the true values with more samples.
             Assert.AreEqual (mean, sampleMean, 0.01);
             Assert.AreEqual (stddev, sampleStddev, 0.01);
 
@@ -153,7 +155,7 @@ namespace MLAgents.Tests
 
             int i = 0;
             foreach (float f in t.Data) {
-                Assert.AreEqual (f, reference [i], 0.0001);
+                Assert.AreEqual (f, reference [i], epsilon);
                 ++i;
             }
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/Utils/RandomNormal.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/Utils/RandomNormal.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace MLAgents.InferenceBrain.Utils
 {
@@ -12,7 +12,7 @@ namespace MLAgents.InferenceBrain.Utils
         private readonly double m_mean;
         private readonly double m_stddev;
         private readonly System.Random m_random;
-        
+
         public RandomNormal(int seed, float mean = 0.0f, float stddev = 1.0f)
         {
             m_mean = mean;
@@ -23,7 +23,7 @@ namespace MLAgents.InferenceBrain.Utils
         // Each iteration produces two numbers. Hold one here for next call
         private bool m_hasSpare = false;
         private double m_spare = 0.0f;
-        
+
         /// <summary>
         /// Return the next random double number
         /// </summary>
@@ -44,7 +44,7 @@ namespace MLAgents.InferenceBrain.Utils
                 s = u * u + v * v;
             } while (s >= 1.0 || s == 0.0);
 
-            s = Math.Sqrt(-2.0 * Math.Log(s) / 2);
+            s = Math.Sqrt(-2.0 * Math.Log(s) / s);
             m_spare = u * s;
             m_hasSpare = true;
 
@@ -66,9 +66,9 @@ namespace MLAgents.InferenceBrain.Utils
                 }
             }
         }
-        
+
         /// <summary>
-        /// Fill a pre-allocated Tensor with random numbers 
+        /// Fill a pre-allocated Tensor with random numbers
         /// </summary>
         /// <param name="t">The pre-allocated Tensor to fill</param>
         /// <exception cref="NotImplementedException">Throws when trying to fill a Tensor of type other than float</exception>


### PR DESCRIPTION
A typo in `RandomNormal.NextDouble()` was causing it to generate values with the right mean but incorrect standard deviation. This fixes the bug and also adds a test that the sample mean and stddev are close to what's expected.

Note on whitespace: I used the standard (I think) `.editorconfig` and applied "Format Document" in Visual Studio. This changed a lot of tabs to spaces.