### PR TITLE
Better environment shutdown

### DIFF
--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -33,6 +33,7 @@ from mlagents.envs.communicator_objects.custom_action_pb2 import CustomAction
 
 from .rpc_communicator import RpcCommunicator
 from sys import platform
+import signal
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mlagents.envs")
@@ -79,6 +80,7 @@ class UnityEnvironment(BaseUnityEnvironment):
         self.proc1 = (
             None
         )  # The process that is started. If None, no process was started
+        self.timeout_wait: int = timeout_wait
         self.communicator = self.get_communicator(worker_id, base_port, timeout_wait)
         self.worker_id = worker_id
 
@@ -249,7 +251,14 @@ class UnityEnvironment(BaseUnityEnvironment):
                 subprocess_args += ["--port", str(self.port)]
                 subprocess_args += args
                 try:
-                    self.proc1 = subprocess.Popen(subprocess_args)
+                    self.proc1 = subprocess.Popen(
+                        subprocess_args,
+                        # start_new_session=True means that signals to the parent python process
+                        # (e.g. SIGINT from keyboard interrupt) will not be sent to the new process.
+                        # This is generally good since we want the environment to have a chance to shutdown,
+                        # but may be undesirable in come cases.
+                        start_new_session=True,
+                    )
                 except PermissionError as perm:
                     # This is likely due to missing read or execute permissions on file.
                     raise UnityEnvironmentException(
@@ -583,12 +592,13 @@ class UnityEnvironment(BaseUnityEnvironment):
         self._loaded = False
         self.communicator.close()
         if self.proc1 is not None:
-            # Wait a few seconds for the process to shutdown, but kill it if it takes too long
+            # Wait a bit for the process to shutdown, but kill it if it takes too long
             try:
-                self.proc1.wait(timeout=5.0)
-                logger.info(
-                    f"Environment shut down cleanly with return code {self.proc1.returncode}"
-                )
+                self.proc1.wait(timeout=self.timeout_wait)
+                signal_name = self.returncode_to_signal_name(self.proc1.returncode)
+                signal_name = f" ({signal_name})" if signal_name else ""
+                return_info = f"Environment shut down with return code {self.proc1.returncode}{signal_name}."
+                logger.info(return_info)
             except subprocess.TimeoutExpired:
                 logger.info("Environment timed out shutting down. Killing...")
                 self.proc1.kill()
@@ -683,3 +693,17 @@ class UnityEnvironment(BaseUnityEnvironment):
         result = UnityInput()
         result.rl_input.CopyFrom(rl_input)
         return result
+
+    @staticmethod
+    def returncode_to_signal_name(returncode: int) -> Optional[str]:
+        """
+        Try to convert return codes into their corresponding signal name.
+        E.g. returncode_to_signal_name(-2) -> "SIGINT"
+        """
+        try:
+            # A negative value -N indicates that the child was terminated by signal N (POSIX only).
+            s = signal.Signals(-returncode)
+            return s.name
+        except Exception:
+            # Should generally be a ValueError, but catch everything just in case.
+            return None

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -583,7 +583,15 @@ class UnityEnvironment(BaseUnityEnvironment):
         self._loaded = False
         self.communicator.close()
         if self.proc1 is not None:
-            self.proc1.kill()
+            # Wait a few seconds for the process to shutdown, but kill it if it takes too long
+            try:
+                self.proc1.wait(timeout=5.0)
+                logger.info(
+                    f"Environment shut down cleanly with return code {self.proc1.returncode}"
+                )
+            except subprocess.TimeoutExpired:
+                logger.info("Environment timed out shutting down. Killing...")
+                self.proc1.kill()
 
     @classmethod
     def _flatten(cls, arr: Any) -> List[float]:

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -254,9 +254,10 @@ class UnityEnvironment(BaseUnityEnvironment):
                     self.proc1 = subprocess.Popen(
                         subprocess_args,
                         # start_new_session=True means that signals to the parent python process
-                        # (e.g. SIGINT from keyboard interrupt) will not be sent to the new process.
+                        # (e.g. SIGINT from keyboard interrupt) will not be sent to the new process on POSIX platforms.
                         # This is generally good since we want the environment to have a chance to shutdown,
-                        # but may be undesirable in come cases.
+                        # but may be undesirable in come cases; if so, we'll add a command-line toggle.
+                        # Note that on Windows, the CTRL_C signal will still be sent.
                         start_new_session=True,
                     )
                 except PermissionError as perm:
@@ -602,6 +603,7 @@ class UnityEnvironment(BaseUnityEnvironment):
             except subprocess.TimeoutExpired:
                 logger.info("Environment timed out shutting down. Killing...")
                 self.proc1.kill()
+            # Set to None so we don't try to close multiple times.
             self.proc1 = None
 
     @classmethod

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -602,6 +602,7 @@ class UnityEnvironment(BaseUnityEnvironment):
             except subprocess.TimeoutExpired:
                 logger.info("Environment timed out shutting down. Killing...")
                 self.proc1.kill()
+            self.proc1 = None
 
     @classmethod
     def _flatten(cls, arr: Any) -> List[float]:

--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -119,18 +119,18 @@ def worker(
             elif cmd.name == "close":
                 break
     except (KeyboardInterrupt, UnityCommunicationException):
-        print("UnityEnvironment worker: environment stopping.")
+        logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
         step_queue.put(EnvironmentResponse("env_close", worker_id, None))
     finally:
         # If this worker has put an item in the step queue that hasn't been processed by the EnvManager, the process
         # will hang until the item is processed. We avoid this behavior by using Queue.cancel_join_thread()
         # See https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.cancel_join_thread for
         # more info.
-        logger.debug(f"Worker {worker_id} closing.")
+        logger.debug(f"UnityEnvironment worker {worker_id} closing.")
         step_queue.cancel_join_thread()
         step_queue.close()
         env.close()
-        logger.debug(f"Worker {worker_id} done.")
+        logger.debug(f"UnityEnvironment worker {worker_id} done.")
 
 
 class SubprocessEnvManager(EnvManager):

--- a/ml-agents-envs/mlagents/envs/tests/test_envs.py
+++ b/ml-agents-envs/mlagents/envs/tests/test_envs.py
@@ -108,5 +108,11 @@ def test_close(mock_communicator, mock_launcher):
     assert comm.has_been_closed
 
 
+def test_returncode_to_signal_name():
+    assert UnityEnvironment.returncode_to_signal_name(-2) == "SIGINT"
+    assert UnityEnvironment.returncode_to_signal_name(42) is None
+    assert UnityEnvironment.returncode_to_signal_name("SIGINT") is None
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
While working on the timer code in https://github.com/Unity-Technologies/ml-agents/pull/2198 I noticed we weren't executing code at shutdown (namely so that I could write out the timer data).

This fixes two issues:
1) Don't kill the subprocess right away, give it a chance to shutdown. This should happen in the Academy code when the QUIT command is received*:
https://github.com/Unity-Technologies/ml-agents/blob/c916801475950ef92016b51c3fe5806ac60afc90/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs#L536-L544
2) Launch the executable process with `start_new_session=True`. Without this, hitting Ctrl-C would propagate the signal (SIGINT) to the subprocess, so it dies before getting a chance to do anything.

Related to 2), also nicely format the return code (would have saved me some time if I know negative return corresponded to the signal ID).

I'm not sure if we should add configuration parameters for
* shutdown timeout (I'm currently using the communicator's `timeout_wait` which defaults to 30s, but that seems too long)
* whether or not to set start_new_session - I think this should default to True but might need an option to override.


*(NOTE) We don't actually send QUIT here, but when the communicator gets the `400` status that python sends
https://github.com/Unity-Technologies/ml-agents/blob/c916801475950ef92016b51c3fe5806ac60afc90/UnitySDK/Assets/ML-Agents/Scripts/RpcCommunicator.cs#L107-L116
it returns null, so the batcher treats this as a QUIT
https://github.com/Unity-Technologies/ml-agents/blob/c916801475950ef92016b51c3fe5806ac60afc90/UnitySDK/Assets/ML-Agents/Scripts/Batcher.cs#L241-L245