### PR TITLE
build fixes for 2018+

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/MLAgentsEditModeTest.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/MLAgentsEditModeTest.cs
@@ -93,9 +93,9 @@ namespace MLAgents.Tests
             return null;
         }
 
-        public CompressionType GetCompressionType()
+        public SensorCompressionType GetCompressionType()
         {
-            return CompressionType.None;
+            return SensorCompressionType.None;
         }
 
         public string GetName()

--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
@@ -1,6 +1,9 @@
 using System;
 using UnityEditor;
 using UnityEngine;
+#if UNITY_2018_1_OR_NEWER
+using UnityEditor.Build.Reporting;
+#endif
 
 namespace MLAgents
 {
@@ -9,8 +12,25 @@ namespace MLAgents
         static void BuildStandalonePlayerOSX()
         {
             string[] scenes = { "Assets/ML-Agents/Examples/3DBall/Scenes/3DBall.unity" };
-            var error = BuildPipeline.BuildPlayer(scenes, "testPlayer", BuildTarget.StandaloneOSX, BuildOptions.None);
-            if (string.IsNullOrEmpty(error))
+            var buildResult = BuildPipeline.BuildPlayer(scenes, "testPlayer", BuildTarget.StandaloneOSX, BuildOptions.None);
+#if UNITY_2018_1_OR_NEWER
+            var isOK = buildResult.summary.result == BuildResult.Succeeded;
+            var error = "";
+            foreach (var stepInfo in buildResult.steps)
+            {
+                foreach (var msg in stepInfo.messages)
+                {
+                    if (msg.type != LogType.Log && msg.type != LogType.Warning)
+                    {
+                        error += msg.content + "\n";
+                    }
+                }
+            }
+#else
+            var error = buildResult;
+            var isOK = string.IsNullOrEmpty(error);
+#endif
+            if (isOK)
             {
                 EditorApplication.Exit(0);
             }
@@ -18,10 +38,11 @@ namespace MLAgents
             {
                 Console.Error.WriteLine(error);
                 EditorApplication.Exit(1);
-                
+
             }
             Debug.Log(error);
+
         }
-        
+
     }
 }

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -160,7 +160,7 @@ namespace MLAgents
     /// of the environment extracts its current observation, sends them to its
     /// policy and in return receives an action. In practice,
     /// however, an agent need not send its observation at every step since very
-    /// little may have changed between successive steps. 
+    /// little may have changed between successive steps.
     ///
     /// At any step, an agent may be considered <see cref="m_Done"/>.
     /// This could occur due to a variety of reasons:
@@ -328,15 +328,15 @@ namespace MLAgents
 
         /// <summary>
         /// Updates the Model for the agent. Any model currently assigned to the
-        /// agent will be replaced with the provided one. If the arguments are 
+        /// agent will be replaced with the provided one. If the arguments are
         /// identical to the current parameters of the agent, the model will
-        /// remain unchanged. 
+        /// remain unchanged.
         /// </summary>
-        /// <param name="behaviorName"> The identifier of the behavior. This 
-        /// will categorize the agent when training. 
+        /// <param name="behaviorName"> The identifier of the behavior. This
+        /// will categorize the agent when training.
         /// </param>
         /// <param name="model"> The model to use for inference.</param>
-        /// <param name = "inferenceDevide"> Define on what device the model 
+        /// <param name = "inferenceDevide"> Define on what device the model
         /// will be run.</param>
         public void GiveModel(
             string behaviorName,

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensor.cs
@@ -55,9 +55,9 @@ namespace MLAgents.Sensor
             }
         }
 
-        public CompressionType GetCompressionType()
+        public SensorCompressionType GetCompressionType()
         {
-            return CompressionType.PNG;
+            return SensorCompressionType.PNG;
         }
 
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CompressedObservation.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CompressedObservation.cs
@@ -1,5 +1,4 @@
 using System;
-using MLAgents.InferenceBrain;
 using UnityEngine;
 
 namespace MLAgents.Sensor
@@ -14,7 +13,7 @@ namespace MLAgents.Sensor
         /// <summary>
         /// The format of the compressed data
         /// </summary>
-        public CompressionType CompressionType;
+        public SensorCompressionType CompressionType;
 
         /// <summary>
         /// The uncompressed dimensions of the data.

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
@@ -2,7 +2,7 @@ using MLAgents.InferenceBrain;
 
 namespace MLAgents.Sensor
 {
-    public enum CompressionType
+    public enum SensorCompressionType
     {
         None,
         PNG,
@@ -38,10 +38,10 @@ namespace MLAgents.Sensor
         byte[] GetCompressedObservation();
 
         /// <summary>
-        /// Return the compression type being used. If no compression is used, return CompressionType.None
+        /// Return the compression type being used. If no compression is used, return SensorCompressionType.None
         /// </summary>
         /// <returns></returns>
-        CompressionType GetCompressionType();
+        SensorCompressionType GetCompressionType();
 
         /// <summary>
         /// Get the name of the sensor. This is used to ensure deterministic sorting of the sensors on an Agent,

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensor.cs
@@ -56,9 +56,9 @@ namespace MLAgents.Sensor
             }
         }
 
-        public CompressionType GetCompressionType()
+        public SensorCompressionType GetCompressionType()
         {
-            return CompressionType.PNG;
+            return SensorCompressionType.PNG;
         }
 
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/SensorBase.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/SensorBase.cs
@@ -46,9 +46,9 @@ namespace MLAgents.Sensor
             return null;
         }
 
-        public virtual CompressionType GetCompressionType()
+        public virtual SensorCompressionType GetCompressionType()
         {
-            return CompressionType.None;
+            return SensorCompressionType.None;
         }
     }
 }


### PR DESCRIPTION
* BuildPipeline.BuildPlayer return type change from a string to a BuildReport in 2018.1. Handles both types now.
* CompressionType is also in UnityEngine namespace, which causes conflicts. We could be explicit about the namespace where we use it, but it would be annoying for users, so just be verbose with the name instead.