### PR TITLE
Fix visual Pyramids and Pushblock scenes

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Brains/PushBlockLearning.asset
+++ b/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Brains/PushBlockLearning.asset
@@ -12,13 +12,10 @@ MonoBehaviour:
   m_Name: PushBlockLearning
   m_EditorClassIdentifier: 
   brainParameters:
-    vectorObservationSize: 0
+    vectorObservationSize: 70
     numStackedVectorObservations: 3
     vectorActionSize: 07000000
-    cameraResolutions:
-    - width: 84
-      height: 84
-      blackAndWhite: 0
+    cameraResolutions: []
     vectorActionDescriptions:
     - 
     vectorActionSpaceType: 0

--- a/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Prefabs/VisualAreaPyramids.prefab
+++ b/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Prefabs/VisualAreaPyramids.prefab
@@ -3196,7 +3196,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8db44472779248d3be46895c4d562d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  brain: {fileID: 11400000, guid: 59a04e208fb8a423586adf25bf1fecd0, type: 2}
+  brain: {fileID: 11400000, guid: 60f0ffcd08c3b43a6bdc746cfc0c4059, type: 2}
   agentParameters:
     agentCameras:
     - {fileID: 20712684238256298}

--- a/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/VisualPyramids.unity
+++ b/UnitySDK/Assets/ML-Agents/Examples/Pyramids/Scenes/VisualPyramids.unity
@@ -609,9 +609,7 @@ MonoBehaviour:
   broadcastHub:
     broadcastingBrains:
     - {fileID: 11400000, guid: 60f0ffcd08c3b43a6bdc746cfc0c4059, type: 2}
-    m_BrainsToControl:
-    - {fileID: 11400000, guid: 60f0ffcd08c3b43a6bdc746cfc0c4059, type: 2}
-  m_MaxSteps: 0
+    m_BrainsToControl: []
   m_TrainingConfiguration:
     width: 80
     height: 80


### PR DESCRIPTION
- Uncheck "Control" box
- Assign VisualPyramidsLearning to agent by default
- Add vector obs back into PushBlockLearning (non Visual) and remove camera obs