### PR TITLE
Use bokken image reference 

### DIFF
--- a/.yamato/csharp-tests.yml
+++ b/.yamato/csharp-tests.yml
@@ -8,7 +8,7 @@ test_mac_editmode_{{ editor.version }}:
   name: Test Mac EditMode {{ editor.version }}
   agent:
     type: Unity::VM::osx
-    image: ml-agents/ml-agents-bokken-mac:stable
+    image: ml-agents/ml-agents-bokken-mac:v0.1.2-440635
     flavor: i1.small
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -8,7 +8,7 @@ test_mac_standalone_{{ editor.version }}:
   name: Test Mac Standalone {{ editor.version }}
   agent:
     type: Unity::VM::osx
-    image: ml-agents/ml-agents-bokken-mac:stable
+    image: ml-agents/ml-agents-bokken-mac:v0.1.2-440635
     flavor: i1.small
   variables:
     UNITY_VERSION: {{ editor.version }}


### PR DESCRIPTION
Use bokken image reference instead of tags so we don't need to have different image tags for master/develop.