### PR TITLE
Fixes missing camera resolution info in demos

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/DemonstrationDrawer.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/DemonstrationDrawer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Net.NetworkInformation;
+using System.Text;
 using MLAgents;
 using UnityEditor;
 
@@ -60,6 +61,29 @@ public class DemonstrationEditor : Editor
     }
 
     /// <summary>
+    /// Constructs complex label for each CameraResolution object.
+    /// </summary>
+    static string BuildCameraResolutionLabel(SerializedProperty cameraArray)
+    {
+        var numCameras = cameraArray.arraySize;
+        StringBuilder cameraLabel = new StringBuilder("[ ");
+        for (int i = 0; i < numCameras; i++)
+        {
+            cameraLabel.Append(cameraArray.GetArrayElementAtIndex(i).FindPropertyRelative("height").intValue);
+            cameraLabel.Append(" X ");
+            cameraLabel.Append(cameraArray.GetArrayElementAtIndex(i).FindPropertyRelative("width").intValue);
+            if (i < numCameras - 1)
+            {
+                cameraLabel.Append(", ");
+            }
+        }
+
+        cameraLabel.Append(" ]");
+        return cameraLabel.ToString();
+
+    }
+
+    /// <summary>
     /// Renders Inspector UI for Brain Parameters of Demonstration.
     /// </summary>
     void MakeBrainParametersProperty(SerializedProperty property)
@@ -73,7 +97,7 @@ public class DemonstrationEditor : Editor
         var vecObsSizeLabel = vecObsSizeProp.displayName + ": " + vecObsSizeProp.intValue;
         var numStackedLabel = numStackedProp.displayName + ": " + numStackedProp.intValue;
         var vecActSizeLabel = actSizeProperty.displayName + ": " + BuildActionArrayLabel(actSizeProperty);
-        var camResLabel = camResProp.displayName + ": " + camResProp.arraySize;
+        var camResLabel = camResProp.displayName + ": " + BuildCameraResolutionLabel(camResProp);
         var actSpaceTypeLabel = actSpaceTypeProp.displayName + ": " + (SpaceType) actSpaceTypeProp.enumValueIndex;
 
         EditorGUILayout.LabelField(vecObsSizeLabel);

--- a/UnitySDK/Assets/ML-Agents/Scripts/BrainParameters.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/BrainParameters.cs
@@ -95,9 +95,28 @@ namespace MLAgents
             
         }
 
+        /// <summary>
+        /// Converts Resolution array protobuf to C# Resolution array.
+        /// </summary>
+        static Resolution[] CameraProtoToNative(CommunicatorObjects.ResolutionProto[] resolutionProtos)
+        {
+            Resolution[] localCameraResolutions = new Resolution[resolutionProtos.Length];
+            for (int i = 0; i < resolutionProtos.Length; i++)
+            {
+                localCameraResolutions[i] = new Resolution
+                {
+                    height = resolutionProtos[i].Height,
+                    width = resolutionProtos[i].Width,
+                    blackAndWhite = resolutionProtos[i].GrayScale
+                };
+            }
+            return localCameraResolutions;
+        }
+
         public BrainParameters(CommunicatorObjects.BrainParametersProto brainParametersProto)
         {
             vectorObservationSize = brainParametersProto.VectorObservationSize;
+            cameraResolutions = CameraProtoToNative(brainParametersProto.CameraResolutions.ToArray());
             numStackedVectorObservations = brainParametersProto.NumStackedVectorObservations;
             vectorActionSize = brainParametersProto.VectorActionSize.ToArray();
             vectorActionDescriptions = brainParametersProto.VectorActionDescriptions.ToArray();


### PR DESCRIPTION
We were not reporting camera resolution information in the demonstration file. This addresses this, and ensures it is printed in the inspector correctly as well.