### PR TITLE
python coverage: specify dirs, exclude test files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            pytest --cov=ml-agents --cov=ml-agents-envs --cov-report html --junitxml=test-reports/junit.xml -p no:warnings
+            pytest --cov=ml-agents --cov=ml-agents-envs --cov=gym-unity --cov-report html --junitxml=test-reports/junit.xml -p no:warnings
 
       - run:
           name: Check Code Style using pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            pytest --cov=ml-agents --cov=ml-agents-envs --cov-report xml --junitxml=test-reports/junit.xml -p no:warnings
+            pytest --cov=ml-agents --cov=ml-agents-envs --cov-report html --junitxml=test-reports/junit.xml -p no:warnings
 
       - run:
           name: Check Code Style using pre-commit
@@ -58,3 +58,6 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
+
+      - store_artifacts:
+          path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,3 +61,4 @@ jobs:
 
       - store_artifacts:
           path: htmlcov
+          destination: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            pytest --cov=mlagents --cov-report xml --junitxml=test-reports/junit.xml -p no:warnings
+            pytest --cov=ml-agents --cov=ml-agents-envs --cov-report xml --junitxml=test-reports/junit.xml -p no:warnings
 
       - run:
           name: Check Code Style using pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv/
 
 # Code coverage report
 .coverage
+coverage.xml
+/htmlcov/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[coverage:run]
+omit = */tests/*
+
 [coverage:report]
 # Run "pytest --cov=mlagents" to see the current coverage percentage.
 # Run "pytest --cov=mlagents --cov-report html" to get a nice visualization of what is/isn't coverge in html format.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 omit = */tests/*
 
 [coverage:report]
-# Run "pytest --cov=ml-agents --cov=ml-agents-envs" to see the current coverage percentage.
-# Run "pytest --cov=ml-agents --cov=ml-agents-envs --cov-report html" to get a nice visualization of what is/isn't coverge in html format.
+# Run "pytest --cov=ml-agents --cov=ml-agents-envs --cov=gym-unity" to see the current coverage percentage.
+# Run the above plus "--cov-report html" to get a nice visualization of what is/isn't covered in html format.
 fail_under = 60
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 omit = */tests/*
 
 [coverage:report]
-# Run "pytest --cov=mlagents" to see the current coverage percentage.
-# Run "pytest --cov=mlagents --cov-report html" to get a nice visualization of what is/isn't coverge in html format.
+# Run "pytest --cov=ml-agents --cov=ml-agents-envs" to see the current coverage percentage.
+# Run "pytest --cov=ml-agents --cov=ml-agents-envs --cov-report html" to get a nice visualization of what is/isn't coverge in html format.
 fail_under = 60
 
 


### PR DESCRIPTION
* When running coverage checks locally, I noticed it was excluding some files from counting (in particular, buffer.py). This seems to be a better way to specify and includes the expected files.
* Save the coverage results as html and upload them as artifacts in circleci. This is a bit noisy, but the main coverage results can be found in the `index.html` file.
* Exclude the test files from coverage calculations.

Example coverage result: https://1701-102904613-gh.circle-artifacts.com/0/htmlcov/index.html