### PR TITLE
Whitelist announcement label from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,3 +24,4 @@ issues:
     - bug
     - request
     - help-wanted
+    - announcement


### PR DESCRIPTION
Re: https://github.com/Unity-Technologies/ml-agents/issues/2493#issuecomment-542958280

@unityjeffrey's announcements are timeless and should be exempt from stalebot.