### PR TITLE
Fix naming conflict between Curiosity and GAIL

### DIFF
--- a/ml-agents/mlagents/trainers/components/reward_signals/curiosity/model.py
+++ b/ml-agents/mlagents/trainers/components/reward_signals/curiosity/model.py
@@ -42,7 +42,7 @@ class CuriosityModel(object):
                 # Create input ops for next (t+1) visual observations.
                 next_visual_input = LearningModel.create_visual_input(
                     self.policy_model.brain.camera_resolutions[i],
-                    name="next_visual_observation_" + str(i),
+                    name="curiosity_next_visual_observation_" + str(i),
                 )
                 self.next_visual_in.append(next_visual_input)
 
@@ -53,7 +53,7 @@ class CuriosityModel(object):
                     self.encoding_size,
                     LearningModel.swish,
                     1,
-                    "stream_{}_visual_obs_encoder".format(i),
+                    "curiosity_stream_{}_visual_obs_encoder".format(i),
                     False,
                 )
 
@@ -62,7 +62,7 @@ class CuriosityModel(object):
                     self.encoding_size,
                     LearningModel.swish,
                     1,
-                    "stream_{}_visual_obs_encoder".format(i),
+                    "curiosity_stream_{}_visual_obs_encoder".format(i),
                     True,
                 )
                 visual_encoders.append(encoded_visual)
@@ -80,7 +80,7 @@ class CuriosityModel(object):
             self.next_vector_in = tf.placeholder(
                 shape=[None, self.policy_model.vec_obs_size],
                 dtype=tf.float32,
-                name="next_vector_observation",
+                name="curiosity_next_vector_observation",
             )
 
             encoded_vector_obs = self.policy_model.create_vector_observation_encoder(
@@ -88,7 +88,7 @@ class CuriosityModel(object):
                 self.encoding_size,
                 LearningModel.swish,
                 2,
-                "vector_obs_encoder",
+                "curiosity_vector_obs_encoder",
                 False,
             )
             encoded_next_vector_obs = self.policy_model.create_vector_observation_encoder(
@@ -96,7 +96,7 @@ class CuriosityModel(object):
                 self.encoding_size,
                 LearningModel.swish,
                 2,
-                "vector_obs_encoder",
+                "curiosity_vector_obs_encoder",
                 True,
             )
             encoded_state_list.append(encoded_vector_obs)

--- a/ml-agents/mlagents/trainers/components/reward_signals/gail/model.py
+++ b/ml-agents/mlagents/trainers/components/reward_signals/gail/model.py
@@ -112,7 +112,7 @@ class GAILModel(object):
                 # Create input ops for next (t+1) visual observations.
                 visual_input = self.policy_model.create_visual_input(
                     self.policy_model.brain.camera_resolutions[i],
-                    name="visual_observation_" + str(i),
+                    name="gail_visual_observation_" + str(i),
                 )
                 self.expert_visual_in.append(visual_input)
 
@@ -121,7 +121,7 @@ class GAILModel(object):
                     self.encoding_size,
                     LearningModel.swish,
                     1,
-                    "stream_{}_visual_obs_encoder".format(i),
+                    "gail_stream_{}_visual_obs_encoder".format(i),
                     False,
                 )
 
@@ -130,7 +130,7 @@ class GAILModel(object):
                     self.encoding_size,
                     LearningModel.swish,
                     1,
-                    "stream_{}_visual_obs_encoder".format(i),
+                    "gail_stream_{}_visual_obs_encoder".format(i),
                     True,
                 )
                 visual_policy_encoders.append(encoded_policy_visual)
@@ -163,7 +163,7 @@ class GAILModel(object):
                 concat_input,
                 self.h_size,
                 activation=LearningModel.swish,
-                name="d_hidden_1",
+                name="gail_d_hidden_1",
                 reuse=reuse,
             )
 
@@ -171,7 +171,7 @@ class GAILModel(object):
                 hidden_1,
                 self.h_size,
                 activation=LearningModel.swish,
-                name="d_hidden_2",
+                name="gail_d_hidden_2",
                 reuse=reuse,
             )
 
@@ -182,7 +182,7 @@ class GAILModel(object):
                     hidden_2,
                     self.z_size,
                     reuse=reuse,
-                    name="z_mean",
+                    name="gail_z_mean",
                     kernel_initializer=LearningModel.scaled_init(0.01),
                 )
 
@@ -198,7 +198,7 @@ class GAILModel(object):
                 estimate_input,
                 1,
                 activation=tf.nn.sigmoid,
-                name="d_estimate",
+                name="gail_d_estimate",
                 reuse=reuse,
             )
             return estimate, z_mean, concat_input
@@ -209,7 +209,7 @@ class GAILModel(object):
         """
         if self.use_vail:
             self.z_sigma = tf.get_variable(
-                "sigma_vail",
+                "gail_sigma_vail",
                 self.z_size,
                 dtype=tf.float32,
                 initializer=tf.ones_initializer(),
@@ -217,7 +217,7 @@ class GAILModel(object):
             self.z_sigma_sq = self.z_sigma * self.z_sigma
             self.z_log_sigma_sq = tf.log(self.z_sigma_sq + EPSILON)
             self.use_noise = tf.placeholder(
-                shape=[1], dtype=tf.float32, name="NoiseLevel"
+                shape=[1], dtype=tf.float32, name="gail_NoiseLevel"
             )
         self.expert_estimate, self.z_mean_expert, _ = self.create_encoder(
             self.encoded_expert, self.expert_action, self.done_expert, reuse=False
@@ -229,7 +229,7 @@ class GAILModel(object):
             reuse=True,
         )
         self.discriminator_score = tf.reshape(
-            self.policy_estimate, [-1], name="GAIL_reward"
+            self.policy_estimate, [-1], name="gail_reward"
         )
         self.intrinsic_reward = -tf.log(1.0 - self.discriminator_score + EPSILON)
 


### PR DESCRIPTION
- When using visual obs, enabling Curiosity and GAIL will cause an issue with the visual encoders (same scope name). This fixes that issue. 