### PR TITLE
initialize trainer step count

### DIFF
--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -36,7 +36,6 @@ class RLTrainer(Trainer):
 
     def __init__(self, *args, **kwargs):
         super(RLTrainer, self).__init__(*args, **kwargs)
-        self.step = 0
         # Make sure we have at least one reward_signal
         if not self.trainer_parameters["reward_signals"]:
             raise UnityTrainerException(

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -59,6 +59,7 @@ class Trainer(object):
         self.summary_writer = tf.summary.FileWriter(self.summary_path)
         self._reward_buffer: Deque[float] = deque(maxlen=reward_buff_cap)
         self.policy: Policy = None
+        self.step: int = 0
 
     def check_param_keys(self):
         for k in self.param_keys:


### PR DESCRIPTION
This was being used by `TrainerController._not_done_training()` before it was set in `Trainer.increment_step()`

We still need better test coverage on the BC trainers, but this fixes the immediate problem.

(as reported in https://github.com/Unity-Technologies/ml-agents/issues/2496)