### PR TITLE
Remove writing to UnitySDKlog in build directory

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -197,13 +197,6 @@ namespace MLAgents
         /// Pointer to the batcher currently in use by the Academy.
         Batcher m_BrainBatcher;
 
-        /// Used to write error messages.
-        StreamWriter m_LogWriter;
-
-        /// The path to where the log should be written.
-        string m_LogPath;
-
-
         // Flag used to keep track of the first time the Academy is reset.
         bool m_FirstAcademyReset;
 
@@ -348,15 +341,6 @@ namespace MLAgents
 
                 var pythonParameters = m_BrainBatcher.SendAcademyParameters(academyParameters);
                 Random.InitState(pythonParameters.Seed);
-                Application.logMessageReceived += HandleLog;
-                m_LogPath = Path.GetFullPath(".") + "/UnitySDK.log";
-                using (var fs = File.Open(m_LogPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                {
-                    m_LogWriter = new StreamWriter(fs);
-                    m_LogWriter.WriteLine(System.DateTime.Now.ToString());
-                    m_LogWriter.WriteLine(" ");
-                    m_LogWriter.Close();
-                }
             }
 
             // If a communicator is enabled/provided, then we assume we are in
@@ -388,18 +372,6 @@ namespace MLAgents
                     resetParameters[kv.Key] = kv.Value;
                 }
                 customResetParameters = newResetParameters.CustomResetParameters;
-            }
-        }
-
-        void HandleLog(string logString, string stackTrace, LogType type)
-        {
-            using (var fs = File.Open(m_LogPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-            {
-                m_LogWriter = new StreamWriter(fs);
-                m_LogWriter.WriteLine(type.ToString());
-                m_LogWriter.WriteLine(logString);
-                m_LogWriter.WriteLine(stackTrace);
-                m_LogWriter.Close();
             }
         }
 


### PR DESCRIPTION
This change removes the feature that InitializeEnvironment in Academy.cs wrote to UnitySDK.log in the directory of the build which caused the exception 

`Exception
ObjectDisposedException: Cannot write to a closed TextWriter.
System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
System.IO.StreamWriter.Write (System.Char[] buffer, System.Int32 index, System.Int32 count) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
System.IO.TextWriter.WriteLine (System.String value) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
MLAgents.Academy.InitializeEnvironment () (at <e17f0c64ba434a8e854fa9b58dd1a03d>:0)
MLAgents.Academy.Awake () (at <e17f0c64ba434a8e854fa9b58dd1a03d>:0)`

in Unity version 19.2.2f1.  

