### PR TITLE
Fix determinism in unit test

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -38,7 +38,7 @@ class Simple1DEnvironment(BaseUnityEnvironment):
         super().__init__()
         self.discrete = use_discrete
         self._brains: Dict[str, BrainParameters] = {}
-        self._brains[BRAIN_NAME] = BrainParameters(
+        brain_params = BrainParameters(
             brain_name=BRAIN_NAME,
             vector_observation_space_size=OBS_SIZE,
             num_stacked_vector_observations=1,
@@ -47,11 +47,12 @@ class Simple1DEnvironment(BaseUnityEnvironment):
             vector_action_descriptions=["moveDirection"],
             vector_action_space_type=0 if use_discrete else 1,
         )
+        self._brains[BRAIN_NAME] = brain_params
 
         # state
         self.position = 0.0
         self.step_count = 0
-        self.random = random.Random(str(self._brains))
+        self.random = random.Random(str(brain_params))
         self.goal = self.random.choice([-1, 1])
 
     def step(

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -229,7 +229,7 @@ def _check_environment_trains(env, config):
         print(tc._get_measure_vals())
         for brain_name, mean_reward in tc._get_measure_vals().items():
             assert not math.isnan(mean_reward)
-            assert mean_reward > 0.9
+            assert mean_reward > 0.99
 
 
 @pytest.mark.parametrize("use_discrete", [True, False])


### PR DESCRIPTION
Turns out `str(dict)` doesn’t call the `__str__` method on the values of the dict, so the seed was something like `{'trainers.tests.test_simple_rl': <mlagents.envs.brain.BrainParameters object at 0x1311ad400>}`

I also restored the threshold that was lowered in https://github.com/Unity-Technologies/ml-agents/pull/2520