### PR TITLE
WIP: Enable finetuning from previous models 

### DIFF
--- a/ml-agents/mlagents/trainers/bc/policy.py
+++ b/ml-agents/mlagents/trainers/bc/policy.py
@@ -31,7 +31,7 @@ class BCPolicy(TFPolicy):
                 )
 
         if load:
-            self._load_graph()
+            self.load_or_finetune_graph(trainer_parameters)
         else:
             self._initialize_graph()
 

--- a/ml-agents/mlagents/trainers/ppo/policy.py
+++ b/ml-agents/mlagents/trainers/ppo/policy.py
@@ -56,7 +56,7 @@ class PPOPolicy(TFPolicy):
                 self.bc_module = None
 
         if load:
-            self._load_graph()
+            self.load_or_finetune_graph(trainer_params)
         else:
             self._initialize_graph()
 

--- a/ml-agents/mlagents/trainers/sac/policy.py
+++ b/ml-agents/mlagents/trainers/sac/policy.py
@@ -77,7 +77,7 @@ class SACPolicy(TFPolicy):
                 self.bc_module = None
 
         if load:
-            self._load_graph()
+            self.load_or_finetune_graph(trainer_params)
         else:
             self._initialize_graph()
             self.sess.run(self.model.target_init_op)

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -93,7 +93,7 @@ class TFPolicy(Policy):
         """
         Loads the graph either fresh, or in finetune mode.
         """
-        if trainer_parameters["finetune_path"]:
+        if "finetune_path" in trainer_parameters:
             self._load_graph(
                 finetune=True, model_load_path=trainer_parameters["finetune_path"]
             )


### PR DESCRIPTION
@awjuliani remembered that finetuning was actually a pretty heavily requested feature from users, so might as well put it in :P 

@awjuliani @vincentpierre Wanted to get your thoughts on UI for something like this. In this PR, it requires the user to put into the trainer_config the _full path_ to the model (e.g. `models/run_id-0/BrainName`) and run with `--load`. We could also:

- Automatically load even without `--load`, if a `finetune_path` is provided. 
- Require that the brain names match