### PR TITLE
use [] instead of Dictionary.Add to avoid key exception

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Brain.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Brain.cs
@@ -53,7 +53,7 @@ namespace MLAgents
         public void SendState(Agent agent, AgentInfo info)
         {
             LazyInitialize();
-            m_AgentInfos.Add(agent, info);
+            m_AgentInfos[agent] = info;
         }
 
         /// <summary>


### PR DESCRIPTION
When running inference, I sometimes see this error:
```ArgumentException: An item with the same key has already been added. Key: Agent (Ball3DAgent)
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
MLAgents.Brain.SendState (MLAgents.Agent agent, MLAgents.AgentInfo info) (at Assets/ML-Agents/Scripts/Brain.cs:56)
MLAgents.Agent.SendInfoToBrain () (at Assets/ML-Agents/Scripts/Agent.cs:653)
MLAgents.Agent.SendInfo () (at Assets/ML-Agents/Scripts/Agent.cs:1039)
MLAgents.Academy.EnvironmentStep () (at Assets/ML-Agents/Scripts/Academy.cs:556)
MLAgents.Academy.FixedUpdate () (at Assets/ML-Agents/Scripts/Academy.cs:583)
```
The root cause is another error (in this case, no model for the brain) but it's hidden by this one.

This has come up in some issues before https://github.com/Unity-Technologies/ml-agents/issues?utf8=%E2%9C%93&q=InsertionBehavior+