### PR TITLE
Cleanup unused code in TrainerController

### DIFF
--- a/ml-agents/mlagents/trainers/bc/trainer.py
+++ b/ml-agents/mlagents/trainers/bc/trainer.py
@@ -126,6 +126,7 @@ class BCTrainer(Trainer):
                 self.stats["Environment/Episode Length"].append(
                     self.episode_steps.get(agent_id, 0)
                 )
+                self.reward_buffer.appendleft(self.cumulative_rewards.get(agent_id, 0))
                 self.cumulative_rewards[agent_id] = 0
                 self.episode_steps[agent_id] = 0
 

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -32,9 +32,7 @@ class PPOTrainer(Trainer):
         :param seed: The seed the model will be initialized with
         :param run_id: The identifier of the current run
         """
-        super(PPOTrainer, self).__init__(
-            brain, trainer_parameters, training, run_id, reward_buff_cap
-        )
+        super().__init__(brain, trainer_parameters, training, run_id, reward_buff_cap)
         self.param_keys = [
             "batch_size",
             "beta",

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -3,7 +3,7 @@
 # Contains an implementation of PPO as described in: https://arxiv.org/abs/1707.06347
 
 import logging
-from collections import deque, defaultdict
+from collections import defaultdict
 from typing import List, Any
 
 import numpy as np
@@ -32,7 +32,9 @@ class PPOTrainer(Trainer):
         :param seed: The seed the model will be initialized with
         :param run_id: The identifier of the current run
         """
-        super(PPOTrainer, self).__init__(brain, trainer_parameters, training, run_id)
+        super(PPOTrainer, self).__init__(
+            brain, trainer_parameters, training, run_id, reward_buff_cap
+        )
         self.param_keys = [
             "batch_size",
             "beta",
@@ -79,8 +81,6 @@ class PPOTrainer(Trainer):
         self.stats = stats
 
         self.training_buffer = Buffer()
-
-        self._reward_buffer = deque(maxlen=reward_buff_cap)
         self.episode_steps = {}
 
     def __str__(self):
@@ -112,16 +112,6 @@ class PPOTrainer(Trainer):
         :return: the step count of the trainer
         """
         return self.step
-
-    @property
-    def reward_buffer(self):
-        """
-        Returns the reward buffer. The reward buffer contains the cumulative
-        rewards of the most recent episodes completed by agents using this
-        trainer.
-        :return: the reward buffer.
-        """
-        return self._reward_buffer
 
     def increment_step(self, n_steps: int) -> None:
         """

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -361,7 +361,7 @@ def test_start_learning_trains_until_max_steps_then_saves(tf_reset_graph):
     env_mock.reset.assert_called_once()
     assert tc.advance.call_count == trainer_mock.get_max_steps + 1
     env_mock.close.assert_called_once()
-    tc._save_model.assert_called_once_with(steps=6)
+    tc._save_model.assert_called_once()
 
 
 def test_start_learning_updates_meta_curriculum_lesson_number():

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -3,6 +3,7 @@ import logging
 import os
 import tensorflow as tf
 import numpy as np
+from collections import deque
 
 from mlagents.envs import UnityException, AllBrainInfo, ActionInfoOutputs
 from mlagents.trainers import TrainerMetrics
@@ -21,7 +22,7 @@ class UnityTrainerException(UnityException):
 class Trainer(object):
     """This class is the base class for the mlagents.envs.trainers"""
 
-    def __init__(self, brain, trainer_parameters, training, run_id):
+    def __init__(self, brain, trainer_parameters, training, run_id, reward_buff_cap=1):
         """
         Responsible for collecting experiences and training a neural network model.
         :BrainParameters brain: Brain to be trained.
@@ -44,6 +45,7 @@ class Trainer(object):
         )
         self.summary_writer = tf.summary.FileWriter(self.summary_path)
         self.policy = None
+        self._reward_buffer = deque(maxlen=reward_buff_cap)
 
     def __str__(self):
         return """{} Trainer""".format(self.__class__)
@@ -107,6 +109,16 @@ class Trainer(object):
         :return: the step count of the trainer
         """
         raise UnityTrainerException("The get_step property was not implemented.")
+
+    @property
+    def reward_buffer(self):
+        """
+        Returns the reward buffer. The reward buffer contains the cumulative
+        rewards of the most recent episodes completed by agents using this
+        trainer.
+        :return: the reward buffer.
+        """
+        return self._reward_buffer
 
     def increment_step(self, n_steps: int) -> None:
         """


### PR DESCRIPTION
* Removes unused SubprocessEnvManager import in trainer_controller
* Removes unused `steps` argument to `TrainerController._save_model`
* Consolidates unnecessary branching for curricula in
  `TrainerController.advance`
* Moves `reward_buffer` into `TFPolicy` from `PPOPolicy` and adds
  `BCTrainer` support so that we don't have a broken interface /
  undefined behavior when BCTrainer is used with curricula.