### PR TITLE
update git instructions for latest_branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,10 @@ reach out to us directly at ml-agents@unity3d.com and/or browse the GitHub
 issues with the `contributions welcome` label.
 
 ## Git Branches
+The master branch corresponds to the most recent version of the project.
+Note that this may be newer that the [latest release](https://github.com/Unity-Technologies/ml-agents/releases/tag/latest_release).
 
-Starting with v0.3, we adopted the
-[Gitflow Workflow](http://nvie.com/posts/a-successful-git-branching-model/).
-Consequently, the `master` branch corresponds to the latest release of
-the project, while the `develop` branch corresponds to the most recent, stable,
-version of the project.
-
-Thus, when adding to the project, **please branch off `develop`**
-and make sure that your Pull Request (PR) contains the following:
+When contributing to the project, please make sure that your Pull Request (PR) contains the following:
 
 * Detailed description of the changes performed
 * Corresponding changes to documentation, unit tests and sample environments (if

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![docs badge](https://img.shields.io/badge/docs-reference-blue.svg)](docs/Readme.md)
 [![license badge](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 
+([latest release](https://github.com/Unity-Technologies/ml-agents/releases/tag/latest_release))
+([all releases](https://github.com/Unity-Technologies/ml-agents/releases))
+
 **The Unity Machine Learning Agents Toolkit** (ML-Agents) is an open-source
 Unity plugin that enables games and simulations to serve as environments for
 training intelligent agents. Agents can be trained using reinforcement learning,

--- a/docs/Installation-Windows.md
+++ b/docs/Installation-Windows.md
@@ -123,11 +123,11 @@ an Anaconda Prompt _(if you open a new prompt, be sure to activate the ml-agents
 Conda environment by typing `activate ml-agents`)_:
 
 ```sh
-git clone https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch latest_release https://github.com/Unity-Technologies/ml-agents.git
 ```
 
 If you don't want to use Git, you can always directly download all the files
-[here](https://github.com/Unity-Technologies/ml-agents/archive/master.zip).
+[here](https://github.com/Unity-Technologies/ml-agents/archive/latest_release.zip).
 
 The `UnitySDK` subdirectory contains the Unity Assets to add to your projects.
 It also contains many [example environments](Learning-Environment-Examples.md)

--- a/docs/Installation-Windows.md
+++ b/docs/Installation-Windows.md
@@ -125,6 +125,8 @@ Conda environment by typing `activate ml-agents`)_:
 ```sh
 git clone --branch latest_release https://github.com/Unity-Technologies/ml-agents.git
 ```
+The `--branch latest_release` option will switch to the tag of the latest stable release.
+Omitting that will get the `master` branch which is potentially unstable.
 
 If you don't want to use Git, you can always directly download all the files
 [here](https://github.com/Unity-Technologies/ml-agents/archive/latest_release.zip).

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -26,7 +26,7 @@ follow this [guide](Using-Virtual-Environment.md).
 Once installed, you will want to clone the ML-Agents Toolkit GitHub repository.
 
 ```sh
-git clone https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch latest_release https://github.com/Unity-Technologies/ml-agents.git
 ```
 
 The `UnitySDK` subdirectory contains the Unity Assets to add to your projects.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -28,6 +28,8 @@ Once installed, you will want to clone the ML-Agents Toolkit GitHub repository.
 ```sh
 git clone --branch latest_release https://github.com/Unity-Technologies/ml-agents.git
 ```
+The `--branch latest_release` option will switch to the tag of the latest stable release.
+Omitting that will get the `master` branch which is potentially unstable.
 
 The `UnitySDK` subdirectory contains the Unity Assets to add to your projects.
 It also contains many [example environments](Learning-Environment-Examples.md)

--- a/docs/Training-on-Amazon-Web-Service.md
+++ b/docs/Training-on-Amazon-Web-Service.md
@@ -69,7 +69,7 @@ After launching your EC2 instance using the ami and ssh into it:
 2. Clone the ML-Agents repo and install the required Python packages
 
     ```sh
-    git clone https://github.com/Unity-Technologies/ml-agents.git
+    git clone --branch latest_release https://github.com/Unity-Technologies/ml-agents.git
     cd ml-agents/ml-agents/
     pip3 install -e .
     ```


### PR DESCRIPTION
In preparations for changes to our git workflow:
* Update the CONTRIBUTING instructions
* Add links to the latest release and previous releases on the main landing page
* Update `git clone` commands to specify `--branch latest_release`