### PR TITLE
Add clearer message for bad permissions

### DIFF
--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -245,21 +245,21 @@ class UnityEnvironment(BaseUnityEnvironment):
             logger.debug("This is the launch string {}".format(launch_string))
             # Launch Unity environment
             if not docker_training:
+                subprocess_args = [launch_string]
                 if no_graphics:
-                    self.proc1 = subprocess.Popen(
-                        [
-                            launch_string,
-                            "-nographics",
-                            "-batchmode",
-                            "--port",
-                            str(self.port),
-                        ]
-                        + args
-                    )
-                else:
-                    self.proc1 = subprocess.Popen(
-                        [launch_string, "--port", str(self.port)] + args
-                    )
+                    subprocess_args += ["-nographics", "-batchmode"]
+                subprocess_args += ["--port", str(self.port)]
+                subprocess_args += args
+                try:
+                    self.proc1 = subprocess.Popen(subprocess_args)
+                except PermissionError as perm:
+                    # This is likely due to missing read or execute permissions on file.
+                    raise UnityEnvironmentException(
+                        f"Error when trying to launch environment - make sure "
+                        f"permissions are set correctly. For example "
+                        f'"chmod -R 755 {launch_string}"'
+                    ) from perm
+
             else:
                 """
                 Comments for future maintenance:


### PR DESCRIPTION
Followup from https://github.com/Unity-Technologies/ml-agents/issues/2488 - we have a section in the FAQ related to this (https://github.com/Unity-Technologies/ml-agents/blob/master/docs/FAQ.md#environment-permission-error), but adding the help at the point of failure makes it easier to discover the fix.

Also cleans up how the args are passed to `subprocess.Popen()`

Example of the error log with this change (when trying to run a non-executable file):
```
Traceback (most recent call last):
  File "/Users/chris.elion/code/ml-agents/ml-agents-envs/mlagents/envs/environment.py", line 254, in executable_launcher
    self.proc1 = subprocess.Popen(subprocess_args)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: '/Users/chris.elion/code/ml-agents/UnitySDK/Builds/hallway.app/Contents/MacOS/hallway'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/chris.elion/code/ml-agents/ml-agents-envs/mlagents/envs/subprocess_env_manager.py", line 74, in worker
    env = env_factory(worker_id)
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 259, in create_unity_environment
    base_port=start_port,
  File "/Users/chris.elion/code/ml-agents/ml-agents-envs/mlagents/envs/environment.py", line 92, in __init__
    self.executable_launcher(file_name, docker_training, no_graphics, args)
  File "/Users/chris.elion/code/ml-agents/ml-agents-envs/mlagents/envs/environment.py", line 261, in executable_launcher
    ) from perm
mlagents.envs.exception.UnityEnvironmentException: Error when trying to launch environment - make sure permissions are set correctly. For example "chmod -R 755 /Users/chris.elion/code/ml-agents/UnitySDK/Builds/hallway.app/Contents/MacOS/hallway"
```