### PR TITLE
Added the side channel for the Engine Configuration.

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -316,7 +316,7 @@ namespace MLAgents
                     Communicator.QuitCommandReceived += OnQuitCommandReceived;
                     Communicator.ResetCommandReceived += OnResetCommand;
                     Communicator.RLInputReceived += OnRLInputReceived;
-                    Communicator.RegisterSideChannel(new EngineConfigurationSideChannel());
+                    Communicator.RegisterSideChannel(new EngineConfigurationChannel());
                 }
             }
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -316,6 +316,7 @@ namespace MLAgents
                     Communicator.QuitCommandReceived += OnQuitCommandReceived;
                     Communicator.ResetCommandReceived += OnResetCommand;
                     Communicator.RLInputReceived += OnRLInputReceived;
+                    Communicator.RegisterSideChannel(new EngineConfigurationSideChannel());
                 }
             }
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace MLAgents
+{
+    public class EngineConfigurationSideChannel : SideChannel
+    {
+
+        public override int ChannelType() { return 1; }
+
+        public override void OnMessageReceived(byte[] data)
+        {
+            using (var memStream = new MemoryStream(data))
+            {
+                using (var binaryReader = new BinaryReader(memStream))
+                {
+                    var width = binaryReader.ReadInt32();
+                    var height = binaryReader.ReadInt32();
+                    var qualityLevel = binaryReader.ReadInt32();
+                    var timeScale = binaryReader.ReadSingle();
+                    var targetFrameRate = binaryReader.ReadInt32();
+
+
+                    Screen.SetResolution(width, height, false);
+                    QualitySettings.SetQualityLevel(qualityLevel, true);
+                    Time.timeScale = timeScale;
+                    Time.captureFramerate = 60;
+                    Application.targetFrameRate = targetFrameRate;
+                }
+            }
+        }
+    }
+}

--- a/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace MLAgents
 {
-    public class EngineConfigurationSideChannel : SideChannel
+    public class EngineConfigurationChannel : SideChannel
     {
 
         public override int ChannelType() { return 1; }

--- a/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs.meta
+++ b/UnitySDK/Assets/ML-Agents/Scripts/SideChannel/EngineConfigurationChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18ccdf3ce76784f2db68016fa284c33f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ml-agents-envs/mlagents/envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents/envs/side_channel/engine_configuration_channel.py
@@ -1,0 +1,56 @@
+from mlagents.envs.side_channel.side_channel import SideChannel, ChannelType
+from mlagents.envs.exception import UnityCommunicationException
+import struct
+
+
+class EngineConfigurationChannel(SideChannel):
+    """
+    This is  the SideChannel for engine configuration exchange. The data in the
+    engine configuration is as follows :
+     - int width;
+     - int height;
+     - int qualityLevel;
+     - float timeScale;
+     - int targetFrameRate;
+    """
+
+    def __init__(self):
+        self.received_messages = []
+        super().__init__()
+
+    @property
+    def channel_type(self) -> ChannelType:
+        return 1
+
+    def on_message_received(self, data: bytearray) -> None:
+        """
+        Is called by the environment to the side channel. Can be called
+        multiple times per step if multiple messages are meant for that
+        SideChannel.
+        Note that Python should never receive an engine configuration from
+        Unity
+        """
+        raise UnityCommunicationException(
+            "The EngineConfigurationChannel received a message from Unity, "
+            + "this should not have happend."
+        )
+
+    def set_configuration(
+        self,
+        width: int = 80,
+        height: int = 80,
+        quality_level: int = 1,
+        time_scale: float = 20.0,
+        target_frame_rate: int = -1,
+    ) -> None:
+        """
+        Sets the engine configuration. Takes as input the configurations of the
+        engine.
+        """
+        data = bytearray()
+        data += struct.pack("i", width)
+        data += struct.pack("i", height)
+        data += struct.pack("i", quality_level)
+        data += struct.pack("f", time_scale)
+        data += struct.pack("i", target_frame_rate)
+        super().queue_message_to_send(data)

--- a/ml-agents-envs/mlagents/envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents/envs/side_channel/engine_configuration_channel.py
@@ -14,10 +14,6 @@ class EngineConfigurationChannel(SideChannel):
      - int targetFrameRate;
     """
 
-    def __init__(self):
-        self.received_messages = []
-        super().__init__()
-
     @property
     def channel_type(self) -> ChannelType:
         return 1


### PR DESCRIPTION
Note that this change does not require modifying a lot of files :
 - Adding a sender in Python
 - Adding a receiver in C#
 - subscribe the receiver to the communicator (here is a one liner in the Academy)
 - Add the side channel to the Python UnityEnvironment (not represented here)

Adding the side channel to the environment would look like such :

```python
from mlagents.envs.environment import UnityEnvironment
from mlagents.envs.side_channel.raw_bytes_channel import RawBytesChannel
from mlagents.envs.side_channel.engine_configuration_channel import EngineConfigurationChannel

channel0 = RawBytesChannel()
channel1 = EngineConfigurationChannel()

env = UnityEnvironment(base_port = 5004, side_channels = [channel0, channel1])
```