### PR TITLE
precommit: check-mock-methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
                 .*_pb2.py|
                 .*_pb2_grpc.py
             )$
+
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.720
     hooks:
@@ -25,6 +26,7 @@ repos:
         name: mypy-gym-unity
         files: "gym-unity/.*"
         args: [--ignore-missing-imports, --disallow-incomplete-defs]
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
@@ -43,6 +45,12 @@ repos:
                 .*_pb2_grpc.py
             )$
         additional_dependencies: [flake8-comprehensions]
+
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.4.1  # Use the ref you want to point at
+    hooks:
+    -   id: python-check-mock-methods
+
 # "Local" hooks, see https://pre-commit.com/#repository-local-hooks
 -   repo: local
     hooks:


### PR DESCRIPTION
This flags some common mock mis-usages, like
``` python
mck.assert_not_called  #wrong
assert mck.not_called()  # wrong
mck.assert_not_called()  # right
```
Fortunately none of these were happening here.
