### PR TITLE
Fix flake8-comprehensions on master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,8 @@ repos:
                 .*_pb2.py|
                 .*_pb2_grpc.py
             )$
-        additional_dependencies: [flake8-comprehensions]
+        # temporarily pin flake8-comprehensions
+        additional_dependencies: [flake8-comprehensions==3.0.1]
     -   id: trailing-whitespace
         name: trailing-whitespace-markdown
         types: [markdown]


### PR DESCRIPTION
This is fixed on develop in https://github.com/Unity-Technologies/ml-agents/pull/2917
Rather than change the code, just pin the flake8 plugin for CI.