### PR TITLE
When checking for the compatibility of the expert brain with the poli…

### DIFF
--- a/ml-agents/mlagents/trainers/bc/offline_trainer.py
+++ b/ml-agents/mlagents/trainers/bc/offline_trainer.py
@@ -57,6 +57,8 @@ class OfflineBCTrainer(BCTrainer):
         expert_brain = copy.deepcopy(brain_params.__dict__)
         policy_brain.pop("brain_name")
         expert_brain.pop("brain_name")
+        policy_brain.pop("vector_action_descriptions")
+        expert_brain.pop("vector_action_descriptions")
         if expert_brain != policy_brain:
             raise UnityTrainerException(
                 "The provided demonstration is not compatible with the "


### PR DESCRIPTION
…cy brain, we will remove the action descriptions from the dictionary of things we need to compare. This is to prevent the case where a user has different descriptions for his actions but still wants to train a brain using expert demonstrations.