### PR TITLE
Add markdown link check to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,4 @@ repos:
         language_version: 12.6.0
         types: [markdown]
         additional_dependencies: ['markdown-link-check@3.7.3']
+        #args: [--verbose]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
         entry: markdown-link-check
         language: node
         language_version: 12.6.0
+        exclude: localized
         types: [markdown]
         additional_dependencies: ['markdown-link-check@3.7.3']
-        #args: [--verbose]
+        args: [-c, markdown-link-check.config.json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,13 @@ repos:
                 .*_pb2.py|
                 .*_pb2_grpc.py
             )$
+# "Local" hooks, see https://pre-commit.com/#repository-local-hooks
+-   repo: local
+    hooks:
+    -   id: markdown-link-check
+        name: markdown-link-check
+        entry: markdown-link-check
+        language: node
+        language_version: 12.6.0
+        types: [markdown]
+        additional_dependencies: ['markdown-link-check@3.7.3']

--- a/docs/Training-PPO.md
+++ b/docs/Training-PPO.md
@@ -220,7 +220,7 @@ Typical Range: `0.1` - `0.5`
 ### Demo Path
 
 `demo_path` is the path to your `.demo` file or directory of `.demo` files. 
-See the [imitation learning guide](Training-ImitationLearning.md) for more on `.demo` files.
+See the [imitation learning guide](Training-Imitation-Learning.md) for more on `.demo` files.
 
 ### Steps
 

--- a/docs/Training-RewardSignals.md
+++ b/docs/Training-RewardSignals.md
@@ -156,7 +156,7 @@ Typical Range: `0.8` - `0.9`
 #### Demo Path
 
 `demo_path` is the path to your `.demo` file or directory of `.demo` files. See the [imitation learning guide]
-(Training-ImitationLearning.md).
+(Training-Imitation-Learning.md).
 
 #### Encoding Size
 

--- a/docs/Training-on-Microsoft-Azure.md
+++ b/docs/Training-on-Microsoft-Azure.md
@@ -10,7 +10,7 @@ support.
 
 A pre-configured virtual machine image is available in the Azure Marketplace and
 is nearly completely ready for training.  You can start by deploying the
-[Data Science Virtual Machine for Linux (Ubuntu)](https://azuremarketplace.microsoft.com/marketplace/apps/microsoft-ads.linux-data-science-vm-ubuntu)
+[Data Science Virtual Machine for Linux (Ubuntu)](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-dsvm.linux-data-science-vm-ubuntu)
 into your Azure subscription.  Once your VM is deployed, SSH into it and run the
 following command to complete dependency installation:
 

--- a/docs/localized/zh-CN/README.md
+++ b/docs/localized/zh-CN/README.md
@@ -32,7 +32,7 @@ TensorFlow），让游戏开发者和业余爱好者能够轻松地
 **除了安装和使用说明外，如需更多信息，
 请参阅我们的[文档主页](docs/Readme.md)。**如果您使用的
 是 v0.3 之前的 ML-Agents 版本，强烈建议您参考
-我们的[关于迁移到 v0.3 的指南](/docs/Migrating.md)。
+我们的[关于迁移到 v0.3 的指南](../../../docs/Migrating.md)。
 
 我们还发布了一系列与 ML-Agents 相关的博客文章：
 - reinforcement learning（强化学习）概念概述
@@ -53,8 +53,8 @@ TensorFlow），让游戏开发者和业余爱好者能够轻松地
 
 ML-Agents 是一个开源项目，我们鼓励并欢迎大家贡献自己的力量。
 如果您想做出贡献，请务必查看我们的
-[贡献准则](/CONTRIBUTING.md)和
-[行为准则](/CODE_OF_CONDUCT.md)。
+[贡献准则](../../../CONTRIBUTING.md)和
+[行为准则](../../../CODE_OF_CONDUCT.md)。
 
 您可以通过 Unity Connect 和 GitHub 与我们以及更广泛的社区进行交流：
 * 加入我们的 
@@ -71,4 +71,4 @@ ML-Agents 是一个开源项目，我们鼓励并欢迎大家贡献自己的力�
 
 ## 许可证
 
-[Apache 许可证 2.0](LICENSE)
+[Apache 许可证 2.0](../../../LICENSE)

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -1,0 +1,10 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^http://localhost"
+        },
+        {
+            "pattern": "^https://developer.nvidia.com/compute/machine-learning/cudnn/secure"
+        }
+    ]
+}


### PR DESCRIPTION
Automates part of the release process. Expecting this to fail in the short term; need to whitelist some things (like localhost:6006 for tensorboard)