### PR TITLE
unit test - don't use global random generator

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -94,7 +94,7 @@ class Simple1DEnvironment(BaseUnityEnvironment):
     def _reset_agent(self):
         self.position = 0.0
         self.step_count = 0
-        self.goal = random.choice([-1, 1])
+        self.goal = self.random.choice([-1, 1])
 
     def reset(
         self,

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -52,7 +52,7 @@ class Simple1DEnvironment(BaseUnityEnvironment):
         self.position = 0.0
         self.step_count = 0
         self.random = random.Random(str(self._brains))
-        self.goal = random.choice([-1, 1])
+        self.goal = self.random.choice([-1, 1])
 
     def step(
         self,


### PR DESCRIPTION
(hopefully) make this test more deterministic. It's creating its own `random.Random` instance but not using it.