### PR TITLE
Use tag names which actually exist in the project

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/RayPerceptionTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/RayPerceptionTests.cs
@@ -10,7 +10,7 @@ namespace MLAgents.Tests
         public void TestPerception3D()
         {
             var angles = new[] {0f, 90f, 180f};
-            var tags = new[] {"test", "test_1"};
+            var tags = new[] {"wall", "pit"};
 
             var go = new GameObject("MyGameObject");
             var rayPer3D = go.AddComponent<RayPerception3D>();
@@ -24,7 +24,7 @@ namespace MLAgents.Tests
         public void TestPerception2D()
         {
             var angles = new[] {0f, 90f, 180f};
-            var tags = new[] {"test", "test_1"};
+            var tags = new[] {"wall", "pit"};
 
             var go = new GameObject("MyGameObject");
             var rayPer2D = go.AddComponent<RayPerception2D>();


### PR DESCRIPTION
Fixes issue (https://github.com/Unity-Technologies/ml-agents/issues/2558) by using tag names that are part of the `UnitySDK` project. 