### PR TITLE
Modified meta_curriculum JSON reading loop to only deal with .json

### DIFF
--- a/ml-agents/mlagents/trainers/meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/meta_curriculum.py
@@ -30,6 +30,11 @@ class MetaCurriculum(object):
 
         try:
             for curriculum_filename in os.listdir(curriculum_folder):
+                
+                # This process requires JSON files
+                if not curriculum_filename.lower().endswith('.json'):
+                    continue
+
                 brain_name = curriculum_filename.split(".")[0]
                 curriculum_filepath = os.path.join(
                     curriculum_folder, curriculum_filename

--- a/ml-agents/mlagents/trainers/meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/meta_curriculum.py
@@ -32,7 +32,7 @@ class MetaCurriculum(object):
             for curriculum_filename in os.listdir(curriculum_folder):
                 
                 # This process requires JSON files
-                if not curriculum_filename.lower().endswith('.json'):
+                if not curriculum_filename.lower().endswith(".json"):
                     continue
 
                 brain_name = curriculum_filename.split(".")[0]

--- a/ml-agents/mlagents/trainers/meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/meta_curriculum.py
@@ -30,11 +30,9 @@ class MetaCurriculum(object):
 
         try:
             for curriculum_filename in os.listdir(curriculum_folder):
-                
                 # This process requires JSON files
                 if not curriculum_filename.lower().endswith(".json"):
                     continue
-
                 brain_name = curriculum_filename.split(".")[0]
                 curriculum_filepath = os.path.join(
                     curriculum_folder, curriculum_filename


### PR DESCRIPTION
See #2627
This is a bit cleaner!

Causes a `continue` in curriculum generation when the source file is not an expected JSON file.