### PR TITLE
Remove UnitySDK.log file 

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -197,13 +197,6 @@ namespace MLAgents
         /// Pointer to the batcher currently in use by the Academy.
         Batcher m_BrainBatcher;
 
-        /// Used to write error messages.
-        StreamWriter m_LogWriter;
-
-        /// The path to where the log should be written.
-        string m_LogPath;
-
-
         // Flag used to keep track of the first time the Academy is reset.
         bool m_FirstAcademyReset;
 
@@ -348,15 +341,6 @@ namespace MLAgents
 
                 var pythonParameters = m_BrainBatcher.SendAcademyParameters(academyParameters);
                 Random.InitState(pythonParameters.Seed);
-                Application.logMessageReceived += HandleLog;
-                m_LogPath = Path.GetFullPath(".") + "/UnitySDK.log";
-                using (var fs = File.Open(m_LogPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                {
-                    m_LogWriter = new StreamWriter(fs);
-                    m_LogWriter.WriteLine(System.DateTime.Now.ToString());
-                    m_LogWriter.WriteLine(" ");
-                    m_LogWriter.Close();
-                }
             }
 
             // If a communicator is enabled/provided, then we assume we are in
@@ -390,19 +374,7 @@ namespace MLAgents
                 customResetParameters = newResetParameters.CustomResetParameters;
             }
         }
-
-        void HandleLog(string logString, string stackTrace, LogType type)
-        {
-            using (var fs = File.Open(m_LogPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-            {
-                m_LogWriter = new StreamWriter(fs);
-                m_LogWriter.WriteLine(type.ToString());
-                m_LogWriter.WriteLine(logString);
-                m_LogWriter.WriteLine(stackTrace);
-                m_LogWriter.Close();
-            }
-        }
-
+        
         /// <summary>
         /// Configures the environment settings depending on the training/inference
         /// mode and the corresponding parameters passed in the Editor.

--- a/ml-agents-envs/mlagents/envs/exception.py
+++ b/ml-agents-envs/mlagents/envs/exception.py
@@ -47,35 +47,8 @@ class UnityTimeOutException(UnityException):
     """
     Related to errors with communication timeouts.
     """
-
-    def __init__(self, message, log_file_path=None):
-        if log_file_path is not None:
-            try:
-                with open(log_file_path, "r") as f:
-                    printing = False
-                    unity_error = "\n"
-                    for line in f:
-                        line = line.strip()
-                        if (line == "Exception") or (line == "Error"):
-                            printing = True
-                            unity_error += "----------------------\n"
-                        if line == "":
-                            printing = False
-                        if printing:
-                            unity_error += line + "\n"
-                    logger.info(unity_error)
-                    logger.error(
-                        "An error might have occured in the environment. "
-                        "You can check the logfile for more information at {}".format(
-                            log_file_path
-                        )
-                    )
-            except Exception:
-                logger.error(
-                    "An error might have occured in the environment. "
-                    "No UnitySDK.log file could be found."
-                )
-        super(UnityTimeOutException, self).__init__(message)
+    
+    pass
 
 
 class UnityWorkerInUseException(UnityException):

--- a/ml-agents-envs/mlagents/envs/exception.py
+++ b/ml-agents-envs/mlagents/envs/exception.py
@@ -47,7 +47,7 @@ class UnityTimeOutException(UnityException):
     """
     Related to errors with communication timeouts.
     """
-    
+
     pass
 
 


### PR DESCRIPTION
This change removes the feature that Academy.cs creates and writes to UnitySDK.log in the directory of the build. UnitySDK.log is a bit redundant given the player log and as written it's logging of "System.DateTime.Now" was causing the following warning and exception with newer versions of Unity.

```
Warning
Plugins: Couldn't open libc, error: dlopen(libc, 2): image not found

Exception
ObjectDisposedException: Cannot write to a closed TextWriter.
System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
System.IO.StreamWriter.Write (System.Char[] buffer, System.Int32 index, System.Int32 count) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
System.IO.TextWriter.WriteLine (System.String value) (at <b35a51e37b9044f3a540f83fa39a96e3>:0)
MLAgents.Academy.InitializeEnvironment () (at <31b28fc73f93469aa66b0663de536fb0>:0)
MLAgents.Academy.Awake () (at <31b28fc73f93469aa66b0663de536fb0>:0)
```

This change also modifies the UnityTimeOutException class to simply pass the exception message through to Exception (as most of the other exceptions do) and no longer read from UnitySDK.log.

