### PR TITLE
handle None action outputs

### DIFF
--- a/ml-agents-envs/mlagents/envs/env_manager.py
+++ b/ml-agents-envs/mlagents/envs/env_manager.py
@@ -10,6 +10,13 @@ class EnvironmentStep(NamedTuple):
     current_all_brain_info: AllBrainInfo
     brain_name_to_action_info: Optional[Dict[str, ActionInfo]]
 
+    def has_actions_for_brain(self, brain_name: str) -> bool:
+        return (
+            self.brain_name_to_action_info is not None
+            and brain_name in self.brain_name_to_action_info
+            and self.brain_name_to_action_info[brain_name].outputs is not None
+        )
+
 
 class EnvManager(ABC):
     def __init__(self):

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -276,7 +276,7 @@ class TrainerController(object):
             for brain_name, trainer in self.trainers.items():
                 if brain_name in self.trainer_metrics:
                     self.trainer_metrics[brain_name].add_delta_step(delta_time_step)
-                if brain_name in step_info.brain_name_to_action_info:
+                if step_info.has_actions_for_brain(brain_name):
                     trainer.add_experiences(
                         step_info.previous_all_brain_info[brain_name],
                         step_info.current_all_brain_info[brain_name],


### PR DESCRIPTION
This started happening in https://github.com/Unity-Technologies/ml-agents/pull/2913, but only shows up in the WallJump scene. It happens eventually when running the full scene, but happens right away if only 2 of the areas are enabled; we believe it's due to all of the agents only using one of the two brains.

There might be a cleaner fix for this, but we'll merge this today for the release if a better solution doesn't present itself.