### PR TITLE
speed up slow unit test

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -156,13 +156,13 @@ PPO_CONFIG = """
 SAC_CONFIG = """
     default:
         trainer: sac
-        batch_size: 32
-        buffer_size: 10240
-        buffer_init_steps: 1000
-        hidden_units: 64
+        batch_size: 8
+        buffer_size: 500
+        buffer_init_steps: 100
+        hidden_units: 16
         init_entcoef: 0.01
         learning_rate: 5.0e-3
-        max_steps: 2000
+        max_steps: 1000
         memory_size: 256
         normalize: false
         num_update: 1


### PR DESCRIPTION
Takes the test time for 
```
pytest ml-agents/mlagents/trainers/tests/test_simple_rl.py::test_simple_sac
```
from 17.63 seconds down to  11.64 seconds on my laptop.