### PR TITLE
exclude bair.berkeley.edu temporarily

### DIFF
--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -7,6 +7,10 @@
         {
             "pattern": "^https://developer.nvidia.com/compute/machine-learning/cudnn/secure",
             "comment": "Requires login"
+        },
+        {
+            "pattern": "^https?://bair.berkeley.edu",
+            "comment": "Temporary berkeley outage"
         }
     ]
 }


### PR DESCRIPTION
These aren't responding, so temporarily whitelist them.

I created MLA-162 as a reminder to undo this one it's fixed.