### PR TITLE
Change samplers to use random state to allow consistency in reset par…

### DIFF
--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -22,7 +22,7 @@ class UniformSampler(Sampler):
         self,
         min_value: Union[int, float],
         max_value: Union[int, float],
-        seed:Optional[int]=None,
+        seed: Optional[int] = None,
         **kwargs
     ) -> None:
         self.min_value = min_value
@@ -45,7 +45,7 @@ class MultiRangeUniformSampler(Sampler):
     def __init__(
         self,
         intervals: List[List[Union[int, float]]],
-        seed:Optional[int]=None,
+        seed: Optional[int] = None,
         **kwargs
     ) -> None:
         self.intervals = intervals
@@ -74,7 +74,7 @@ class GaussianSampler(Sampler):
         self,
         mean: Union[float, int],
         st_dev: Union[float, int],
-        seed:Optional[int]=None,
+        seed: Optional[int] = None,
         **kwargs
     ) -> None:
         self.mean = mean
@@ -104,7 +104,7 @@ class SamplerFactory:
 
     @staticmethod
     def init_sampler_class(
-        name: str, params: Dict[str, Any], seed:Optional[int]=None
+        name: str, params: Dict[str, Any], seed: Optional[int] = None
     ) -> None:
         if name not in SamplerFactory.NAME_TO_CLASS:
             raise SamplerException(
@@ -126,7 +126,7 @@ class SamplerFactory:
 
 class SamplerManager:
     def __init__(
-        self, reset_param_dict: Dict[str, Any], seed:Optional[int]=None
+        self, reset_param_dict: Dict[str, Any], seed: Optional[int] = None
     ) -> None:
         self.reset_param_dict = reset_param_dict if reset_param_dict else {}
         assert isinstance(self.reset_param_dict, dict)

--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -19,7 +19,7 @@ class UniformSampler(Sampler):
     """
 
     def __init__(
-        self, min_value: Union[int, float], max_value: Union[int, float], seed: Optional[int], **kwargs
+        self, min_value: Union[int, float], max_value: Union[int, float], seed:Optional[int]=None, **kwargs
     ) -> None:
         self.min_value = min_value
         self.max_value = max_value
@@ -38,7 +38,7 @@ class MultiRangeUniformSampler(Sampler):
     it proceeds to pick a value uniformly in that range.
     """
 
-    def __init__(self, intervals: List[List[Union[int, float]]], seed: Optional[int] = None, **kwargs) -> None:
+    def __init__(self, intervals: List[List[Union[int, float]]], seed:Optional[int]=None, **kwargs) -> None:
         self.intervals = intervals
         # Measure the length of the intervals
         interval_lengths = [abs(x[1] - x[0]) for x in self.intervals]
@@ -62,7 +62,7 @@ class GaussianSampler(Sampler):
     """
 
     def __init__(
-        self, mean: Union[float, int], st_dev: Union[float, int], seed=Optional[int], **kwargs
+        self, mean: Union[float, int], st_dev: Union[float, int], seed:Optional[int]=None, **kwargs
     ) -> None:
         self.mean = mean
         self.st_dev = st_dev
@@ -90,7 +90,7 @@ class SamplerFactory:
         SamplerFactory.NAME_TO_CLASS[name] = sampler_cls
 
     @staticmethod
-    def init_sampler_class(name: str, params: Dict[str, Any], seed):
+    def init_sampler_class(name: str, params: Dict[str, Any], seed:Optional[int]=None):
         if name not in SamplerFactory.NAME_TO_CLASS:
             raise SamplerException(
                 name + " sampler is not registered in the SamplerFactory."
@@ -110,7 +110,7 @@ class SamplerFactory:
 
 
 class SamplerManager:
-    def __init__(self, reset_param_dict: Dict[str, Any], seed=Optional[int]) -> None:
+    def __init__(self, reset_param_dict: Dict[str, Any], seed:Optional[int]=None) -> None:
         self.reset_param_dict = reset_param_dict if reset_param_dict else {}
         assert isinstance(self.reset_param_dict, dict)
         self.samplers: Dict[str, Sampler] = {}

--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -19,7 +19,11 @@ class UniformSampler(Sampler):
     """
 
     def __init__(
-        self, min_value: Union[int, float], max_value: Union[int, float], seed:Optional[int]=None, **kwargs
+        self,
+        min_value: Union[int, float],
+        max_value: Union[int, float],
+        seed:Optional[int]=None,
+        **kwargs
     ) -> None:
         self.min_value = min_value
         self.max_value = max_value
@@ -38,7 +42,12 @@ class MultiRangeUniformSampler(Sampler):
     it proceeds to pick a value uniformly in that range.
     """
 
-    def __init__(self, intervals: List[List[Union[int, float]]], seed:Optional[int]=None, **kwargs) -> None:
+    def __init__(
+        self,
+        intervals: List[List[Union[int, float]]],
+        seed:Optional[int]=None,
+        **kwargs
+    ) -> None:
         self.intervals = intervals
         # Measure the length of the intervals
         interval_lengths = [abs(x[1] - x[0]) for x in self.intervals]
@@ -62,7 +71,11 @@ class GaussianSampler(Sampler):
     """
 
     def __init__(
-        self, mean: Union[float, int], st_dev: Union[float, int], seed:Optional[int]=None, **kwargs
+        self,
+        mean: Union[float, int],
+        st_dev: Union[float, int],
+        seed:Optional[int]=None,
+        **kwargs
     ) -> None:
         self.mean = mean
         self.st_dev = st_dev
@@ -90,7 +103,9 @@ class SamplerFactory:
         SamplerFactory.NAME_TO_CLASS[name] = sampler_cls
 
     @staticmethod
-    def init_sampler_class(name: str, params: Dict[str, Any], seed:Optional[int]=None):
+    def init_sampler_class(
+        name: str, params: Dict[str, Any], seed:Optional[int]=None
+    ) -> None:
         if name not in SamplerFactory.NAME_TO_CLASS:
             raise SamplerException(
                 name + " sampler is not registered in the SamplerFactory."
@@ -110,7 +125,9 @@ class SamplerFactory:
 
 
 class SamplerManager:
-    def __init__(self, reset_param_dict: Dict[str, Any], seed:Optional[int]=None) -> None:
+    def __init__(
+        self, reset_param_dict: Dict[str, Any], seed:Optional[int]=None
+    ) -> None:
         self.reset_param_dict = reset_param_dict if reset_param_dict else {}
         assert isinstance(self.reset_param_dict, dict)
         self.samplers: Dict[str, Sampler] = {}

--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -23,6 +23,7 @@ class UniformSampler(Sampler):
     ) -> None:
         self.min_value = min_value
         self.max_value = max_value
+        # Draw from random state to allow for consistent reset parameter draw for a seed
         self.random_state = np.random.RandomState(seed)
 
     def sample_parameter(self) -> float:
@@ -44,6 +45,7 @@ class MultiRangeUniformSampler(Sampler):
         cum_interval_length = sum(interval_lengths)
         # Assign weights to an interval proportionate to the interval size
         self.interval_weights = [x / cum_interval_length for x in interval_lengths]
+        # Draw from random state to allow for consistent reset parameter draw for a seed
         self.random_state = np.random.RandomState(seed)
 
     def sample_parameter(self) -> float:
@@ -64,6 +66,7 @@ class GaussianSampler(Sampler):
     ) -> None:
         self.mean = mean
         self.st_dev = st_dev
+        # Draw from random state to allow for consistent reset parameter draw for a seed
         self.random_state = np.random.RandomState(seed)
 
     def sample_parameter(self) -> float:

--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -25,7 +25,7 @@ class UniformSampler(Sampler):
         seed: Optional[int] = None,
         **kwargs
     ) -> None:
-        """            
+        """
         :param min_value: minimum value of the range to be sampled uniformly from
         :param max_value: maximum value of the range to be sampled uniformly from
         :param seed: Random seed used for making draws from the uniform sampler

--- a/ml-agents-envs/mlagents/envs/sampler_class.py
+++ b/ml-agents-envs/mlagents/envs/sampler_class.py
@@ -105,7 +105,7 @@ class SamplerFactory:
     @staticmethod
     def init_sampler_class(
         name: str, params: Dict[str, Any], seed: Optional[int] = None
-    ) -> None:
+    ) -> Sampler:
         if name not in SamplerFactory.NAME_TO_CLASS:
             raise SamplerException(
                 name + " sampler is not registered in the SamplerFactory."

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -91,7 +91,7 @@ def run_training(
     env = SubprocessEnvManager(env_factory, num_envs)
     maybe_meta_curriculum = try_create_meta_curriculum(curriculum_folder, env)
     sampler_manager, resampling_interval = create_sampler_manager(
-        sampler_file_path, env.reset_parameters
+        sampler_file_path, env.reset_parameters, run_seed
     )
 
     # Create controller and begin training.
@@ -118,7 +118,7 @@ def run_training(
     tc.start_learning(env, trainer_config)
 
 
-def create_sampler_manager(sampler_file_path, env_reset_params):
+def create_sampler_manager(sampler_file_path, env_reset_params, run_seed):
     sampler_config = None
     resample_interval = None
     if sampler_file_path is not None:
@@ -136,7 +136,7 @@ def create_sampler_manager(sampler_file_path, env_reset_params):
                 "Resampling interval was not specified in the sampler file."
                 " Please specify it with the 'resampling-interval' key in the sampler config file."
             )
-    sampler_manager = SamplerManager(sampler_config)
+    sampler_manager = SamplerManager(sampler_config, run_seed)
     return sampler_manager, resample_interval
 
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -118,7 +118,7 @@ def run_training(
     tc.start_learning(env, trainer_config)
 
 
-def create_sampler_manager(sampler_file_path, env_reset_params, run_seed = None):
+def create_sampler_manager(sampler_file_path, env_reset_params, run_seed=None):
     sampler_config = None
     resample_interval = None
     if sampler_file_path is not None:

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -118,7 +118,7 @@ def run_training(
     tc.start_learning(env, trainer_config)
 
 
-def create_sampler_manager(sampler_file_path, env_reset_params, run_seed):
+def create_sampler_manager(sampler_file_path, env_reset_params, run_seed = None):
     sampler_config = None
     resample_interval = None
     if sampler_file_path is not None:


### PR DESCRIPTION
Instead of sampling reset parameters directly from numpy, use the np.random_state to allow a fixed sequence of reset param values for a specified seed. 