### PR TITLE
move CacheBrainParameters() and friends out of #if blocks

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Grpc/RpcCommunicator.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Grpc/RpcCommunicator.cs
@@ -409,23 +409,6 @@ namespace MLAgents
             };
         }
 
-        #endregion
-
-#if UNITY_EDITOR
-#if UNITY_2017_2_OR_NEWER
-        /// <summary>
-        /// When the editor exits, the communicator must be closed
-        /// </summary>
-        /// <param name="state">State.</param>
-        private void HandleOnPlayModeChanged(PlayModeStateChange state)
-        {
-            // This method is run whenever the playmode state is changed.
-            if (state == PlayModeStateChange.ExitingPlayMode)
-            {
-                Dispose();
-            }
-        }
-
         private void CacheBrainParameters(string brainKey, BrainParameters brainParameters)
         {
             if (m_sentBrainKeys.Contains(brainKey))
@@ -468,6 +451,23 @@ namespace MLAgents
             {
                 m_sentBrainKeys.Add(brainProto.BrainName);
                 m_unsentBrainKeys.Remove(brainProto.BrainName);
+            }
+        }
+
+        #endregion
+
+#if UNITY_EDITOR
+#if UNITY_2017_2_OR_NEWER
+        /// <summary>
+        /// When the editor exits, the communicator must be closed
+        /// </summary>
+        /// <param name="state">State.</param>
+        private void HandleOnPlayModeChanged(PlayModeStateChange state)
+        {
+            // This method is run whenever the playmode state is changed.
+            if (state == PlayModeStateChange.ExitingPlayMode)
+            {
+                Dispose();
             }
         }
 


### PR DESCRIPTION
The diff is a bit wonky; this moves CacheBrainParameters, GetTempUnityRlInitializationOutput, and UpdateSentBrainParameters outside of the 
```
#if UNITY_EDITOR
#if UNITY_2017_2_OR_NEWER
```
block that they're currently in