### PR TITLE
Tf compat warnings

### DIFF
--- a/ml-agents/mlagents/trainers/models.py
+++ b/ml-agents/mlagents/trainers/models.py
@@ -3,7 +3,11 @@ from enum import Enum
 from typing import Any, Callable, Dict, List
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import tensorflow.contrib.layers as c_layers
 
 from mlagents.trainers.trainer import UnityTrainerException

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -2,7 +2,11 @@ import logging
 from typing import Any, Dict
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 
 from mlagents.envs.exception import UnityException
 from mlagents.envs.policy import Policy

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -2,7 +2,11 @@
 import logging
 from typing import Dict, List, Deque, Any
 import os
-import tensorflow as tf
+
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import numpy as np
 from collections import deque, defaultdict
 

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -8,7 +8,11 @@ import logging
 from typing import Dict, List, Optional
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from time import time
 
 from mlagents.envs.env_manager import EnvironmentStep


### PR DESCRIPTION
Try to quiet some spamming warnings like
```
WARNING:tensorflow:From /ml-agents/ml-agents/mlagents/trainers/models.py:35: The name tf.set_random_seed is deprecated. Please use tf.compat.v1.set_random_seed instead.
```