### PR TITLE
Check for unnecessary list comprehensions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
                 .*_pb2.py|
                 .*_pb2_grpc.py
             )$
+        additional_dependencies: [flake8-comprehensions]
 # "Local" hooks, see https://pre-commit.com/#repository-local-hooks
 -   repo: local
     hooks:

--- a/ml-agents-envs/mlagents/envs/brain.py
+++ b/ml-agents-envs/mlagents/envs/brain.py
@@ -207,7 +207,7 @@ class BrainInfo:
         if len(agent_info_list) == 0:
             memory_size = 0
         else:
-            memory_size = max([len(x.memories) for x in agent_info_list])
+            memory_size = max(len(x.memories) for x in agent_info_list)
         if memory_size == 0:
             memory = np.zeros((0, 0))
         else:
@@ -225,11 +225,11 @@ class BrainInfo:
                         0 if agent_info.action_mask[k] else 1
                         for k in range(total_num_actions)
                     ]
-        if any([np.isnan(x.reward) for x in agent_info_list]):
+        if any(np.isnan(x.reward) for x in agent_info_list):
             logger.warning(
                 "An agent had a NaN reward for brain " + brain_params.brain_name
             )
-        if any([np.isnan(x.stacked_vector_observation).any() for x in agent_info_list]):
+        if any(np.isnan(x.stacked_vector_observation).any() for x in agent_info_list):
             logger.warning(
                 "An agent had a NaN observation for brain " + brain_params.brain_name
             )

--- a/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
+++ b/ml-agents-envs/mlagents/envs/subprocess_env_manager.py
@@ -202,7 +202,7 @@ class SubprocessEnvManager(EnvManager):
         train_mode: bool = True,
         custom_reset_parameters: Any = None,
     ) -> List[EnvironmentStep]:
-        while any([ew.waiting for ew in self.env_workers]):
+        while any(ew.waiting for ew in self.env_workers):
             if not self.step_queue.empty():
                 step = self.step_queue.get_nowait()
                 self.env_workers[step.worker_id].waiting = False

--- a/ml-agents/mlagents/trainers/meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/meta_curriculum.py
@@ -1,6 +1,7 @@
 """Contains the MetaCurriculum class."""
 
 import os
+from typing import Any, Dict, Set
 from mlagents.trainers.curriculum import Curriculum
 from mlagents.trainers.exception import MetaCurriculumError
 
@@ -14,7 +15,9 @@ class MetaCurriculum(object):
     particular brain in the environment.
     """
 
-    def __init__(self, curriculum_folder, default_reset_parameters):
+    def __init__(
+        self, curriculum_folder: str, default_reset_parameters: Dict[str, Any]
+    ):
         """Initializes a MetaCurriculum object.
 
         Args:
@@ -25,8 +28,8 @@ class MetaCurriculum(object):
             default_reset_parameters (dict): The default reset parameters
                 of the environment.
         """
-        used_reset_parameters = set()
-        self._brains_to_curriculums = {}
+        used_reset_parameters: Set[str] = set()
+        self._brains_to_curriculums: Dict[str, Curriculum] = {}
 
         try:
             for curriculum_filename in os.listdir(curriculum_folder):
@@ -38,14 +41,10 @@ class MetaCurriculum(object):
                     curriculum_folder, curriculum_filename
                 )
                 curriculum = Curriculum(curriculum_filepath, default_reset_parameters)
+                config_keys: Set[str] = set(curriculum.get_config().keys())
 
                 # Check if any two curriculums use the same reset params.
-                if any(
-                    [
-                        (parameter in curriculum.get_config().keys())
-                        for parameter in used_reset_parameters
-                    ]
-                ):
+                if config_keys & used_reset_parameters:
                     logger.warning(
                         "Two or more curriculums will "
                         "attempt to change the same reset "
@@ -53,7 +52,7 @@ class MetaCurriculum(object):
                         "non-deterministic."
                     )
 
-                used_reset_parameters.update(curriculum.get_config().keys())
+                used_reset_parameters.update(config_keys)
                 self._brains_to_curriculums[brain_name] = curriculum
         except NotADirectoryError:
             raise MetaCurriculumError(

--- a/ml-agents/mlagents/trainers/sac/policy.py
+++ b/ml-agents/mlagents/trainers/sac/policy.py
@@ -113,7 +113,7 @@ class SACPolicy(TFPolicy):
                 seed=seed,
                 stream_names=list(reward_signal_configs.keys()),
                 tau=float(trainer_params["tau"]),
-                gammas=list(_val["gamma"] for _val in reward_signal_configs.values()),
+                gammas=[_val["gamma"] for _val in reward_signal_configs.values()],
                 vis_encode_type=EncoderType(
                     trainer_params.get("vis_encode_type", "simple")
                 ),

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -163,7 +163,7 @@ class TrainerController(object):
 
     def _not_done_training(self) -> bool:
         return (
-            any([t.get_step <= t.get_max_steps for k, t in self.trainers.items()])
+            any(t.get_step <= t.get_max_steps for k, t in self.trainers.items())
             or not self.train_model
         ) or len(self.trainers) == 0
 


### PR DESCRIPTION
Small python cleanup - lines like `any([x for x in y if z])` are slightly wasteful because they form the whole list (no opportunity to early out). This PR adds enforcement for this, and fixes the few cases where it was being used.