### PR TITLE
Add ISensor.Update()

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/DemonstrationTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/DemonstrationTests.cs
@@ -102,24 +102,20 @@ namespace MLAgents.Tests
                 BindingFlags.Instance | BindingFlags.NonPublic);
             var agentEnableMethod = typeof(Agent).GetMethod("OnEnable",
                 BindingFlags.Instance | BindingFlags.NonPublic);
+            var agentSendInfo = typeof(Agent).GetMethod("SendInfo",
+                BindingFlags.Instance | BindingFlags.NonPublic);
 
             agentEnableMethod?.Invoke(agent1, new object[] { });
             academyInitializeMethod?.Invoke(aca, new object[] { });
 
             // Step the agent
             agent1.RequestDecision();
-            // TODO grab with reflection?
-            agent1.SendInfo();
+            agentSendInfo?.Invoke(agent1, new object[] { });
+
             demoRecorder.Close();
 
             // Read back the demo file and make sure observations were written
-
-            var filename = DemonstrationStore.k_DemoDirecory + demoRecorder.demonstrationName + DemonstrationStore.k_ExtensionType;
-            Assert.AreEqual(filename, "Assets/Demonstrations/TestBrain.demo");
-            var reader = fileSystem.File.OpenRead(filename);
-
-            DemonstrationMetaProto.Parser.ParseDelimitedFrom(reader);
-
+            var reader = fileSystem.File.OpenRead("Assets/Demonstrations/TestBrain.demo");
             reader.Seek(DemonstrationStore.MetaDataBytes + 1, 0);
             BrainParametersProto.Parser.ParseDelimitedFrom(reader);
 

--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/MLAgentsEditModeTest.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/MLAgentsEditModeTest.cs
@@ -105,6 +105,8 @@ namespace MLAgents.Tests
         {
             return sensorName;
         }
+
+        public void Update() { }
     }
 
     public class EditModeTestGeneration

--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/StackingSensorTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/StackingSensorTests.cs
@@ -24,16 +24,23 @@ namespace MLAgents.Tests
             wrapped.AddObservation(new [] {1f, 2f});
             SensorTestHelper.CompareObservation(sensor, new [] {0f, 0f, 0f, 0f, 1f, 2f});
 
+            sensor.Update();
             wrapped.AddObservation(new [] {3f, 4f});
             SensorTestHelper.CompareObservation(sensor, new [] {0f, 0f, 1f, 2f, 3f, 4f});
 
+            sensor.Update();
             wrapped.AddObservation(new [] {5f, 6f});
             SensorTestHelper.CompareObservation(sensor, new [] {1f, 2f, 3f, 4f, 5f, 6f});
 
+            sensor.Update();
             wrapped.AddObservation(new [] {7f, 8f});
             SensorTestHelper.CompareObservation(sensor, new [] {3f, 4f, 5f, 6f, 7f, 8f});
 
+            sensor.Update();
             wrapped.AddObservation(new [] {9f, 10f});
+            SensorTestHelper.CompareObservation(sensor, new [] {5f, 6f, 7f, 8f, 9f, 10f});
+
+            // Check that if we don't call Update(), the same observations are produced
             SensorTestHelper.CompareObservation(sensor, new [] {5f, 6f, 7f, 8f, 9f, 10f});
         }
 

--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/VectorSensorTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/VectorSensorTests.cs
@@ -53,6 +53,13 @@ namespace MLAgents.Tests
             sensor.AddObservation(4f);
 
             SensorTestHelper.CompareObservation(sensor, new[] { 1f, 2f, 3f, 4f });
+            // Check that if we don't call Update(), the same observations are produced
+            SensorTestHelper.CompareObservation(sensor, new[] { 1f, 2f, 3f, 4f });
+
+            // Check that Update() clears the data
+            sensor.Update();
+            SensorTestHelper.CompareObservation(sensor, new[] { 0f, 0f, 0f, 0f });
+
         }
 
         [Test]

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -538,6 +538,7 @@ namespace MLAgents
             m_Info.storedVectorActions = m_Action.vectorActions;
             m_Info.compressedObservations.Clear();
             m_ActionMasker.ResetMask();
+            UpdateSensors();
             using (TimerStack.Instance.Scoped("CollectObservations"))
             {
                 CollectObservations();
@@ -565,6 +566,14 @@ namespace MLAgents
                 m_Recorder.WriteExperience(m_Info);
             }
 
+        }
+
+        void UpdateSensors()
+        {
+            for (var i = 0; i < sensors.Count; i++)
+            {
+                sensors[i].Update();
+            }
         }
 
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -909,7 +909,7 @@ namespace MLAgents
         /// <summary>
         /// Signals the agent that it must sent its decision to the brain.
         /// </summary>
-        void SendInfo()
+        public void SendInfo()
         {
             if (m_RequestDecision)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -909,7 +909,7 @@ namespace MLAgents
         /// <summary>
         /// Signals the agent that it must sent its decision to the brain.
         /// </summary>
-        public void SendInfo()
+        void SendInfo()
         {
             if (m_RequestDecision)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -78,6 +78,7 @@ namespace MLAgents
             if (m_DemoStore != null)
             {
                 m_DemoStore.Close();
+                m_DemoStore = null;
             }
         }
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -1,5 +1,6 @@
-using UnityEngine;
+using System.IO.Abstractions;
 using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace MLAgents
 {
@@ -35,15 +36,16 @@ namespace MLAgents
         /// <summary>
         /// Creates demonstration store for use in recording.
         /// </summary>
-        void InitializeDemoStore()
+        public void InitializeDemoStore(IFileSystem fileSystem = null)
         {
             m_RecordingAgent = GetComponent<Agent>();
-            m_DemoStore = new DemonstrationStore();
+            m_DemoStore = new DemonstrationStore(fileSystem);
+            var behaviorParams = GetComponent<BehaviorParameters>();
             demonstrationName = SanitizeName(demonstrationName, MaxNameLength);
             m_DemoStore.Initialize(
                 demonstrationName,
-                GetComponent<BehaviorParameters>().brainParameters,
-                GetComponent<BehaviorParameters>().behaviorName);
+                behaviorParams.brainParameters,
+                behaviorParams.behaviorName);
             Monitor.Log("Recording Demonstration of Agent: ", m_RecordingAgent.name);
         }
 
@@ -71,14 +73,22 @@ namespace MLAgents
             m_DemoStore.Record(info);
         }
 
+        public void Close()
+        {
+            if (m_DemoStore != null)
+            {
+                m_DemoStore.Close();
+            }
+        }
+
         /// <summary>
         /// Closes Demonstration store.
         /// </summary>
         void OnApplicationQuit()
         {
-            if (Application.isEditor && record && m_DemoStore != null)
+            if (Application.isEditor && record)
             {
-                m_DemoStore.Close();
+                Close();
             }
         }
     }

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationStore.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationStore.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using Google.Protobuf;
+using UnityEngine;
 
 namespace MLAgents
 {
@@ -21,12 +22,14 @@ namespace MLAgents
 
         public DemonstrationStore(IFileSystem fileSystem)
         {
-            m_FileSystem = fileSystem;
-        }
-
-        public DemonstrationStore()
-        {
-            m_FileSystem = new FileSystem();
+            if (fileSystem != null)
+            {
+                m_FileSystem = fileSystem;
+            }
+            else
+            {
+                m_FileSystem = new FileSystem();
+            }
         }
 
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensor.cs
@@ -55,6 +55,8 @@ namespace MLAgents.Sensor
             }
         }
 
+        public void Update() { }
+
         public SensorCompressionType GetCompressionType()
         {
             return SensorCompressionType.PNG;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
@@ -22,6 +22,8 @@ namespace MLAgents.Sensor
         /// <summary>
         /// Write the observation data directly to the WriteAdapter.
         /// This is considered an advanced interface; for a simpler approach, use SensorBase and override WriteFloats instead.
+        /// Note that this (and GetCompressedObservation) may be called multiple times per agent step, so should not
+        /// mutate any internal state.
         /// </summary>
         /// <param name="adapater"></param>
         /// <returns>The number of elements written</returns>
@@ -34,6 +36,11 @@ namespace MLAgents.Sensor
         /// </summary>
         /// <returns></returns>
         byte[] GetCompressedObservation();
+
+        /// <summary>
+        /// Update any internal state of the sensor. This is called once per each agent step.
+        /// </summary>
+        void Update();
 
         /// <summary>
         /// Return the compression type being used. If no compression is used, return SensorCompressionType.None

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensor.cs
@@ -55,6 +55,8 @@ namespace MLAgents.Sensor
             }
         }
 
+        public void Update() { }
+
         public SensorCompressionType GetCompressionType()
         {
             return SensorCompressionType.PNG;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/SensorBase.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/SensorBase.cs
@@ -38,6 +38,8 @@ namespace MLAgents.Sensor
             return numFloats;
         }
 
+        public void Update() { }
+
         public virtual byte[] GetCompressedObservation()
         {
             return null;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/StackingSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/StackingSensor.cs
@@ -78,9 +78,16 @@ namespace MLAgents.Sensor
                 numWritten += m_UnstackedObservationSize;
             }
 
-            // Finally update the index of the "current" buffer.
-            m_CurrentIndex = (m_CurrentIndex + 1) % m_NumStackedObservations;
             return numWritten;
+        }
+
+        /// <summary>
+        /// Updates the index of the "current" buffer.
+        /// </summary>
+        public void Update()
+        {
+            m_WrappedSensor.Update();
+            m_CurrentIndex = (m_CurrentIndex + 1) % m_NumStackedObservations;
         }
 
         public int[] GetFloatObservationShape()

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/VectorSensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/VectorSensor.cs
@@ -48,8 +48,12 @@ namespace MLAgents.Sensor
                 }
             }
             adapter.AddRange(m_Observations);
-            Clear();
             return expectedObservations;
+        }
+
+        public void Update()
+        {
+            Clear();
         }
 
         public int[] GetFloatObservationShape()

--- a/UnitySDK/ProjectSettings/ProjectVersion.txt
+++ b/UnitySDK/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.4.32f1
+m_EditorVersion: 2017.4.33f1

--- a/UnitySDK/ProjectSettings/ProjectVersion.txt
+++ b/UnitySDK/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.4.33f1
+m_EditorVersion: 2017.4.32f1


### PR DESCRIPTION
This add an ISensor.Update() method and implements it for the cases where it makes sense. This prevents observations from being cleared before they can be sent to the DemonstrationRecorder.