### PR TITLE
Add a note on Custom messages about needing trainer changes

### DIFF
--- a/docs/Creating-Custom-Protobuf-Messages.md
+++ b/docs/Creating-Custom-Protobuf-Messages.md
@@ -1,5 +1,5 @@
 # Disclaimer
-> *NOTE:* `CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
+*NOTE:* `CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
 
 # Creating Custom Protobuf Messages
 

--- a/docs/Creating-Custom-Protobuf-Messages.md
+++ b/docs/Creating-Custom-Protobuf-Messages.md
@@ -1,5 +1,5 @@
 # Disclaimer
-*NOTE:* `CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
+*NOTE:* `CustomAction` and `CustomObservation` are meant for researchers who intend to use the resulting environments with their own training code. In addition to implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; we don't recommend modifying our trainer code, or using this feature unless you know what you are doing and have a very specific use-case in mind. *Proceed at your own risk*.
 
 # Creating Custom Protobuf Messages
 

--- a/docs/Creating-Custom-Protobuf-Messages.md
+++ b/docs/Creating-Custom-Protobuf-Messages.md
@@ -1,10 +1,9 @@
+# Disclaimer
+> *NOTE:* `CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
+
 # Creating Custom Protobuf Messages
 
 Unity and Python communicate by sending protobuf messages to and from each other. You can create custom protobuf messages if you want to exchange structured data beyond what is included by default. 
-
-<aside class="warning">
-`CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
-</aside>
 
 ## Implementing a Custom Message
 

--- a/docs/Creating-Custom-Protobuf-Messages.md
+++ b/docs/Creating-Custom-Protobuf-Messages.md
@@ -2,6 +2,10 @@
 
 Unity and Python communicate by sending protobuf messages to and from each other. You can create custom protobuf messages if you want to exchange structured data beyond what is included by default. 
 
+<aside class="warning">
+`CustomAction` and `CustomObservation` are intended for expert users. In addition implementing a custom message, you will also need to make extensive modifications to the trainer in order to produce custom actions or consume custom observations; these modifications are not supported nor documented. *Proceed at your own risk*.
+</aside>
+
 ## Implementing a Custom Message
 
 Whenever you change the fields of a custom message, you must follow the directions in [this file](../protobuf-definitions/README.md) to create C# and Python files corresponding to the new message and re-install the mlagents Python package.


### PR DESCRIPTION
Followup from in-person discussion. The current documentation undersells the amount of effort needed to get Custom* working.