### PR TITLE
Fix vertical offsets for RayPerception3D

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -85,7 +85,7 @@ public class PushAgentBasic : Agent
             var rayDistance = 12f;
 
             AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, m_DetectableObjects));
-            AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, m_DetectableObjects, 1.5f));
+            AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, m_DetectableObjects, 1.5f, 1.5f));
         }
     }
 

--- a/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
@@ -48,6 +48,8 @@ namespace MLAgents
                 Vector3 startPositionLocal = new Vector3(0, startOffset, 0);
                 Vector3 endPositionLocal = PolarToCartesian(rayDistance, angle);
                 endPositionLocal.y += endOffset;
+//                // BAD old behavior
+//                endPositionLocal.y += startOffset;
 
                 var startPositionWorld = transform.TransformPoint(startPositionLocal);
                 var endPositionWorld = transform.TransformPoint(endPositionLocal);
@@ -55,8 +57,7 @@ namespace MLAgents
                 var rayDirection = endPositionWorld - startPositionWorld;
                 if (Application.isEditor)
                 {
-                    //Debug.DrawRay(startPositionWorld,rayDirection, Color.black, 0.01f, true);
-                    Debug.DrawRay(startPositionWorld,rayDirection, Color.black, 0.0f, true);
+                    Debug.DrawRay(startPositionWorld,rayDirection, Color.black, 0.01f, true);
                 }
 
                 Array.Clear(m_SubList, 0, m_SubList.Length);

--- a/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
@@ -10,7 +10,6 @@ namespace MLAgents
     /// </summary>
     public class RayPerception3D : RayPerception
     {
-        Vector3 m_EndPosition;
         RaycastHit m_Hit;
         float[] m_SubList;
 
@@ -46,20 +45,23 @@ namespace MLAgents
             // along with object distance.
             foreach (var angle in rayAngles)
             {
-                m_EndPosition = transform.TransformDirection(
-                    PolarToCartesian(rayDistance, angle));
-                m_EndPosition.y = endOffset;
+                Vector3 startPositionLocal = new Vector3(0, startOffset, 0);
+                Vector3 endPositionLocal = PolarToCartesian(rayDistance, angle);
+                endPositionLocal.y += endOffset;
+
+                var startPositionWorld = transform.TransformPoint(startPositionLocal);
+                var endPositionWorld = transform.TransformPoint(endPositionLocal);
+
+                var rayDirection = endPositionWorld - startPositionWorld;
                 if (Application.isEditor)
                 {
-                    Debug.DrawRay(transform.position + new Vector3(0f, startOffset, 0f),
-                        m_EndPosition, Color.black, 0.01f, true);
+                    //Debug.DrawRay(startPositionWorld,rayDirection, Color.black, 0.01f, true);
+                    Debug.DrawRay(startPositionWorld,rayDirection, Color.black, 0.0f, true);
                 }
 
                 Array.Clear(m_SubList, 0, m_SubList.Length);
 
-                if (Physics.SphereCast(transform.position +
-                    new Vector3(0f, startOffset, 0f), 0.5f,
-                    m_EndPosition, out m_Hit, rayDistance))
+                if (Physics.SphereCast(startPositionWorld, 0.5f, rayDirection, out m_Hit, rayDistance))
                 {
                     for (var i = 0; i < detectableObjects.Length; i++)
                     {

--- a/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/SharedAssets/Scripts/RayPerception3D.cs
@@ -48,8 +48,6 @@ namespace MLAgents
                 Vector3 startPositionLocal = new Vector3(0, startOffset, 0);
                 Vector3 endPositionLocal = PolarToCartesian(rayDistance, angle);
                 endPositionLocal.y += endOffset;
-//                // BAD old behavior
-//                endPositionLocal.y += startOffset;
 
                 var startPositionWorld = transform.TransformPoint(startPositionLocal);
                 var endPositionWorld = transform.TransformPoint(endPositionLocal);

--- a/UnitySDK/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
@@ -94,7 +94,7 @@ public class AgentSoccer : Agent
             detectableObjects = m_DetectableObjectsBlue;
         }
         AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, detectableObjects));
-        AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, detectableObjects, 1f));
+        AddVectorObs(m_RayPer.Perceive(rayDistance, m_RayAngles, detectableObjects, 1f, 1f));
     }
 
     public void MoveAgent(float[] act)

--- a/UnitySDK/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/UnitySDK/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -144,7 +144,7 @@ public class WallJumpAgent : Agent
         AddVectorObs(m_RayPer.Perceive(
             rayDistance, rayAngles, m_DetectableObjects));
         AddVectorObs(m_RayPer.Perceive(
-            rayDistance, rayAngles, m_DetectableObjects, 2.5f, 2.5f));
+            rayDistance, rayAngles, m_DetectableObjects, 2.5f, 5.0f));
         var agentPos = m_AgentRb.position - ground.transform.position;
 
         AddVectorObs(agentPos / 20f);


### PR DESCRIPTION
[Behavior change]
The vertical offset for the end point of the raycasts was computed incorrectly; it was effectively `startOffset+endOffset` instead of `endOffset` as expected. Additionally, if the GameObject's transform contained scale it would not behave as expected.

To reproduce the old behavior, If you use a non-zero startOffset, you should increase the previous endOffset by startOffset.