### PR TITLE
Fix crash with VAIL + GAIL

### DIFF
--- a/ml-agents/mlagents/trainers/components/reward_signals/gail/model.py
+++ b/ml-agents/mlagents/trainers/components/reward_signals/gail/model.py
@@ -51,7 +51,7 @@ class GAILModel(object):
         new_beta = tf.maximum(
             self.beta + self.alpha * (self.kl_loss - self.mutual_information), EPSILON
         )
-        with tf.control_dependencies(self.update_batch):
+        with tf.control_dependencies([self.update_batch]):
             self.update_beta = tf.assign(self.beta, new_beta)
 
     def make_inputs(self) -> None:

--- a/ml-agents/mlagents/trainers/tests/test_reward_signals.py
+++ b/ml-agents/mlagents/trainers/tests/test_reward_signals.py
@@ -76,6 +76,7 @@ def gail_dummy_config():
             "strength": 0.1,
             "gamma": 0.9,
             "encoding_size": 128,
+            "use_vail": True,
             "demo_path": os.path.dirname(os.path.abspath(__file__)) + "/test.demo",
         }
     }


### PR DESCRIPTION
`tf.control_dependencies` requires a list, we were giving it a single Tensor. This was causing a crash if VAIL was enabled. This fixes that issue. 