### PR TITLE
Fix issue exporting graph with multi-GPU

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/models.py
+++ b/ml-agents/mlagents/trainers/ppo/models.py
@@ -109,6 +109,7 @@ class PPOModel(LearningModel):
             self.act_size[0],
             activation=None,
             kernel_initializer=LearningModel.scaled_init(0.01),
+            reuse=tf.AUTO_REUSE
         )
 
         self.log_sigma_sq = tf.get_variable(

--- a/ml-agents/mlagents/trainers/ppo/models.py
+++ b/ml-agents/mlagents/trainers/ppo/models.py
@@ -109,7 +109,7 @@ class PPOModel(LearningModel):
             self.act_size[0],
             activation=None,
             kernel_initializer=LearningModel.scaled_init(0.01),
-            reuse=tf.AUTO_REUSE
+            reuse=tf.AUTO_REUSE,
         )
 
         self.log_sigma_sq = tf.get_variable(

--- a/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
+++ b/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
@@ -41,7 +41,7 @@ class MultiGpuPPOPolicy(PPOPolicy):
         self.devices = get_devices()
         self.towers = []
         with self.graph.as_default():
-            with tf.variable_scope(TOWER_SCOPE_NAME, reuse=tf.AUTO_REUSE):
+            with tf.variable_scope("", reuse=tf.AUTO_REUSE):
                 for device in self.devices:
                     with tf.device(device):
                         self.towers.append(
@@ -70,7 +70,6 @@ class MultiGpuPPOPolicy(PPOPolicy):
                         )
                         self.towers[-1].create_ppo_optimizer()
             self.model = self.towers[0]
-
             avg_grads = self.average_gradients([t.grads for t in self.towers])
             update_batch = self.model.optimizer.apply_gradients(avg_grads)
 

--- a/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
+++ b/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
@@ -1500,7 +1500,7 @@ def very_slow_but_stable_topological_sort(nodes, verbose):
 
 
 def convert(
-    source_file,
+    source_graph,
     target_file,
     trim_unused_by_output="",
     verbose=False,
@@ -1533,10 +1533,15 @@ def convert(
         barracuda.print_known_operations(known_classes, known_activations)
 
     # Load Tensorflow model
-    print("Converting %s to %s" % (source_file, target_file))
-    f = open(source_file, "rb")
-    i_model = tf.GraphDef()
-    i_model.ParseFromString(f.read())
+    if isinstance(source_graph, str):
+        print("Converting %s to %s" % (source_graph, target_file))
+        f = open(source_graph, "rb")
+        i_model = tf.GraphDef()
+        i_model.ParseFromString(f.read())
+    elif isinstance(source_graph, tf.GraphDef):
+        i_model = source_graph
+    else:
+        raise Exception("Source graph must be either a filename or GraphDef")
 
     if args.verbose:
         print("OP_TYPES:", {layer.op for layer in i_model.node})

--- a/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
+++ b/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
@@ -1499,13 +1499,23 @@ def very_slow_but_stable_topological_sort(nodes, verbose):
 #########################################################
 
 
-def convert_graph_def(
-    source_graph_def,
+def convert(
+    source_file,
     target_file,
     trim_unused_by_output="",
     verbose=False,
     compress_f16=False,
 ):
+    """
+    Converts a TensorFlow model into a Barracuda model.
+    :param source_file: The TensorFlow Model
+    :param target_file: The name of the file the converted model will be saved to
+    :param trim_unused_by_output: The regexp to match output nodes to remain in the model.
+        All other unconnected nodes will be removed.
+    :param verbose: If True, will display debug messages
+    :param compress_f16: If true, the float values will be converted to f16
+    :return:
+    """
     if type(verbose) == bool:
         args = Struct()
         args.verbose = verbose
@@ -1522,21 +1532,24 @@ def convert_graph_def(
     if args.print_supported_ops:
         barracuda.print_known_operations(known_classes, known_activations)
 
-    if not isinstance(source_graph_def, tf.GraphDef):
-        raise Exception("Source graph must be either a filename or GraphDef")
+    # Load Tensorflow model
+    print("Converting %s to %s" % (source_file, target_file))
+    f = open(source_file, "rb")
+    i_model = tf.GraphDef()
+    i_model.ParseFromString(f.read())
 
     if args.verbose:
-        print("OP_TYPES:", {layer.op for layer in source_graph_def.node})
+        print("OP_TYPES:", {layer.op for layer in i_model.node})
 
     if args.print_source_json or args.verbose:
-        for layer in source_graph_def.node:
+        for layer in i_model.node:
             if not layer.op == "Const":
                 print("MODEL:", MessageToJson(layer) + ",")
 
     # Convert
     o_model = barracuda.Model()
     o_model.layers, o_input_shapes, o_model.tensors, o_model.memories, o_model.globals = process_model(
-        source_graph_def, args
+        i_model, args
     )
 
     # Cleanup unconnected Identities (they might linger after processing complex node patterns like LSTM)
@@ -1647,30 +1660,3 @@ def convert_graph_def(
     # Write to file
     barracuda.write(o_model, target_file)
     print("DONE: wrote", target_file, "file.")
-
-
-def convert(
-    source_graph,
-    target_file,
-    trim_unused_by_output="",
-    verbose=False,
-    compress_f16=False,
-):
-    """
-    Converts a TensorFlow model into a Barracuda model.
-    :param source_file: The TensorFlow Model
-    :param target_file: The name of the file the converted model will be saved to
-    :param trim_unused_by_output: The regexp to match output nodes to remain in the model.
-        All other unconnected nodes will be removed.
-    :param verbose: If True, will display debug messages
-    :param compress_f16: If true, the float values will be converted to f16
-    :return:
-    """
-    # Load Tensorflow model
-    print("Converting %s to %s" % (source_graph, target_file))
-    f = open(source_graph, "rb")
-    graph_def = tf.GraphDef()
-    graph_def.ParseFromString(f.read())
-    convert_graph_def(
-        graph_def, target_file, trim_unused_by_output, verbose, compress_f16
-    )

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -224,7 +224,7 @@ class TFPolicy(Policy):
             output_graph_def = graph_util.convert_variables_to_constants(
                 self.sess, graph_def, target_nodes.replace(" ", "").split(",")
             )
-            tf2bc.convert(output_graph_def, self.model_path + ".nn")
+            tf2bc.convert_graph_def(output_graph_def, self.model_path + ".nn")
             logger.info("Exported " + self.model_path + ".nn file")
 
     def _process_graph(self):

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from mlagents.envs.exception import UnityException
 from mlagents.envs.policy import Policy
 from mlagents.envs.action_info import ActionInfo
-from tensorflow.python.tools import freeze_graph
+from tensorflow.python.platform import gfile
 from tensorflow.python.framework import graph_util
 from mlagents.trainers import tensorflow_to_barracuda as tf2bc
 from mlagents.envs.brain import BrainInfo
@@ -224,7 +224,10 @@ class TFPolicy(Policy):
             output_graph_def = graph_util.convert_variables_to_constants(
                 self.sess, graph_def, target_nodes.replace(" ", "").split(",")
             )
-            tf2bc.convert_graph_def(output_graph_def, self.model_path + ".nn")
+            frozen_graph_def_path = self.model_path + "/frozen_graph_def.pb"
+            with gfile.GFile(frozen_graph_def_path, "wb") as f:
+                f.write(output_graph_def.SerializeToString())
+            tf2bc.convert(frozen_graph_def_path, self.model_path + ".nn")
             logger.info("Exported " + self.model_path + ".nn file")
 
     def _process_graph(self):


### PR DESCRIPTION
Our multi-GPU training had a regression such that freezing the
graph was broken.  This change fixes that issue by making a few
changes:

* Removes the top level "tower" variable scope added by multi-GPU
  so that the output nodes have correct names
* Removes the use of "freeze_graph" and updates the tensorflow to
  barracuda converter to accept GraphDef objects
* Adds the "auto reuse" to network layers which require them