### PR TITLE
add options to set version on files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,4 +97,4 @@ repos:
         name: validate library versions
         language: script
         entry: utils/validate_versions.py
-        files: ".*/setup.py"
+        files: ".*/__init__.py"

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -50,6 +50,8 @@ def set_version(new_version: str) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--new-version", default=None)
+    # unused, but allows precommit to pass filenames
+    parser.add_argument("files", nargs="*")
     args = parser.parse_args()
     if args.new_version:
         print(f"Updating to verison {args.new_version}")

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from typing import Dict
+import argparse
 
 VERSION_LINE_START = "__version__ = "
 
@@ -37,7 +38,23 @@ def check_versions() -> bool:
     return True
 
 
+def set_version(new_version: str) -> None:
+    new_contents = f'{VERSION_LINE_START}"{new_version}"\n'
+    for directory in DIRECTORIES:
+        path = os.path.join(directory, "__init__.py")
+        print(f"Setting {path} to version {new_version}")
+        with open(path, "w") as f:
+            f.write(new_contents)
+
+
 if __name__ == "__main__":
-    ok = check_versions()
-    return_code = 0 if ok else 1
-    sys.exit(return_code)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--new-version", default=None)
+    args = parser.parse_args()
+    if args.new_version:
+        print(f"Updating to verison {args.new_version}")
+        set_version(args.new_version)
+    else:
+        ok = check_versions()
+        return_code = 0 if ok else 1
+        sys.exit(return_code)


### PR DESCRIPTION
Adds a `--new-version` option to the version validation script. This makes it a little less tedious to do a new release.

```shell
(venv) ~/code/ml-agents (develop-update-versions) $ python utils/validate_versions.py --new-version=0.42.0
Updating to verison 0.42.0
Setting ml-agents/mlagents/trainers/__init__.py to version 0.42.0
Setting ml-agents-envs/mlagents/envs/__init__.py to version 0.42.0
Setting gym-unity/gym_unity/__init__.py to version 0.42.0
(venv) ~/code/ml-agents (develop-update-versions) $ git diff
```
```diff
diff --git a/gym-unity/gym_unity/__init__.py b/gym-unity/gym_unity/__init__.py
index ae6db5f1..92717f71 100644
--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1 +1 @@
-__version__ = "0.11.0"
+__version__ = "0.42.0"
diff --git a/ml-agents-envs/mlagents/envs/__init__.py b/ml-agents-envs/mlagents/envs/__init__.py
index ae6db5f1..92717f71 100644
--- a/ml-agents-envs/mlagents/envs/__init__.py
+++ b/ml-agents-envs/mlagents/envs/__init__.py
@@ -1 +1 @@
-__version__ = "0.11.0"
+__version__ = "0.42.0"
diff --git a/ml-agents/mlagents/trainers/__init__.py b/ml-agents/mlagents/trainers/__init__.py
index ae6db5f1..92717f71 100644
--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1 +1 @@
-__version__ = "0.11.0"
+__version__ = "0.42.0"

```