### PR TITLE
Barracuda Boolean Tensor Support

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TFSharpInferenceEngine.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TFSharpInferenceEngine.cs
@@ -56,6 +56,10 @@ namespace MLAgents.InferenceBrain
                     {
                         runner.AddInput(m_graph[input.Name][0], (int)data);
                     }
+                    else if (input.DataType == typeof(bool))
+                    {
+                        runner.AddInput(m_graph[input.Name][0], (bool)data);
+                    }
                     else
                     {
                         runner.AddInput(m_graph[input.Name][0], (float)data);
@@ -178,6 +182,9 @@ namespace MLAgents.InferenceBrain
             {
                 case TFDataType.Float:
                     placeholder_type = TensorProxy.TensorType.FloatingPoint;
+                    break;
+                case TFDataType.Bool:
+                    placeholder_type = TensorProxy.TensorType.Boolean;
                     break;
                 case TFDataType.Int32:
                     placeholder_type = TensorProxy.TensorType.Integer;

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorProxy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorProxy.cs
@@ -21,14 +21,14 @@ namespace MLAgents.InferenceBrain
 		{
 			Integer,
 			FloatingPoint,
-            Boolean
+			Boolean
 		};
 
 		private static Dictionary<TensorType, Type> m_typeMap = new Dictionary<TensorType, Type>()
 		{
 			{ TensorType.FloatingPoint, typeof(float) },
 			{ TensorType.Integer, typeof(int) },
-            { TensorType.Boolean, typeof(bool) }
+			{ TensorType.Boolean, typeof(bool) }
 		};
 
 		public string Name;

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorProxy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/TensorProxy.cs
@@ -20,13 +20,15 @@ namespace MLAgents.InferenceBrain
 		public enum TensorType
 		{
 			Integer,
-			FloatingPoint
+			FloatingPoint,
+            Boolean
 		};
 
 		private static Dictionary<TensorType, Type> m_typeMap = new Dictionary<TensorType, Type>()
 		{
-			{ TensorType.FloatingPoint, typeof(float)},
-			{TensorType.Integer, typeof(int)}
+			{ TensorType.FloatingPoint, typeof(float) },
+			{ TensorType.Integer, typeof(int) },
+            { TensorType.Boolean, typeof(bool) }
 		};
 
 		public string Name;


### PR DESCRIPTION
Barracuda currently does not implement the boolean tensor type.
There might be a boolean placeholder (`is_training_ph`) of the inference graph.
My PR introduces a simple solution to TFSharp inference engine.