### PR TITLE
Clean up env logging on initialization

### DIFF
--- a/docs/Basic-Guide.md
+++ b/docs/Basic-Guide.md
@@ -158,10 +158,9 @@ like this:
 INFO:mlagents.envs:
 'Ball3DAcademy' started successfully!
 Unity Academy name: Ball3DAcademy
-        Number of Brains: 1
-        Number of Training Brains : 1
-        Reset Parameters :
+        Reset Parameters : {}
 
+INFO:mlagents.envs:Connected new brain:
 Unity brain name: 3DBallLearning
         Number of Visual Observations (per agent): 0
         Vector Observation space size (per agent): 8

--- a/docs/Learning-Environment-Executable.md
+++ b/docs/Learning-Environment-Executable.md
@@ -143,13 +143,10 @@ Mono path[0] = '/Users/dericp/workspace/ml-agents/3DBall.app/Contents/Resources/
 Mono config path = '/Users/dericp/workspace/ml-agents/3DBall.app/Contents/MonoBleedingEdge/etc'
 INFO:mlagents.envs:
 'Ball3DAcademy' started successfully!
-INFO:mlagents.envs:
-'Ball3DAcademy' started successfully!
 Unity Academy name: Ball3DAcademy
-        Number of Brains: 1
-        Number of Training Brains : 1
-        Reset Parameters :
+        Reset Parameters : {}
 
+INFO:mlagents.envs:Connected new brain:
 Unity brain name: Ball3DLearning
         Number of Visual Observations (per agent): 0
         Vector Observation space size (per agent): 8

--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -274,22 +274,18 @@ class UnityEnvironment(BaseUnityEnvironment):
                 )
 
     def __str__(self):
-        return (
-            """Unity Academy name: {0}
-        Number of Training Brains : {1}
-        Reset Parameters :\n\t\t{2}""".format(
-                self._academy_name,
-                str(self._num_external_brains),
-                "\n\t\t".join(
-                    [
-                        str(k) + " -> " + str(self._resetParameters[k])
-                        for k in self._resetParameters
-                    ]
-                ),
+        reset_params_str = (
+            "\n\t\t".join(
+                [
+                    str(k) + " -> " + str(self._resetParameters[k])
+                    for k in self._resetParameters
+                ]
             )
-            + "\n"
-            + "\n".join([str(self._brains[b]) for b in self._brains])
+            if self._resetParameters
+            else "{}"
         )
+        return f"""Unity Academy name: {self._academy_name}
+        Reset Parameters : {reset_params_str}"""
 
     def reset(
         self,
@@ -538,9 +534,9 @@ class UnityEnvironment(BaseUnityEnvironment):
             agent_infos = output.rl_output.agentInfos[brain_param.brain_name]
             if agent_infos.value:
                 agent = agent_infos.value[0]
-                self._brains[brain_param.brain_name] = BrainParameters.from_proto(
-                    brain_param, agent
-                )
+                new_brain = BrainParameters.from_proto(brain_param, agent)
+                self._brains[brain_param.brain_name] = new_brain
+                logger.info(f"Connected new brain:\n{new_brain}")
         self._external_brain_names = list(self._brains.keys())
         self._num_external_brains = len(self._external_brain_names)
 


### PR DESCRIPTION
This was misleading, because we now never have brains at the start, only after an agent sends its actions.
old:
```
'Academy' started successfully!
Unity Academy name: Academy
        Number of Training Brains : 0
        Reset Parameters :
```
new:
```
INFO:mlagents.envs:
'Academy' started successfully!
Unity Academy name: Academy
        Reset Parameters : {}
INFO:mlagents.envs:Connected new brain:
Unity brain name: Hallway
        Number of Visual Observations (per agent): 0
        Camera Resolutions: []
        Vector Observation space size (per agent): 108
        Vector Action space type: discrete
        Vector Action space size (per agent): [5]
        Vector Action descriptions: 
```
Saw one user confused about it on discord, and there as an issue comment on it too: https://github.com/Unity-Technologies/ml-agents/issues/2856#issuecomment-555023070