### PR TITLE
reduce max_steps for Gridworld

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -251,7 +251,7 @@ GridWorld:
     init_entcoef: 0.5
     buffer_init_steps: 1000
     buffer_size: 50000
-    max_steps: 5.0e5
+    max_steps: 50000
     summary_freq: 2000
     time_horizon: 5
     reward_signals:

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -264,7 +264,7 @@ GridWorld:
     hidden_units: 256
     beta: 5.0e-3
     buffer_size: 256
-    max_steps: 5.0e5
+    max_steps: 50000
     summary_freq: 2000
     time_horizon: 5
     reward_signals:


### PR DESCRIPTION
The Gridworld scene was changed to have 9 agents in it, but the number of steps was not reduced accordingly.