### PR TITLE
Added --cpu flag to run using only cpu for training

### DIFF
--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -159,7 +159,7 @@ environment, you can set the following command line options when invoking
   All arguments after this flag will be passed to the executable. For example, setting
   `mlagents-learn config/trainer_config.yaml --env-args --num-orcs 42` would result in
    ` --num-orcs 42` passed to the executable.
-
+* `--cpu`: Forces training using CPU only.
 
 ### Training Config File
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -44,6 +44,7 @@ class CommandLineOptions(NamedTuple):
     sampler_file_path: Optional[str]
     docker_target_name: Optional[str]
     env_args: Optional[List[str]]
+    cpu: bool
 
     @property
     def fast_simulation(self) -> bool:
@@ -155,6 +156,13 @@ def parse_command_line(argv: Optional[List[str]] = None) -> CommandLineOptions:
         default=None,
         nargs=argparse.REMAINDER,
         help="Arguments passed to the Unity executable.",
+    )
+    
+    parser.add_argument(
+        "--cpu",
+        default=False,
+        action="store_true",
+        help="Run with CPU only",
     )
 
     args = parser.parse_args(argv)
@@ -410,6 +418,8 @@ def main():
 
     jobs = []
     run_seed = options.seed
+    if options.cpu:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
     if options.num_runs == 1:
         if options.seed == -1:

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -157,12 +157,8 @@ def parse_command_line(argv: Optional[List[str]] = None) -> CommandLineOptions:
         nargs=argparse.REMAINDER,
         help="Arguments passed to the Unity executable.",
     )
-    
     parser.add_argument(
-        "--cpu",
-        default=False,
-        action="store_true",
-        help="Run with CPU only",
+        "--cpu", default=False, action="store_true", help="Run with CPU only"
     )
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
Discussion: 
[Flag to force training with CPU #2751 ](https://github.com/Unity-Technologies/ml-agents/issues/2751)