### PR TITLE
Coding convention fixes

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -24,12 +24,10 @@ public class GridAgent : Agent
     private const int k_Down = 2;
     private const int k_Left = 3;
     private const int k_Right = 4;
-    static Collider[] s_Colliders;
 
     public override void InitializeAgent()
     {
         m_Academy = FindObjectOfType(typeof(GridAcademy)) as GridAcademy;
-        s_Colliders = new Collider[16];
     }
 
     public override void CollectObservations()
@@ -103,18 +101,18 @@ public class GridAgent : Agent
                 throw new ArgumentException("Invalid action value");
         }
 
-        Physics.OverlapBoxNonAlloc(
-            targetPos, new Vector3(0.3f, 0.3f, 0.3f), s_Colliders);
-        if (s_Colliders.Where(col => col.gameObject.CompareTag("wall")).ToArray().Length == 0)
+        var hit = Physics.OverlapBox(
+            targetPos, new Vector3(0.3f, 0.3f, 0.3f));
+        if (hit.Where(col => col.gameObject.CompareTag("wall")).ToArray().Length == 0)
         {
             transform.position = targetPos;
 
-            if (s_Colliders.Where(col => col.gameObject.CompareTag("goal")).ToArray().Length == 1)
+            if (hit.Where(col => col.gameObject.CompareTag("goal")).ToArray().Length == 1)
             {
                 Done();
                 SetReward(1f);
             }
-            if (s_Colliders.Where(col => col.gameObject.CompareTag("pit")).ToArray().Length == 1)
+            if (hit.Where(col => col.gameObject.CompareTag("pit")).ToArray().Length == 1)
             {
                 Done();
                 SetReward(-1f);

--- a/UnitySDK/Assets/ML-Agents/Plugins/Barracuda.Core/Barracuda/Plugins/Editor/BarracudaEditor/NNModelImporter.cs
+++ b/UnitySDK/Assets/ML-Agents/Plugins/Barracuda.Core/Barracuda/Plugins/Editor/BarracudaEditor/NNModelImporter.cs
@@ -9,7 +9,7 @@ namespace Barracuda
     /// Asset Importer of barracuda models.
     /// </summary>
     [ScriptedImporter(1, new[] {"nn"})]
-    public class NnModelImporter : ScriptedImporter
+    public class NNModelImporter : ScriptedImporter
     {
         private const string k_IconName = "NNModelIcon";
 

--- a/UnitySDK/UnitySDK.sln.DotSettings
+++ b/UnitySDK/UnitySDK.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BLAS/@EntryIndexedValue">BLAS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CPU/@EntryIndexedValue">CPU</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GPU/@EntryIndexedValue">GPU</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NN/@EntryIndexedValue">NN</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BLAS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Logits/@EntryIndexedValue">True</s:Boolean>
 	


### PR DESCRIPTION
Fix issues that cropped up from the coding convention change.

- Crash in 2017.4.10f because of `NNModelImporter` rename.
- Gridworld Null Reference Exception from NonAlloc physics call.