### PR TITLE
disable tensorflow warnings by default

### DIFF
--- a/ml-agents/mlagents/tf_utils/__init__.py
+++ b/ml-agents/mlagents/tf_utils/__init__.py
@@ -1,1 +1,2 @@
 from mlagents.tf_utils.tf import tf as tf  # noqa
+from mlagents.tf_utils.tf import set_warnings_enabled  # noqa

--- a/ml-agents/mlagents/tf_utils/tf.py
+++ b/ml-agents/mlagents/tf_utils/tf.py
@@ -13,7 +13,12 @@ if _is_tensorflow2:
     tf.disable_v2_behavior()
     tf_logging = tf.logging
 else:
-    tf_logging = tf.compat.v1.logging
+    try:
+        # Newer versions of tf 1.x will complain that tf.logging is deprecated
+        tf_logging = tf.compat.v1.logging
+    except AttributeError:
+        # Fall back to the safe import, even if it might generate a warning or two.
+        tf_logging = tf.logging
 
 
 def set_warnings_enabled(is_enabled: bool) -> None:

--- a/ml-agents/mlagents/tf_utils/tf.py
+++ b/ml-agents/mlagents/tf_utils/tf.py
@@ -11,5 +11,15 @@ if _is_tensorflow2:
     import tensorflow.compat.v1 as tf
 
     tf.disable_v2_behavior()
+    tf_logging = tf.logging
 else:
-    pass
+    tf_logging = tf.compat.v1.logging
+
+
+def set_warnings_enabled(is_enabled: bool) -> None:
+    """
+    Enable or disable tensorflow warnings (notabley, this disables deprecation warnings.
+    :param is_enabled:
+    """
+    level = tf_logging.WARN if is_enabled else tf_logging.ERROR
+    tf_logging.set_verbosity(level)

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from typing import Any, Callable, Optional, List, NamedTuple
 
-
+from mlagents import tf_utils
 from mlagents.trainers.trainer_controller import TrainerController
 from mlagents.trainers.exception import TrainerError
 from mlagents.trainers.meta_curriculum import MetaCurriculum
@@ -389,6 +389,9 @@ def main():
     if options.debug:
         trainer_logger.setLevel("DEBUG")
         env_logger.setLevel("DEBUG")
+    else:
+        # disable noisy warnings from tensorflow.
+        tf_utils.set_warnings_enabled(False)
     if options.env_path is None and options.num_runs > 1:
         raise TrainerError(
             "It is not possible to launch more than one concurrent training session "


### PR DESCRIPTION
This disables all tensorflow warnings by default in mlagents-learn. This mostly affects deprecation warnings, which we don't care about, and are confusing to new users (sometimes they submit them as issues).

See also https://stackoverflow.com/questions/48608776/how-to-suppress-tensorflow-warning-displayed-in-result

Note that this doesn't disable warnings like
```
I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
```
and shouldn't affect GPU-related ones either.