### PR TITLE
Curricula json fix

### DIFF
--- a/ml-agents/mlagents/trainers/meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/meta_curriculum.py
@@ -29,7 +29,10 @@ class MetaCurriculum(object):
         self._brains_to_curriculums = {}
 
         try:
-            for curriculum_filename in os.listdir(curriculum_folder):
+            for curriculum_filename in\
+            [fn for fn in os.listdir(curriculum_folder)\
+             if not fn.endswith('.meta')]:
+                
                 brain_name = curriculum_filename.split(".")[0]
                 curriculum_filepath = os.path.join(
                     curriculum_folder, curriculum_filename


### PR DESCRIPTION
I was having an issue with `meta_curriculum` attempting to generate curricula instances from Unity-made `curricula/MyThingLearning/MyThingLearning.json.meta` files. Obviously the meta files are _not_ intended to be used as .json sources.

The change simply excludes filenames ending in `.meta`.