### PR TITLE
gym - handle uint8_visual for observation space

### DIFF
--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -53,7 +53,8 @@ class UnityEnv(gym.Env):
         )
 
         # Take a single step so that the brain information will be sent over
-        self._env.step()
+        if not self._env.brains:
+            self._env.step()
 
         self.name = self._env.academy_name
         self.visual_obs = None

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -51,6 +51,10 @@ class UnityEnv(gym.Env):
         self._env = UnityEnvironment(
             environment_filename, worker_id, no_graphics=no_graphics
         )
+
+        # Take a single step so that the brain information will be sent over
+        self._env.step()
+
         self.name = self._env.academy_name
         self.visual_obs = None
         self._current_state = None
@@ -132,16 +136,20 @@ class UnityEnv(gym.Env):
         high = np.array([np.inf] * brain.vector_observation_space_size)
         self.action_meanings = brain.vector_action_descriptions
         if self.use_visual:
-            self._observation_space = spaces.Box(
-                0,
-                1,
-                dtype=np.float32,
-                shape=(
-                    brain.camera_resolutions.height,
-                    brain.camera_resolutions.width,
-                    brain.camera_resolutions.num_channels,
-                ),
+            shape = (
+                brain.camera_resolutions[0].height,
+                brain.camera_resolutions[0].width,
+                brain.camera_resolutions[0].num_channels,
             )
+            if uint8_visual:
+                self._observation_space = spaces.Box(
+                    0, 255, dtype=np.uint8, shape=shape
+                )
+            else:
+                self._observation_space = spaces.Box(
+                    0, 1, dtype=np.float32, shape=shape
+                )
+
         else:
             self._observation_space = spaces.Box(-high, high, dtype=np.float32)
 


### PR DESCRIPTION
* Fixes a bug introduced in https://github.com/Unity-Technologies/ml-agents/pull/2656 when accessing the camera resolutions
* Fixes a bug introduced by the agent/brain refactoring, where the brain parameters aren't always present after environment initialization.
* Fixes the observation space when using `uint8_visual`