### PR TITLE
ingore attribute-defined-outside-init in multi_gpu_policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
             )$
         args: [--score=n]
 
-    # "Local" hooks, see https://pre-commit.com/#repository-local-hooks
+# "Local" hooks, see https://pre-commit.com/#repository-local-hooks
 -   repo: local
     hooks:
     -   id: markdown-link-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,9 +66,9 @@ repos:
                 .*_pb2_grpc.py|
                 .*/tests/.*
             )$
-        require_serial: true
+        args: [--score=n]
 
-# "Local" hooks, see https://pre-commit.com/#repository-local-hooks
+    # "Local" hooks, see https://pre-commit.com/#repository-local-hooks
 -   repo: local
     hooks:
     -   id: markdown-link-check

--- a/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
+++ b/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
@@ -48,7 +48,6 @@ class MultiGpuPPOPolicy(PPOPolicy):
         :param seed: Random seed.
         """
         self.devices = get_devices()
-        self.towers = []
 
         with self.graph.as_default():
             with tf.variable_scope("", reuse=tf.AUTO_REUSE):

--- a/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
+++ b/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
@@ -1,12 +1,14 @@
-# pylint: disable=attribute-defined-outside-init
 import logging
+from typing import Any, Dict, List, Optional
 
 import tensorflow as tf
 from tensorflow.python.client import device_lib
+from mlagents.envs.brain import BrainParameters
 from mlagents.envs.timers import timed
 from mlagents.trainers.models import EncoderType, LearningRateSchedule
 from mlagents.trainers.ppo.policy import PPOPolicy
 from mlagents.trainers.ppo.models import PPOModel
+from mlagents.trainers.components.reward_signals import RewardSignal
 from mlagents.trainers.components.reward_signals.reward_signal_factory import (
     create_reward_signal,
 )
@@ -18,6 +20,23 @@ logger = logging.getLogger("mlagents.trainers")
 
 
 class MultiGpuPPOPolicy(PPOPolicy):
+    def __init__(
+        self,
+        seed: int,
+        brain: BrainParameters,
+        trainer_params: Dict[str, Any],
+        is_training: bool,
+        load: bool,
+    ):
+        self.towers: List[PPOModel] = []
+        self.devices: List[str] = []
+        self.model: Optional[PPOModel] = None
+        self.total_policy_loss: Optional[tf.Tensor] = None
+        self.reward_signal_towers: List[Dict[str, RewardSignal]] = []
+        self.reward_signals: Dict[str, RewardSignal] = {}
+
+        super().__init__(seed, brain, trainer_params, is_training, load)
+
     def create_model(
         self, brain, trainer_params, reward_signal_configs, is_training, load, seed
     ):
@@ -30,6 +49,7 @@ class MultiGpuPPOPolicy(PPOPolicy):
         """
         self.devices = get_devices()
         self.towers = []
+
         with self.graph.as_default():
             with tf.variable_scope("", reuse=tf.AUTO_REUSE):
                 for device in self.devices:
@@ -106,7 +126,6 @@ class MultiGpuPPOPolicy(PPOPolicy):
         Create reward signals
         :param reward_signal_configs: Reward signal config.
         """
-        self.reward_signal_towers = []
         with self.graph.as_default():
             with tf.variable_scope(TOWER_SCOPE_NAME, reuse=tf.AUTO_REUSE):
                 for device_id, device in enumerate(self.devices):
@@ -191,7 +210,7 @@ class MultiGpuPPOPolicy(PPOPolicy):
         return average_grads
 
 
-def get_devices():
+def get_devices() -> List[str]:
     """
     Get all available GPU devices
     """

--- a/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
+++ b/ml-agents/mlagents/trainers/ppo/multi_gpu_policy.py
@@ -1,3 +1,4 @@
+# pylint: disable=attribute-defined-outside-init
 import logging
 
 import tensorflow as tf


### PR DESCRIPTION
pylint seems to ignore some files randomly, see https://github.com/PyCQA/pylint/issues/2893

It was currently ignoring the errors on multi_gpu_policy.py, but this can change if the list of files changes (as was happening on a branch).

I think these warnings aren't worth fixing for this file right now.