### PR TITLE
Add console log section to Bug Report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,6 +17,9 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
+**Console logs / stack traces**
+Please wrap in triple backticks (```) to make it easier to read (see https://help.github.com/en/articles/creating-and-highlighting-code-blocks)
+
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ Steps to reproduce the behavior:
 4. See error
 
 **Console logs / stack traces**
-Please wrap in triple backticks (```) to make it easier to read (see https://help.github.com/en/articles/creating-and-highlighting-code-blocks)
+Please wrap in [triple backticks (```)](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) to make it easier to read.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
Some bug reports that come in are hard to read because the callstacks aren't monospaced (and sometimes accidentally add formatting), and some others which have screenshots of the callstacks (which is even worse because it's not searchable).

This encourages uses to paste the logs/callstacks and make them readable.