### PR TITLE
Hotfix 0.9.3

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Examples/BananaCollectors/Scenes/BananaIL.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/BananaCollectors/Scenes/BananaIL.unity
@@ -719,7 +719,11 @@ MonoBehaviour:
     timeScale: 1
     targetFrameRate: 60
   resetParameters:
-    resetParameters: []
+    resetParameters:
+    - key: laser_length
+      value: 1
+    - key: agent_scale
+      value: 1
   agents: []
   listArea: []
   totalScore: 0

--- a/UnitySDK/Assets/ML-Agents/Examples/BananaCollectors/Scripts/BananaAgent.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/BananaCollectors/Scripts/BananaAgent.cs
@@ -30,7 +30,7 @@ public class BananaAgent : Agent
     public bool contribute;
     private RayPerception3D rayPer;
     public bool useVectorObs;
-  
+
 
     public override void InitializeAgent()
     {
@@ -106,7 +106,7 @@ public class BananaAgent : Agent
                 var rightAxis = (int)act[1];
                 var rotateAxis = (int)act[2];
                 var shootAxis = (int)act[3];
-                
+
                 switch (forwardAxis)
                 {
                     case 1:
@@ -116,7 +116,7 @@ public class BananaAgent : Agent
                         dirToGo = -transform.forward;
                         break;
                 }
-                
+
                 switch (rightAxis)
                 {
                     case 1:
@@ -134,7 +134,7 @@ public class BananaAgent : Agent
                         break;
                     case 2:
                         rotateDir = transform.up;
-                        break; 
+                        break;
                 }
                 switch (shootAxis)
                 {
@@ -279,15 +279,16 @@ public class BananaAgent : Agent
 
     public void SetLaserLengths()
     {
-        laser_length = myAcademy.resetParameters["laser_length"];
+        laser_length = myAcademy.resetParameters.TryGetValue("laser_length", out laser_length) ? laser_length: 1.0f;
     }
 
     public void SetAgentScale()
     {
-        var agent_scale = myAcademy.resetParameters["agent_scale"];
-        gameObject.transform.localScale = new Vector3(agent_scale, agent_scale, agent_scale);
+        float agentScale;
+        agentScale = myAcademy.resetParameters.TryGetValue("agent_scale", out agentScale) ? agentScale : 1.0f;
+        gameObject.transform.localScale = new Vector3(agentScale, agentScale, agentScale);
     }
-    
+
     public void SetResetParameters()
     {
         SetLaserLengths();

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -4,12 +4,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="gym_unity",
-    version="0.4.5",
+    version="0.4.6",
     description="Unity Machine Learning Agents Gym Interface",
     license="Apache License 2.0",
     author="Unity Technologies",
     author_email="ML-Agents@unity3d.com",
     url="https://github.com/Unity-Technologies/ml-agents",
     packages=find_packages(),
-    install_requires=["gym", "mlagents_envs==0.9.2"],
+    install_requires=["gym", "mlagents_envs==0.9.3"],
 )

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -5,7 +5,7 @@ here = path.abspath(path.dirname(__file__))
 
 setup(
     name="mlagents_envs",
-    version="0.9.2",
+    version="0.9.3",
     description="Unity Machine Learning Agents Interface",
     url="https://github.com/Unity-Technologies/ml-agents",
     author="Unity Technologies",

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -36,7 +36,6 @@ class RLTrainer(Trainer):
 
     def __init__(self, *args, **kwargs):
         super(RLTrainer, self).__init__(*args, **kwargs)
-        self.step = 0
         # Make sure we have at least one reward_signal
         if not self.trainer_parameters["reward_signals"]:
             raise UnityTrainerException(

--- a/ml-agents/mlagents/trainers/tests/mock_brain.py
+++ b/ml-agents/mlagents/trainers/tests/mock_brain.py
@@ -91,12 +91,13 @@ def setup_mock_unityenvironment(mock_env, mock_brain, mock_braininfo):
     :Mock mock_brain: A mock Brain object that specifies the params of this environment.
     :Mock mock_braininfo: A mock BrainInfo object that will be returned at each step and reset.
     """
+    brain_name = mock_brain.brain_name
     mock_env.return_value.academy_name = "MockAcademy"
-    mock_env.return_value.brains = {"MockBrain": mock_brain}
-    mock_env.return_value.external_brain_names = ["MockBrain"]
-    mock_env.return_value.brain_names = ["MockBrain"]
-    mock_env.return_value.reset.return_value = {"MockBrain": mock_braininfo}
-    mock_env.return_value.step.return_value = {"MockBrain": mock_braininfo}
+    mock_env.return_value.brains = {brain_name: mock_brain}
+    mock_env.return_value.external_brain_names = [brain_name]
+    mock_env.return_value.brain_names = [brain_name]
+    mock_env.return_value.reset.return_value = {brain_name: mock_braininfo}
+    mock_env.return_value.step.return_value = {brain_name: mock_braininfo}
 
 
 def simulate_rollout(env, policy, buffer_init_samples):

--- a/ml-agents/mlagents/trainers/tests/test_bc.py
+++ b/ml-agents/mlagents/trainers/tests/test_bc.py
@@ -18,9 +18,9 @@ from mlagents.envs.mock_communicator import MockCommunicator
 def dummy_config():
     return yaml.safe_load(
         """
-            hidden_units: 128
+            hidden_units: 32
             learning_rate: 3.0e-4
-            num_layers: 2
+            num_layers: 1
             use_recurrent: false
             sequence_length: 32
             memory_size: 32
@@ -32,8 +32,8 @@ def dummy_config():
     )
 
 
-@mock.patch("mlagents.envs.UnityEnvironment")
-def test_bc_trainer(mock_env, dummy_config):
+def create_bc_trainer(dummy_config):
+    mock_env = mock.Mock()
     mock_brain = mb.create_mock_3dball_brain()
     mock_braininfo = mb.create_mock_braininfo(num_agents=12, num_vector_observations=8)
     mb.setup_mock_unityenvironment(mock_env, mock_brain, mock_braininfo)
@@ -49,10 +49,52 @@ def test_bc_trainer(mock_env, dummy_config):
         mock_brain, trainer_parameters, training=True, load=False, seed=0, run_id=0
     )
     trainer.demonstration_buffer = mb.simulate_rollout(env, trainer.policy, 100)
+    return trainer, env
+
+
+def test_bc_trainer_step(dummy_config):
+    trainer, env = create_bc_trainer(dummy_config)
+    # Test get_step
+    assert trainer.get_step == 0
+    # Test update policy
     trainer.update_policy()
     assert len(trainer.stats["Losses/Cloning Loss"]) > 0
+    # Test increment step
     trainer.increment_step(1)
     assert trainer.step == 1
+
+
+def test_bc_trainer_add_proc_experiences(dummy_config):
+    trainer, env = create_bc_trainer(dummy_config)
+    # Test add_experiences
+    returned_braininfo = env.step()
+    trainer.add_experiences(
+        returned_braininfo, returned_braininfo, {}
+    )  # Take action outputs is not used
+    for agent_id in returned_braininfo["Ball3DBrain"].agents:
+        assert trainer.evaluation_buffer[agent_id].last_brain_info is not None
+        assert trainer.episode_steps[agent_id] > 0
+        assert trainer.cumulative_rewards[agent_id] > 0
+    # Test process_experiences by setting done
+    returned_braininfo["Ball3DBrain"].local_done = 12 * [True]
+    trainer.process_experiences(returned_braininfo, returned_braininfo)
+    for agent_id in returned_braininfo["Ball3DBrain"].agents:
+        assert trainer.episode_steps[agent_id] == 0
+        assert trainer.cumulative_rewards[agent_id] == 0
+
+
+def test_bc_trainer_end_episode(dummy_config):
+    trainer, env = create_bc_trainer(dummy_config)
+    returned_braininfo = env.step()
+    trainer.add_experiences(
+        returned_braininfo, returned_braininfo, {}
+    )  # Take action outputs is not used
+    trainer.process_experiences(returned_braininfo, returned_braininfo)
+    # Should set everything to 0
+    trainer.end_episode()
+    for agent_id in returned_braininfo["Ball3DBrain"].agents:
+        assert trainer.episode_steps[agent_id] == 0
+        assert trainer.cumulative_rewards[agent_id] == 0
 
 
 @mock.patch("mlagents.envs.UnityEnvironment.executable_launcher")

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -59,6 +59,7 @@ class Trainer(object):
         self.summary_writer = tf.summary.FileWriter(self.summary_path)
         self._reward_buffer: Deque[float] = deque(maxlen=reward_buff_cap)
         self.policy: Policy = None
+        self.step: int = 0
 
     def check_param_keys(self):
         for k in self.param_keys:

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="mlagents",
-    version="0.9.2",
+    version="0.9.3",
     description="Unity Machine Learning Agents",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,7 +29,7 @@ setup(
     ),
     zip_safe=False,
     install_requires=[
-        "mlagents_envs==0.9.2",
+        "mlagents_envs==0.9.3",
         "tensorflow>=1.7,<1.8",
         "Pillow>=4.2.1",
         "matplotlib",


### PR DESCRIPTION
* Fixed a bug in BCTrainer that would cause it to raise an exception when starting training (https://github.com/Unity-Technologies/ml-agents/pull/2505)
* Fixed a bug in the BananaIL scene that made it unplayable, due to missing reset parameters (https://github.com/Unity-Technologies/ml-agents/pull/2512)