### PR TITLE
Deploy new versions to pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ workflows:
             - python_3.7.3
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
             branches:
               ignore: /.*/
       - deploy:
@@ -250,7 +250,7 @@ workflows:
             - python_3.7.3
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)(\.dev[0-9]+)*/
             branches:
               ignore: /.*/
       - deploy:
@@ -260,6 +260,6 @@ workflows:
             - python_3.7.3
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,50 +170,50 @@ jobs:
             path: /tmp/proto.patch
             destination: proto.patch
 
-deploy:
-  parameters:
-    version:
-      type: directory
-  docker:
-    - image: circleci/python:3.6
-  steps:
-    - checkout
-    - run:
-        name: install python dependencies
-        command: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install  --upgrade pip
-          pip install setuptools wheel twine
-    - run:
-        name: verify git tag vs. version
-        command: |
-          python3 -m venv venv
-          . venv/bin/activate
-          cd << parameters.directory >>
-          python setup.py verify
-    - run:
-        name: init .pypirc
-        # TODO update username for final release
-        command: |
-          echo -e "[pypi]" >> ~/.pypirc
-          echo -e "username = mlagents-test" >> ~/.pypirc
-          echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-    - run:
-        # TODO example doesn't use venv here but I think we need it
-        name: create packages
-        command: |
-          . venv/bin/activate
-          cd << parameters.directory >>
-          python setup.py sdist
-          python setup.py bdist_wheel
-    - run:
-        name: upload to pypi
-        # TODO remove --repository-url for final release
-        command: |
-          . venv/bin/activate
-          cd << parameters.directory >>
-          twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+  deploy:
+    parameters:
+      version:
+        type: directory
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install  --upgrade pip
+            pip install setuptools wheel twine
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            cd << parameters.directory >>
+            python setup.py verify
+      - run:
+          name: init .pypirc
+          # TODO update username for final release
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = mlagents-test" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          # TODO example doesn't use venv here but I think we need it
+          name: create packages
+          command: |
+            . venv/bin/activate
+            cd << parameters.directory >>
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: upload to pypi
+          # TODO remove --repository-url for final release
+          command: |
+            . venv/bin/activate
+            cd << parameters.directory >>
+            twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 workflows:
   workflow:
@@ -233,7 +233,7 @@ workflows:
       - markdown_link_check
       - protobuf_generation_check
       - deploy:
-          name: deploy-ml-agents-envs
+          name: deploy ml-agents-envs
           directory: ml-agents-envs
           requires:
             - python_3.7.3
@@ -243,7 +243,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
-          name: deploy-ml-agents
+          name: deploy ml-agents
           directory: ml-agents
           requires:
             - python_3.7.3
@@ -253,7 +253,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
-          name: deploy-gym-unity
+          name: deploy gym-unity
           directory: gym-unity
           requires:
             - python_3.7.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,6 @@ jobs:
             cd << parameters.directory >>
             python setup.py verify
       - run:
-          # TODO example doesn't use venv here but I think we need it
           name: create packages
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,49 +171,49 @@ jobs:
             destination: proto.patch
 
 deploy:
-    parameters:
-      version:
-        type: directory
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: install python dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install  --upgrade pip
-            pip install setuptools wheel twine
-      - run:
-          name: verify git tag vs. version
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            cd << parameters.directory >>
-            python setup.py verify
-      - run:
-          name: init .pypirc
-          # TODO update username for final release
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = mlagents-test" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
-          # TODO example doesn't use venv here but I think we need it
-          name: create packages
-          command: |
-            . venv/bin/activate
-            cd << parameters.directory >>
-            python setup.py sdist
-            python setup.py bdist_wheel
-      - run:
-          name: upload to pypi
-          # TODO remove --repository-url for final release
-          command: |
-            . venv/bin/activate
-            cd << parameters.directory >>
-            twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+  parameters:
+    version:
+      type: directory
+  docker:
+    - image: circleci/python:3.6
+  steps:
+    - checkout
+    - run:
+        name: install python dependencies
+        command: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install  --upgrade pip
+          pip install setuptools wheel twine
+    - run:
+        name: verify git tag vs. version
+        command: |
+          python3 -m venv venv
+          . venv/bin/activate
+          cd << parameters.directory >>
+          python setup.py verify
+    - run:
+        name: init .pypirc
+        # TODO update username for final release
+        command: |
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "username = mlagents-test" >> ~/.pypirc
+          echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+    - run:
+        # TODO example doesn't use venv here but I think we need it
+        name: create packages
+        command: |
+          . venv/bin/activate
+          cd << parameters.directory >>
+          python setup.py sdist
+          python setup.py bdist_wheel
+    - run:
+        name: upload to pypi
+        # TODO remove --repository-url for final release
+        command: |
+          . venv/bin/activate
+          cd << parameters.directory >>
+          twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 workflows:
   workflow:
@@ -233,7 +233,7 @@ workflows:
       - markdown_link_check
       - protobuf_generation_check
       - deploy:
-          name: deploy ml-agents-envs
+          name: deploy-ml-agents-envs
           directory: ml-agents-envs
           requires:
             - python_3.7.3
@@ -243,7 +243,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
-          name: deploy ml-agents
+          name: deploy-ml-agents
           directory: ml-agents
           requires:
             - python_3.7.3
@@ -253,7 +253,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
-          name: deploy gym-unity
+          name: deploy-gym-unity
           directory: gym-unity
           requires:
             - python_3.7.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,9 @@ jobs:
 
   deploy:
     parameters:
-      version:
-        type: directory
+      directory:
+        type: string
+        description: Local directory to use for publishing (e.g. ml-agents)
     docker:
       - image: circleci/python:3.6
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,51 @@ jobs:
             path: /tmp/proto.patch
             destination: proto.patch
 
+deploy:
+    parameters:
+      version:
+        type: directory
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install  --upgrade pip
+            pip install setuptools wheel twine
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            cd << parameters.directory >>
+            python setup.py verify
+      - run:
+          name: init .pypirc
+          # TODO update username for final release
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = mlagents-test" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          # TODO example doesn't use venv here but I think we need it
+          name: create packages
+          command: |
+            . venv/bin/activate
+            cd << parameters.directory >>
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: upload to pypi
+          # TODO remove --repository-url for final release
+          command: |
+            . venv/bin/activate
+            cd << parameters.directory >>
+            twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
 workflows:
   workflow:
     jobs:
@@ -187,3 +232,33 @@ workflows:
           pip_constraints: test_constraints_max_version.txt
       - markdown_link_check
       - protobuf_generation_check
+      - deploy:
+          name: deploy ml-agents-envs
+          directory: ml-agents-envs
+          requires:
+            - python_3.7.3
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+      - deploy:
+          name: deploy ml-agents
+          directory: ml-agents
+          requires:
+            - python_3.7.3
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+      - deploy:
+          name: deploy gym-unity
+          directory: gym-unity
+          requires:
+            - python_3.7.3
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
             - python_3.7.3
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)(\.dev[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
             branches:
               ignore: /.*/
       - deploy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,8 @@ repos:
         exclude: ".*localized.*"
         # Only run manually, e.g. pre-commit run --hook-stage manual markdown-link-check
         stages: [manual]
+    -   id: validate-versions
+        name: validate library versions
+        language: script
+        entry: utils/validate_versions.py
+        files: ".*/setup.py"

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.11.0.dev"
+VERSION = "0.10.1"
 
 
 class VerifyVersionCommand(install):

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -5,13 +5,13 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.10.1"
+VERSION = "0.11.0.dev"
 
 
 class VerifyVersionCommand(install):
     """
     Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
     """
 
     description = "verify that the git tag matches our version"

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -11,7 +11,7 @@ VERSION = "0.11.0.dev0"
 class VerifyVersionCommand(install):
     """
     Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
     """
 
     description = "verify that the git tag matches our version"

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.10.1"
+VERSION = "0.11.0.dev0"
 
 
 class VerifyVersionCommand(install):

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -1,8 +1,30 @@
 #!/usr/bin/env python
 
+import os
+import sys
 from setuptools import setup, find_packages
+from setuptools.command.install import install
 
 VERSION = "0.10.1"
+
+
+class VerifyVersionCommand(install):
+    """
+    Custom command to verify that the git tag matches our version
+    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    """
+
+    description = "verify that the git tag matches our version"
+
+    def run(self):
+        tag = os.getenv("CIRCLE_TAG")
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
 
 setup(
     name="gym_unity",
@@ -14,4 +36,5 @@ setup(
     url="https://github.com/Unity-Technologies/ml-agents",
     packages=find_packages(),
     install_requires=["gym", "mlagents_envs=={}".format(VERSION)],
+    cmdclass={"verify": VerifyVersionCommand},
 )

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -2,14 +2,16 @@
 
 from setuptools import setup, find_packages
 
+VERSION = "0.10.1"
+
 setup(
     name="gym_unity",
-    version="0.4.8",
+    version=VERSION,
     description="Unity Machine Learning Agents Gym Interface",
     license="Apache License 2.0",
     author="Unity Technologies",
     author_email="ML-Agents@unity3d.com",
     url="https://github.com/Unity-Technologies/ml-agents",
     packages=find_packages(),
-    install_requires=["gym", "mlagents_envs==0.10.1"],
+    install_requires=["gym", "mlagents_envs=={}".format(VERSION)],
 )

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -5,13 +5,13 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.11.0.dev0"
+VERSION = "0.10.1"
 
 
 class VerifyVersionCommand(install):
     """
     Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
     """
 
     description = "verify that the git tag matches our version"

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -11,7 +11,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 class VerifyVersionCommand(install):
     """
     Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
     """
 
     description = "verify that the git tag matches our version"

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.10.1"
+VERSION = "0.11.0.dev0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.11.0.dev0"
+VERSION = "0.10.1"
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -1,9 +1,30 @@
+import os
+import sys
 from setuptools import setup
-from os import path
+from setuptools.command.install import install
 
 VERSION = "0.10.1"
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+class VerifyVersionCommand(install):
+    """
+    Custom command to verify that the git tag matches our version
+    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    """
+
+    description = "verify that the git tag matches our version"
+
+    def run(self):
+        tag = os.getenv("CIRCLE_TAG")
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
 
 setup(
     name="mlagents_envs",
@@ -29,4 +50,5 @@ setup(
         "protobuf>=3.6",
     ],
     python_requires=">=3.5",
+    cmdclass={"verify": VerifyVersionCommand},
 )

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -1,11 +1,13 @@
 from setuptools import setup
 from os import path
 
+VERSION = "0.10.1"
+
 here = path.abspath(path.dirname(__file__))
 
 setup(
     name="mlagents_envs",
-    version="0.10.1",
+    version=VERSION,
     description="Unity Machine Learning Agents Interface",
     url="https://github.com/Unity-Technologies/ml-agents",
     author="Unity Technologies",

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
 
-VERSION = "0.10.1"
+VERSION = "0.11.0.dev0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -1,13 +1,35 @@
-from setuptools import setup, find_namespace_packages
-from os import path
 from io import open
+import os
+import sys
+
+from setuptools import setup, find_namespace_packages
+from setuptools.command.install import install
 
 VERSION = "0.10.1"
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+class VerifyVersionCommand(install):
+    """
+    Custom command to verify that the git tag matches our version
+    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    """
+
+    description = "verify that the git tag matches our version"
+
+    def run(self):
+        tag = os.getenv("CIRCLE_TAG")
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
 
 # Get the long description from the README file
-with open(path.join(here, "README.md"), encoding="utf-8") as f:
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
@@ -47,4 +69,5 @@ setup(
     ],
     python_requires=">=3.6.1",
     entry_points={"console_scripts": ["mlagents-learn=mlagents.trainers.learn:main"]},
+    cmdclass={"verify": VerifyVersionCommand},
 )

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -13,7 +13,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 class VerifyVersionCommand(install):
     """
     Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/Adding-container-security-scanning-anchore/
+    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
     """
 
     description = "verify that the git tag matches our version"

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -2,6 +2,8 @@ from setuptools import setup, find_namespace_packages
 from os import path
 from io import open
 
+VERSION = "0.10.1"
+
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
@@ -10,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="mlagents",
-    version="0.10.1",
+    version=VERSION,
     description="Unity Machine Learning Agents",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -35,7 +37,7 @@ setup(
         "h5py>=2.9.0",
         "jupyter",
         "matplotlib",
-        "mlagents_envs==0.10.1",
+        "mlagents_envs=={}".format(VERSION),
         "numpy>=1.13.3,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
 
-VERSION = "0.11.0.dev0"
+VERSION = "0.10.1"
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from typing import Dict
+
+VERSION_LINE_START = "VERSION = "
+
+DIRECTORIES = ["ml-agents", "ml-agents-envs", "gym-unity"]
+
+
+def extract_version_string(filename):
+    with open(filename) as f:
+        for l in f.readlines():
+            if l.startswith(VERSION_LINE_START):
+                return l.replace(VERSION_LINE_START, "").strip()
+    return None
+
+
+def check_versions() -> bool:
+    version_by_dir: Dict[str, str] = {}
+    for directory in DIRECTORIES:
+        path = os.path.join(directory, "setup.py")
+        version = extract_version_string(path)
+        print(f"Found version {version} for {directory}")
+        version_by_dir[directory] = version
+
+    # Make sure we have exactly one version, and it's not none
+    versions = set(version_by_dir.values())
+    if len(versions) != 1 or None in versions:
+        print("Each setup.py must have the same VERSION string.")
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    ok = check_versions()
+    return_code = 0 if ok else 1
+    sys.exit(return_code)


### PR DESCRIPTION
Deploy to pypi when new releases are made. Follows the instructions from https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/ but with a few modifications to handle 3 packages, and make it easier to switch to test.pypi.org