### PR TITLE
Fix issue where SAC encoder type is always simple

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -17,7 +17,7 @@ default:
     summary_freq: 1000
     tau: 0.005
     use_recurrent: false
-    vis_encode_type: default
+    vis_encode_type: simple
     reward_signals:
         extrinsic:
             strength: 1.0

--- a/ml-agents/mlagents/trainers/sac/models.py
+++ b/ml-agents/mlagents/trainers/sac/models.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 
 import tensorflow as tf
-from mlagents.trainers.models import LearningModel
+from mlagents.trainers.models import LearningModel, EncoderType
 import tensorflow.contrib.layers as c_layers
 
 LOG_STD_MAX = 2
@@ -32,7 +32,7 @@ class SACNetwork(LearningModel):
         num_layers=2,
         stream_names=None,
         seed=0,
-        vis_encode_type="default",
+        vis_encode_type=EncoderType.SIMPLE,
     ):
         LearningModel.__init__(
             self, m_size, normalize, use_recurrent, brain, seed, stream_names
@@ -448,7 +448,7 @@ class SACTargetNetwork(SACNetwork):
         num_layers=2,
         stream_names=None,
         seed=0,
-        vis_encode_type="default",
+        vis_encode_type=EncoderType.SIMPLE,
     ):
         super().__init__(
             brain,
@@ -500,7 +500,7 @@ class SACPolicyNetwork(SACNetwork):
         num_layers=2,
         stream_names=None,
         seed=0,
-        vis_encode_type="default",
+        vis_encode_type=EncoderType.SIMPLE,
     ):
         super().__init__(
             brain,
@@ -630,7 +630,7 @@ class SACModel(LearningModel):
         stream_names=None,
         tau=0.005,
         gammas=None,
-        vis_encode_type="default",
+        vis_encode_type=EncoderType.SIMPLE,
     ):
         """
         Takes a Unity environment and model-specific hyper-parameters and returns the

--- a/ml-agents/mlagents/trainers/sac/policy.py
+++ b/ml-agents/mlagents/trainers/sac/policy.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 
 from mlagents.envs.timers import timed
 from mlagents.trainers import BrainInfo, ActionInfo, BrainParameters
+from mlagents.trainers.models import EncoderType
 from mlagents.trainers.sac.models import SACModel
 from mlagents.trainers.tf_policy import TFPolicy
 from mlagents.trainers.components.reward_signals.reward_signal_factory import (
@@ -111,7 +112,9 @@ class SACPolicy(TFPolicy):
                 stream_names=list(reward_signal_configs.keys()),
                 tau=float(trainer_params["tau"]),
                 gammas=list(_val["gamma"] for _val in reward_signal_configs.values()),
-                vis_encode_type=trainer_params["vis_encode_type"],
+                vis_encode_type=EncoderType(
+                    trainer_params.get("vis_encode_type", "simple")
+                ),
             )
             self.model.create_sac_optimizers()
 

--- a/ml-agents/mlagents/trainers/tests/test_bcmodule.py
+++ b/ml-agents/mlagents/trainers/tests/test_bcmodule.py
@@ -63,7 +63,7 @@ def sac_dummy_config():
         summary_freq: 1000
         tau: 0.005
         use_recurrent: false
-        vis_encode_type: default
+        vis_encode_type: simple
         pretraining:
             demo_path: ./demos/ExpertPyramid.demo
             strength: 1.0

--- a/ml-agents/mlagents/trainers/tests/test_reward_signals.py
+++ b/ml-agents/mlagents/trainers/tests/test_reward_signals.py
@@ -65,7 +65,7 @@ def sac_dummy_config():
         summary_freq: 1000
         tau: 0.005
         use_recurrent: false
-        vis_encode_type: default
+        vis_encode_type: simple
         pretraining:
             demo_path: ./demos/ExpertPyramid.demo
             strength: 1.0

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -46,7 +46,7 @@ def dummy_config():
         use_recurrent: false
         curiosity_enc_size: 128
         demo_path: None
-        vis_encode_type: default
+        vis_encode_type: simple
         reward_signals:
             extrinsic:
                 strength: 1.0

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -179,7 +179,7 @@ SAC_CONFIG = """
         use_recurrent: false
         curiosity_enc_size: 128
         demo_path: None
-        vis_encode_type: default
+        vis_encode_type: simple
         reward_signals:
             extrinsic:
                 strength: 1.0


### PR DESCRIPTION
SAC still assigned visual encoder type as a string, not an `EncoderType`. Therefore, all the checks will fail and `models.py` will default to the `SIMPLE` encoder. This PR corrects this issue. 