### PR TITLE
Added option to use environment arguments in learn

### DIFF
--- a/UnitySDK/ProjectSettings/ProjectVersion.txt
+++ b/UnitySDK/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.4.10f1
+m_EditorVersion: 2017.4.29f1

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -98,7 +98,6 @@ environment, you can set the following command line options when invoking
 `mlagents-learn`:
 
 * `--env=<env>`: Specify an executable environment to train.
-* `--env-args=<string>`: Specify arguments for the executable environment. Be aware that the standalone build will also process these as [Unity Command Line Arguments](https://docs.unity3d.com/Manual/CommandLineArguments.html). You should choose different argument names if you want to create environment-specific arguments.
 * `--curriculum=<file>`: Specify a curriculum JSON file for defining the
   lessons for curriculum training. See [Curriculum
   Training](Training-Curriculum-Learning.md) for more information.
@@ -140,7 +139,10 @@ environment, you can set the following command line options when invoking
   When training, **always** use the `--train` option.
 * `--num-envs=<n>`: Specifies the number of concurrent Unity environment instances to collect
   experiences from when training. Defaults to 1.
-* `--base-port`: Specifies the starting port. Each concurrent Unity environment instance will get assigned a port sequentially, starting from the `base-port`.  Each instance will use the port `(base_port + worker_id)`, where the `worker_id` is sequential IDs given to each instance from 0 to `num_envs - 1`. Default is 5005.
+* `--base-port`: Specifies the starting port. Each concurrent Unity environment instance will
+  get assigned a port sequentially, starting from the `base-port`.  Each instance will use the
+  port `(base_port + worker_id)`, where the `worker_id` is sequential IDs given to each instance
+  from 0 to `num_envs - 1`. Default is 5005.
 * `--docker-target-name=<dt>`: The Docker Volume on which to store curriculum,
   executable and model files. See [Using Docker](Using-Docker.md).
 * `--no-graphics`: Specify this option to run the Unity executable in
@@ -150,6 +152,14 @@ environment, you can set the following command line options when invoking
   details.
 * `--debug`: Specify this option to enable debug-level logging for some parts of the code.
 * `--multi-gpu`: Setting this flag enables the use of multiple GPU's (if available) during training.
+* `--env-args=<string>`: Specify arguments for the executable environment. Be aware that
+  the standalone build will also process these as
+  [Unity Command Line Arguments](https://docs.unity3d.com/Manual/CommandLineArguments.html).
+  You should choose different argument names if you want to create environment-specific arguments.
+  All arguments after this flag will be passed to the executable. For example, setting
+  `mlagents-learn config/trainer_config.yaml --env-args --num-orcs 42` would result in
+   ` --num-orcs 42` passed to the executable.
+
 
 ### Training Config File
 

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -52,7 +52,7 @@ class UnityEnvironment(BaseUnityEnvironment):
         docker_training: bool = False,
         no_graphics: bool = False,
         timeout_wait: int = 30,
-        args: list = [],
+        args: Optional[List[str]] = None,
     ):
         """
         Starts a new unity environment and establishes a connection with the environment.
@@ -68,7 +68,7 @@ class UnityEnvironment(BaseUnityEnvironment):
         :bool train_mode: Whether to run in training mode, speeding up the simulation, by default.
         :list args: Addition Unity command line arguments
         """
-
+        args = args or []
         atexit.register(self._close)
         self.port = base_port + worker_id
         self._buffer_size = 12000

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -43,6 +43,7 @@ class CommandLineOptions(NamedTuple):
     trainer_config_path: str
     sampler_file_path: Optional[str]
     docker_target_name: Optional[str]
+    env_args: Optional[List[str]]
 
     @property
     def fast_simulation(self) -> bool:
@@ -149,9 +150,13 @@ def parse_command_line(argv: Optional[List[str]] = None) -> CommandLineOptions:
         action="store_true",
         help="Setting this flag enables the use of multiple GPU's (if available) during training",
     )
+    parser.add_argument(
+        "--env-args",
+        default=None,
+        nargs=argparse.REMAINDER,
+        help="Arguments passed to the Unity executable.",
+    )
 
-     # TODO --env-args=<string>         Arguments of the Unity executable [default: None].
-    
     args = parser.parse_args(argv)
     return CommandLineOptions.from_argparse(args)
 
@@ -204,7 +209,7 @@ def run_training(
         options.no_graphics,
         run_seed,
         options.base_port + (sub_id * options.num_envs),
-        # TODO options.env_args,
+        options.env_args,
     )
     env = SubprocessEnvManager(env_factory, options.num_envs)
     maybe_meta_curriculum = try_create_meta_curriculum(
@@ -340,7 +345,7 @@ def create_environment_factory(
     no_graphics: bool,
     seed: Optional[int],
     start_port: int,
-    env_args: [],
+    env_args: Optional[List[str]],
 ) -> Callable[[int], BaseUnityEnvironment]:
     if env_path is not None:
         # Strip out executable extensions if passed

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -98,6 +98,7 @@ def test_commandline_args():
     assert opt.no_graphics is False
     assert opt.debug is False
     assert opt.multi_gpu is False
+    assert opt.env_args is None
 
     full_args = [
         "mytrainerpath",
@@ -140,3 +141,18 @@ def test_commandline_args():
     assert opt.no_graphics is True
     assert opt.debug is True
     assert opt.multi_gpu is True
+
+
+def test_env_args():
+    full_args = [
+        "mytrainerpath",
+        "--env=./myenvfile",
+        "--env-args",  # Everything after here will be grouped in a list
+        "--foo=bar",
+        "--blah",
+        "baz",
+        "100",
+    ]
+
+    opt = parse_command_line(full_args)
+    assert opt.env_args == ["--foo=bar", "--blah", "baz", "100"]


### PR DESCRIPTION
(This is mostly from https://github.com/Unity-Technologies/ml-agents/pull/2491 with a few conflicts fixed by me)

#### Detailed description of the changes performed

Environment arguments passed to `mlagents-learn` via `--env-args` are now passed to the environment executables.

#### Corresponding changes to documentation, unit tests and sample environments (if applicable)

I added the new argument to `docs/Training-ML-Agents.md`.

#### Issue numbers that the PR resolves (if any)

Solves https://github.com/Unity-Technologies/ml-agents/issues/2418.