### PR TITLE
Develop deprecate broadcasting

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/BroadcastHubDrawer.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/BroadcastHubDrawer.cs
@@ -18,7 +18,6 @@ namespace MLAgents
         // The vertical space left below the BroadcastHub UI.
         private const float k_ExtraSpaceBelow = 10f;
         // The horizontal size of the Control checkbox
-        private const int k_ControlSize = 80;
 
         /// <summary>
         /// Computes the height of the Drawer depending on the property it is showing
@@ -50,20 +49,15 @@ namespace MLAgents
             position.y += k_LineHeight;
 
             // This is the labels for each columns
-            var brainWidth = position.width - k_ControlSize;
+            var brainWidth = position.width;
             var brainRect = new Rect(
                 position.x, position.y, brainWidth, position.height);
-            var controlRect = new Rect(
-                position.x + brainWidth, position.y, k_ControlSize, position.height);
             if (m_Hub.Count > 0)
             {
                 EditorGUI.LabelField(brainRect, "Brains");
                 brainRect.y += k_LineHeight;
-                EditorGUI.LabelField(controlRect, "Control");
-                controlRect.y += k_LineHeight;
-                controlRect.x += 15;
             }
-            DrawBrains(brainRect, controlRect);
+            DrawBrains(brainRect);
             EditorGUI.indentLevel--;
             EditorGUI.EndProperty();
         }
@@ -118,37 +112,24 @@ namespace MLAgents
         /// </summary>
         /// <param name="brainRect">The Rect to draw the Brains.</param>
         /// <param name="controlRect">The Rect to draw the control checkbox.</param>
-        private void DrawBrains(Rect brainRect, Rect controlRect)
+        private void DrawBrains(Rect brainRect)
         {
             for (var index = 0; index < m_Hub.Count; index++)
             {
-                var exposedBrains = m_Hub.broadcastingBrains;
-                var brain = exposedBrains[index];
+                var controlledBrains = m_Hub.brainsToControl;
+                var brain = controlledBrains[index];
                 // This is the rectangle for the brain
                 EditorGUI.BeginChangeCheck();
                 var newBrain = EditorGUI.ObjectField(
-                    brainRect, brain, typeof(Brain), true) as Brain;
+                    brainRect, brain, typeof(LearningBrain), true) as LearningBrain;
                 brainRect.y += k_LineHeight;
                 if (EditorGUI.EndChangeCheck())
                 {
                     MarkSceneAsDirty();
-                    m_Hub.broadcastingBrains.RemoveAt(index);
-                    var brainToInsert = exposedBrains.Contains(newBrain) ? null : newBrain;
-                    exposedBrains.Insert(index, brainToInsert);
+                    m_Hub.brainsToControl.RemoveAt(index);
+                    var brainToInsert = controlledBrains.Contains(newBrain) ? null : newBrain;
+                    controlledBrains.Insert(index, brainToInsert);
                     break;
-                }
-                // This is the Rectangle for the control checkbox
-                EditorGUI.BeginChangeCheck();
-                if (brain is LearningBrain)
-                {
-                    var isTraining = m_Hub.IsControlled(brain);
-                    isTraining = EditorGUI.Toggle(controlRect, isTraining);
-                    m_Hub.SetControlled(brain, isTraining);
-                }
-                controlRect.y += k_LineHeight;
-                if (EditorGUI.EndChangeCheck())
-                {
-                    MarkSceneAsDirty();
                 }
             }
         }
@@ -192,7 +173,7 @@ namespace MLAgents
         {
             if (m_Hub.Count > 0)
             {
-                m_Hub.broadcastingBrains.RemoveAt(m_Hub.broadcastingBrains.Count - 1);
+                m_Hub.brainsToControl.RemoveAt(m_Hub.brainsToControl.Count - 1);
             }
         }
 
@@ -201,7 +182,7 @@ namespace MLAgents
         /// </summary>
         private void AddBrain()
         {
-            m_Hub.broadcastingBrains.Add(null);
+            m_Hub.brainsToControl.Add(null);
         }
     }
 }

--- a/UnitySDK/Assets/ML-Agents/Examples/3DBall/Scenes/3DBall.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/3DBall/Scenes/3DBall.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4497121, g: 0.4997778, b: 0.5756369, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971162, g: 0.49977726, b: 0.5756362, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -851,11 +851,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb15e3c3d55e54abaafb74c635b6a458, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 383c589e8bb76464eadc2525b5b0f2c1, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 300
     height: 200

--- a/UnitySDK/Assets/ML-Agents/Examples/3DBall/Scenes/3DBallHard.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/3DBall/Scenes/3DBallHard.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4497121, g: 0.4997778, b: 0.5756369, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971162, g: 0.49977726, b: 0.5756362, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -671,11 +671,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb15e3c3d55e54abaafb74c635b6a458, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 4f74e089fbb75455ebf6f0495e30be6e, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 300
     height: 200

--- a/UnitySDK/Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
@@ -282,11 +282,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19276d4dc78ee49f1ba258293f17636c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: e5cf0e35e16264ea483f8863e5115c3c, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity
@@ -835,11 +835,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7223013998783490db672119a97e1fdb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 573920e3a672d40038169c7ffdbdca05, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Crawler/Scenes/CrawlerDynamicTarget.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Crawler/Scenes/CrawlerDynamicTarget.unity
@@ -1323,11 +1323,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 05e76ca0a155e48caa36ee60e64ee9c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 0e3b44d36c7a047c4addb92457b12be5, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Crawler/Scenes/CrawlerStaticTarget.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Crawler/Scenes/CrawlerStaticTarget.unity
@@ -1345,11 +1345,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 05e76ca0a155e48caa36ee60e64ee9c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 0505e961608004377974940ed17e03d5, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 1280
     height: 720

--- a/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/Scenes/FoodCollector.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/Scenes/FoodCollector.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4497121, g: 0.4997778, b: 0.5756369, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971162, g: 0.49977726, b: 0.5756362, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -747,11 +747,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fe57113e76a5426297487dd6faadc5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 9e7865ec29c894c2d8c1617b0fa392f9, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 1500
   m_TrainingConfiguration:
     width: 500
     height: 500

--- a/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/Scenes/VisualFoodCollector.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/Scenes/VisualFoodCollector.unity
@@ -642,11 +642,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fe57113e76a5426297487dd6faadc5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 24e823594179d48189b2c78003c50ce0, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 500
     height: 500

--- a/UnitySDK/Assets/ML-Agents/Examples/GridWorld/Scenes/GridWorld.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/GridWorld/Scenes/GridWorld.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4497121, g: 0.4997778, b: 0.5756369, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971162, g: 0.49977726, b: 0.5756362, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -141,11 +141,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 506d4052eefa14ec9bbb356e3669043d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 2c1d51b7167874f31beda0b0cf0af468, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 84
     height: 84

--- a/UnitySDK/Assets/ML-Agents/Examples/Hallway/Scenes/Hallway.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Hallway/Scenes/Hallway.unity
@@ -1139,11 +1139,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 40db664a3061b46a0a0628f90b2264f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 533f2edd327794ca996d0320901b501c, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 128
     height: 128

--- a/UnitySDK/Assets/ML-Agents/Examples/Hallway/Scenes/VisualHallway.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Hallway/Scenes/VisualHallway.unity
@@ -809,10 +809,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 40db664a3061b46a0a0628f90b2264f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: fe56dd72ed38a4c2fb5419aba1e2d5f2, type: 2}
-    m_BrainsToControl: []
   m_TrainingConfiguration:
     width: 128
     height: 128

--- a/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scenes/PushBlock.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scenes/PushBlock.unity
@@ -1671,11 +1671,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a2ca406dad5ec4ede8184998f4f9067d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: e8b2d719f6a324b1abb68d8cf2859f5c, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 400
     height: 300

--- a/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scenes/VisualPushBlock.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scenes/VisualPushBlock.unity
@@ -616,10 +616,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a2ca406dad5ec4ede8184998f4f9067d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: d359d2290a825421e930c94284994e3f, type: 2}
-    m_BrainsToControl: []
   m_TrainingConfiguration:
     width: 1280
     height: 720

--- a/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/Pyramids.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/Pyramids.unity
@@ -1030,11 +1030,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dba8df9c8b16946dc88d331a301d0ab3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 7b7715ed1d436417db67026a47f17576, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/VisualPyramids.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/VisualPyramids.unity
@@ -606,12 +606,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dba8df9c8b16946dc88d331a301d0ab3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 60f0ffcd08c3b43a6bdc746cfc0c4059, type: 2}
-    m_BrainsToControl:
-    - {fileID: 11400000, guid: 60f0ffcd08c3b43a6bdc746cfc0c4059, type: 2}
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Reacher/Scenes/Reacher.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Reacher/Scenes/Reacher.unity
@@ -1265,11 +1265,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c970415924214d13949fbd6cddd1759, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: aee5a4acc5804447682bf509557afa4f, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/Soccer/Scenes/SoccerTwos.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Soccer/Scenes/SoccerTwos.unity
@@ -656,12 +656,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eaf2b7ab74c8a40608abae7343edd909, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
-    - {fileID: 11400000, guid: 29ed78b3e8fef4340b3a1f6954b88f18, type: 2}
+    brainsToControl:
     - {fileID: 11400000, guid: 090fa5a8588f5433bb7f878e6f5ac954, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
+    - {fileID: 11400000, guid: 29ed78b3e8fef4340b3a1f6954b88f18, type: 2}
   m_TrainingConfiguration:
     width: 800
     height: 500

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
@@ -730,11 +730,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1aadf59c24464a9fb5b4b3a2190c972, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 1674996276be448c2ad51fb139e21e05, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 25000
   m_TrainingConfiguration:
     width: 300
     height: 200

--- a/UnitySDK/Assets/ML-Agents/Examples/Walker/Scenes/Walker.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Walker/Scenes/Walker.unity
@@ -788,11 +788,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa787f943b9c245fbaee101760edef78, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
+    brainsToControl:
     - {fileID: 11400000, guid: 3541a9a488cf54088a4526cff85512cc, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Examples/WallJump/Scenes/WallJump.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/WallJump/Scenes/WallJump.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44971484, g: 0.49977952, b: 0.57563835, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971442, g: 0.499779, b: 0.5756377, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -1328,12 +1328,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50b93afe82bc647b581a706891913e7f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trainInEditor: 0
   broadcastHub:
-    broadcastingBrains:
-    - {fileID: 11400000, guid: b5f530c5bf8d64bf8a18df92e283bb9c, type: 2}
+    brainsToControl:
     - {fileID: 11400000, guid: 2069d6ef649a549feb29054d6af8a86f, type: 2}
-    m_BrainsToControl: []
-  m_MaxSteps: 0
+    - {fileID: 11400000, guid: b5f530c5bf8d64bf8a18df92e283bb9c, type: 2}
   m_TrainingConfiguration:
     width: 80
     height: 80

--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -268,10 +268,6 @@ namespace MLAgents
                 controlledBrains.Clear();
             }
 #endif
-            foreach (var brain in controlledBrains)
-            {
-                brain.SetToControlledExternally();
-            }
 
             // Try to launch the communicator by usig the arguments passed at launch
             try
@@ -320,7 +316,7 @@ namespace MLAgents
                 {
                     var bp = brain.brainParameters;
                     academyParameters.BrainParameters.Add(
-                        bp.ToProto(brain.name, true));
+                        bp.ToProto(brain.name));
                 }
                 academyParameters.EnvironmentParameters =
                     new CommunicatorObjects.EnvironmentParametersProto();

--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -316,7 +316,7 @@ namespace MLAgents
                 {
                     var bp = brain.brainParameters;
                     academyParameters.BrainParameters.Add(
-                        bp.ToProto(brain.name));
+                        bp.ToProto(brain.name, true));
                 }
                 academyParameters.EnvironmentParameters =
                     new CommunicatorObjects.EnvironmentParametersProto();

--- a/UnitySDK/Assets/ML-Agents/Scripts/Brain.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Brain.cs
@@ -21,29 +21,8 @@ namespace MLAgents
         protected Dictionary<Agent, AgentInfo> m_AgentInfos =
             new Dictionary<Agent, AgentInfo>(1024);
 
-        protected Batcher m_BrainBatcher;
-
         [System.NonSerialized]
         private bool m_IsInitialized;
-
-        /// <summary>
-        /// Sets the Batcher of the Brain. The brain will call the batcher at every step and give
-        /// it the agent's data using SendBrainInfo at each DecideAction call.
-        /// </summary>
-        /// <param name="batcher"> The Batcher the brain will use for the current session</param>
-        public void SetBatcher(Batcher batcher)
-        {
-            if (batcher == null)
-            {
-                m_BrainBatcher = null;
-            }
-            else
-            {
-                m_BrainBatcher = batcher;
-                m_BrainBatcher.SubscribeBrain(name);
-            }
-            LazyInitialize();
-        }
 
         /// <summary>
         /// Adds the data of an agent to the current batch so it will be processed in DecideAction.
@@ -84,7 +63,6 @@ namespace MLAgents
             if (m_IsInitialized)
             {
                 m_AgentInfos.Clear();
-
                 m_IsInitialized = false;
             }
         }
@@ -94,12 +72,11 @@ namespace MLAgents
         /// </summary>
         private void BrainDecideAction()
         {
-            m_BrainBatcher?.SendBrainInfo(name, m_AgentInfos);
             DecideAction();
         }
 
         /// <summary>
-        /// Is called only once at the begening of the training or inference session.
+        /// Is called only once at the begining of the training or inference session.
         /// </summary>
         protected abstract void Initialize();
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/BroadcastHub.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/BroadcastHub.cs
@@ -11,50 +11,27 @@ namespace MLAgents
     [System.Serializable]
     public class BroadcastHub
     {
-        [SerializeField]
-        public List<Brain> broadcastingBrains = new List<Brain>();
         [FormerlySerializedAs("_brainsToControl")]
         [SerializeField]
-        private List<Brain> m_BrainsToControl = new List<Brain>();
+        public List<LearningBrain> brainsToControl = new List<LearningBrain>();
 
         /// <summary>
         /// The number of Brains inside the BroadcastingHub.
         /// </summary>
         public int Count
         {
-            get { return broadcastingBrains.Count; }
-        }
-
-        /// <summary>
-        /// Checks that a given Brain is set to be remote controlled.
-        /// </summary>
-        /// <param name="brain"> The Brain that is beeing checked</param>
-        /// <returns>true if the Brain is set to Controlled and false otherwise. Will return
-        /// false if the Brain is not present in the Hub.</returns>
-        public bool IsControlled(Brain brain)
-        {
-            return m_BrainsToControl.Contains(brain);
+            get { return brainsToControl.Count; }
         }
 
         /// <summary>
         /// Sets a brain to controlled.
         /// </summary>
         /// <param name="brain"> The Brain that is being set to controlled</param>
-        /// <param name="controlled"> if true, the Brain will be set to remote controlled. Otherwise
-        /// the brain will be set to broadcast only.</param>
-        public void SetControlled(Brain brain, bool controlled)
+        public void SetControlled(LearningBrain brain)
         {
-            if (broadcastingBrains.Contains(brain))
+            if (!brainsToControl.Contains(brain))
             {
-                if (controlled && !m_BrainsToControl.Contains(brain))
-                {
-                    m_BrainsToControl.Add(brain);
-                }
-
-                if (!controlled && m_BrainsToControl.Contains(brain))
-                {
-                    m_BrainsToControl.Remove(brain);
-                }
+                brainsToControl.Add(brain);
             }
         }
 
@@ -63,8 +40,7 @@ namespace MLAgents
         /// </summary>
         public void Clear()
         {
-            broadcastingBrains.Clear();
-            m_BrainsToControl.Clear();
+            brainsToControl.Clear();
         }
     }
 }

--- a/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
@@ -43,24 +43,24 @@ namespace MLAgents
             }
             return agentInfoProto;
         }
-        
+
         /// <summary>
         /// Converts a Brain into to a Protobuff BrainInfoProto so it can be sent
         /// </summary>
         /// <returns>The BrainInfoProto generated.</returns>
         /// <param name="name">The name of the brain.</param>
         /// <param name="isTraining">Whether or not the Brain is training.</param>
-        public static BrainParametersProto ToProto(this BrainParameters bp, string name, bool isTraining)
+        public static BrainParametersProto ToProto(this BrainParameters bp, string name)
         {
             var brainParametersProto = new BrainParametersProto
             {
                 VectorObservationSize = bp.vectorObservationSize,
                 NumStackedVectorObservations = bp.numStackedVectorObservations,
-                VectorActionSize = {bp.vectorActionSize},
+                VectorActionSize = { bp.vectorActionSize },
                 VectorActionSpaceType =
                     (SpaceTypeProto)bp.vectorActionSpaceType,
                 BrainName = name,
-                IsTraining = isTraining
+                IsTraining = true
             };
             brainParametersProto.VectorActionDescriptions.AddRange(bp.vectorActionDescriptions);
             foreach (var res in bp.cameraResolutions)
@@ -92,7 +92,7 @@ namespace MLAgents
             };
             return demoProto;
         }
-        
+
         /// <summary>
         /// Initialize metadata values based on proto object.
         /// </summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
@@ -50,7 +50,7 @@ namespace MLAgents
         /// <returns>The BrainInfoProto generated.</returns>
         /// <param name="name">The name of the brain.</param>
         /// <param name="isTraining">Whether or not the Brain is training.</param>
-        public static BrainParametersProto ToProto(this BrainParameters bp, string name)
+        public static BrainParametersProto ToProto(this BrainParameters bp, string name, bool isTraining)
         {
             var brainParametersProto = new BrainParametersProto
             {
@@ -60,7 +60,7 @@ namespace MLAgents
                 VectorActionSpaceType =
                     (SpaceTypeProto)bp.vectorActionSpaceType,
                 BrainName = name,
-                IsTraining = true
+                IsTraining = isTraining
             };
             brainParametersProto.VectorActionDescriptions.AddRange(bp.vectorActionDescriptions);
             foreach (var res in bp.cameraResolutions)

--- a/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Grpc/GrpcExtensions.cs
@@ -56,7 +56,7 @@ namespace MLAgents
             {
                 VectorObservationSize = bp.vectorObservationSize,
                 NumStackedVectorObservations = bp.numStackedVectorObservations,
-                VectorActionSize = { bp.vectorActionSize },
+                VectorActionSize = {bp.vectorActionSize},
                 VectorActionSpaceType =
                     (SpaceTypeProto)bp.vectorActionSpaceType,
                 BrainName = name,

--- a/UnitySDK/Assets/ML-Agents/Scripts/LearningBrain.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/LearningBrain.cs
@@ -29,6 +29,7 @@ namespace MLAgents
     [CreateAssetMenu(fileName = "NewLearningBrain", menuName = "ML-Agents/Learning Brain")]
     public class LearningBrain : Brain
     {
+        private Batcher m_Batcher;
         private ITensorAllocator m_TensorAllocator;
         private TensorGenerator m_TensorGenerator;
         private TensorApplier m_TensorApplier;
@@ -47,16 +48,14 @@ namespace MLAgents
         private IReadOnlyList<TensorProxy> m_InferenceInputs;
         private IReadOnlyList<TensorProxy> m_InferenceOutputs;
 
-        [NonSerialized]
-        private bool m_IsControlled;
-
         /// <summary>
         /// When Called, the brain will be controlled externally. It will not use the
         /// model to decide on actions.
         /// </summary>
-        public void SetToControlledExternally()
+        public void SetBatcher(Batcher batcher)
         {
-            m_IsControlled = true;
+            m_Batcher = batcher;
+            m_Batcher?.SubscribeBrain(name);
         }
 
         /// <inheritdoc />
@@ -126,7 +125,8 @@ namespace MLAgents
         /// <inheritdoc />
         protected override void DecideAction()
         {
-            if (m_IsControlled)
+            m_Batcher?.SendBrainInfo(name, m_AgentInfos);
+            if (m_Batcher != null)
             {
                 m_AgentInfos.Clear();
                 return;

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -120,16 +120,12 @@ class UnityEnvironment(BaseUnityEnvironment):
         self._academy_name = aca_params.name
         self._log_path = aca_params.log_path
         self._brains: Dict[str, BrainParameters] = {}
-        self._brain_names: List[str] = []
         self._external_brain_names: List[str] = []
         for brain_param in aca_params.brain_parameters:
-            self._brain_names += [brain_param.brain_name]
             self._brains[brain_param.brain_name] = BrainParameters.from_proto(
                 brain_param
             )
-            if brain_param.is_training:
-                self._external_brain_names += [brain_param.brain_name]
-        self._num_brains = len(self._brain_names)
+            self._external_brain_names += [brain_param.brain_name]
         self._num_external_brains = len(self._external_brain_names)
         self._resetParameters = dict(aca_params.environment_parameters.float_parameters)
         logger.info(
@@ -154,16 +150,8 @@ class UnityEnvironment(BaseUnityEnvironment):
         return self._academy_name
 
     @property
-    def number_brains(self):
-        return self._num_brains
-
-    @property
     def number_external_brains(self):
         return self._num_external_brains
-
-    @property
-    def brain_names(self):
-        return self._brain_names
 
     @property
     def external_brain_names(self):
@@ -301,11 +289,9 @@ class UnityEnvironment(BaseUnityEnvironment):
     def __str__(self):
         return (
             """Unity Academy name: {0}
-        Number of Brains: {1}
-        Number of Training Brains : {2}
-        Reset Parameters :\n\t\t{3}""".format(
+        Number of Training Brains : {1}
+        Reset Parameters :\n\t\t{2}""".format(
                 self._academy_name,
-                str(self._num_brains),
                 str(self._num_external_brains),
                 "\n\t\t".join(
                     [
@@ -402,7 +388,7 @@ class UnityEnvironment(BaseUnityEnvironment):
                 elif self._num_external_brains > 1:
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names a keys, "
-                        "and vector_actions as values".format(self._num_brains)
+                        "and vector_actions as values".format(self._num_external_brains)
                     )
                 else:
                     raise UnityActionException(
@@ -416,7 +402,7 @@ class UnityEnvironment(BaseUnityEnvironment):
                 elif self._num_external_brains > 1:
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
-                        "and memories as values".format(self._num_brains)
+                        "and memories as values".format(self._num_external_brains)
                     )
                 else:
                     raise UnityActionException(
@@ -430,7 +416,7 @@ class UnityEnvironment(BaseUnityEnvironment):
                 elif self._num_external_brains > 1:
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
-                        "and text_actions as values".format(self._num_brains)
+                        "and text_actions as values".format(self._num_external_brains)
                     )
                 else:
                     raise UnityActionException(
@@ -445,7 +431,7 @@ class UnityEnvironment(BaseUnityEnvironment):
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
                         "and state/action value estimates as values".format(
-                            self._num_brains
+                            self._num_external_brains
                         )
                     )
                 else:
@@ -460,7 +446,7 @@ class UnityEnvironment(BaseUnityEnvironment):
                 elif self._num_external_brains > 1:
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
-                        "and CustomAction instances as values".format(self._num_brains)
+                        "and CustomAction instances as values".format(self._num_external_brains)
                     )
                 else:
                     raise UnityActionException(

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -447,8 +447,8 @@ class UnityEnvironment(BaseUnityEnvironment):
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
                         "and CustomAction instances as values".format(
-                                self._num_external_brains
-                            )
+                            self._num_external_brains
+                        )
                     )
                 else:
                     raise UnityActionException(

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -446,7 +446,9 @@ class UnityEnvironment(BaseUnityEnvironment):
                 elif self._num_external_brains > 1:
                     raise UnityActionException(
                         "You have {0} brains, you need to feed a dictionary of brain names as keys "
-                        "and CustomAction instances as values".format(self._num_external_brains)
+                        "and CustomAction instances as values".format(
+                                self._num_external_brains
+                            )
                     )
                 else:
                     raise UnityActionException(

--- a/ml-agents-envs/mlagents/envs/tests/test_envs.py
+++ b/ml-agents-envs/mlagents/envs/tests/test_envs.py
@@ -22,7 +22,7 @@ def test_initialization(mock_communicator, mock_launcher):
         discrete_action=False, visual_inputs=0
     )
     env = UnityEnvironment(" ")
-    assert env.brain_names[0] == "RealFakeBrain"
+    assert env.external_brain_names[0] == "RealFakeBrain"
     env.close()
 
 

--- a/ml-agents/mlagents/trainers/tests/mock_brain.py
+++ b/ml-agents/mlagents/trainers/tests/mock_brain.py
@@ -94,7 +94,6 @@ def setup_mock_unityenvironment(mock_env, mock_brain, mock_braininfo):
     mock_env.return_value.academy_name = "MockAcademy"
     mock_env.return_value.brains = {brain_name: mock_brain}
     mock_env.return_value.external_brain_names = [brain_name]
-    mock_env.return_value.brain_names = [brain_name]
     mock_env.return_value.reset.return_value = {brain_name: mock_braininfo}
     mock_env.return_value.step.return_value = {brain_name: mock_braininfo}
 
@@ -102,7 +101,7 @@ def setup_mock_unityenvironment(mock_env, mock_brain, mock_braininfo):
 def simulate_rollout(env, policy, buffer_init_samples):
     brain_info_list = []
     for i in range(buffer_init_samples):
-        brain_info_list.append(env.step()[env.brain_names[0]])
+        brain_info_list.append(env.step()[env.external_brain_names[0]])
     buffer = create_buffer(brain_info_list, policy.brain, policy.sequence_length)
     return buffer
 

--- a/ml-agents/mlagents/trainers/tests/test_bc.py
+++ b/ml-agents/mlagents/trainers/tests/test_bc.py
@@ -106,13 +106,15 @@ def test_bc_policy_evaluate(mock_communicator, mock_launcher, dummy_config):
     )
     env = UnityEnvironment(" ")
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
 
     trainer_parameters = dummy_config
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
-    policy = BCPolicy(0, env.brains[env.brain_names[0]], trainer_parameters, False)
+    policy = BCPolicy(
+        0, env.brains[env.external_brain_names[0]], trainer_parameters, False
+    )
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (3, 2)
 

--- a/ml-agents/mlagents/trainers/tests/test_bcmodule.py
+++ b/ml-agents/mlagents/trainers/tests/test_bcmodule.py
@@ -83,7 +83,7 @@ def create_policy_with_bc_mock(
     mb.setup_mock_unityenvironment(mock_env, mock_brain, mock_braininfo)
     env = mock_env()
 
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_config["model_path"] = model_path
     trainer_config["keep_checkpoints"] = 3
     trainer_config["use_recurrent"] = use_rnn

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -55,14 +55,14 @@ def test_ppo_policy_evaluate(mock_communicator, mock_launcher, dummy_config):
     )
     env = UnityEnvironment(" ")
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
 
     trainer_parameters = dummy_config
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
     policy = PPOPolicy(
-        0, env.brains[env.brain_names[0]], trainer_parameters, False, False
+        0, env.brains[env.external_brain_names[0]], trainer_parameters, False, False
     )
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (3, 2)
@@ -78,14 +78,14 @@ def test_ppo_get_value_estimates(mock_communicator, mock_launcher, dummy_config)
     )
     env = UnityEnvironment(" ")
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
 
     trainer_parameters = dummy_config
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
     policy = PPOPolicy(
-        0, env.brains[env.brain_names[0]], trainer_parameters, False, False
+        0, env.brains[env.external_brain_names[0]], trainer_parameters, False, False
     )
     run_out = policy.get_value_estimates(brain_info, 0, done=False)
     for key, val in run_out.items():

--- a/ml-agents/mlagents/trainers/tests/test_reward_signals.py
+++ b/ml-agents/mlagents/trainers/tests/test_reward_signals.py
@@ -108,7 +108,7 @@ def create_policy_mock(
     )
 
     trainer_parameters = trainer_config
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
     trainer_parameters["reward_signals"].update(reward_signal_config)
@@ -122,8 +122,8 @@ def create_policy_mock(
 
 def reward_signal_eval(env, policy, reward_signal_name):
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
-    next_brain_info = env.step()[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
+    next_brain_info = env.step()[env.external_brain_names[0]]
     # Test evaluate
     rsig_result = policy.reward_signals[reward_signal_name].evaluate(
         brain_info, next_brain_info

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -65,7 +65,7 @@ def create_sac_policy_mock(mock_env, dummy_config, use_rnn, use_discrete, use_vi
     )
 
     trainer_parameters = dummy_config
-    model_path = env.brain_names[0]
+    model_path = env.external_brain_names[0]
     trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
     trainer_parameters["use_recurrent"] = use_rnn
@@ -81,7 +81,7 @@ def test_sac_cc_policy(mock_env, dummy_config):
         mock_env, dummy_config, use_rnn=False, use_discrete=False, use_visual=False
     )
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (NUM_AGENTS, VECTOR_ACTION_SPACE[0])
 
@@ -128,7 +128,7 @@ def test_sac_dc_policy(mock_env, dummy_config):
         mock_env, dummy_config, use_rnn=False, use_discrete=True, use_visual=False
     )
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (NUM_AGENTS, len(DISCRETE_ACTION_SPACE))
 
@@ -150,7 +150,7 @@ def test_sac_visual_policy(mock_env, dummy_config):
         mock_env, dummy_config, use_rnn=False, use_discrete=True, use_visual=True
     )
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (NUM_AGENTS, len(DISCRETE_ACTION_SPACE))
 
@@ -172,7 +172,7 @@ def test_sac_rnn_policy(mock_env, dummy_config):
         mock_env, dummy_config, use_rnn=True, use_discrete=True, use_visual=False
     )
     brain_infos = env.reset()
-    brain_info = brain_infos[env.brain_names[0]]
+    brain_info = brain_infos[env.external_brain_names[0]]
     run_out = policy.evaluate(brain_info)
     assert run_out["action"].shape == (NUM_AGENTS, len(DISCRETE_ACTION_SPACE))
 

--- a/notebooks/getting-started.ipynb
+++ b/notebooks/getting-started.ipynb
@@ -78,7 +78,7 @@
     "env = UnityEnvironment(file_name=env_name)\n",
     "\n",
     "# Set the default brain to work with\n",
-    "default_brain = env.brain_names[0]\n",
+    "default_brain = env.external_brain_names[0]\n",
     "brain = env.brains[default_brain]"
    ]
   },


### PR DESCRIPTION
[Associated Design Document](https://docs.google.com/document/d/1q_eJ5KHNcVXoEBkGxTm-3Kt4zl4_aAoeuccrdIoEfkI/edit#)

Builds on top of #2659 

In this PR : 
 - Removal of the `Control` checkbox in the BroadcastHub of the Academy
 - By default, all learning brains will be trained by Python
 - The BroadcastHub is now a list of **LearningBrains** and not **Brains**
 - In Editor : 
    - If no brains are in the Hub OR if there is no Python process to communicate with Inference
    - If there is at least one Brain in the Hub and UnityEnvironment was created without an executable : Training
 - In Executable : 
    - If launched with a UnityEnvironment : Training
    - If opened manually : Inference

TODO : 
 - Documentation