### PR TITLE
Close environment if step raises an exception.

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -265,9 +265,9 @@ def run_training(
         options.time_scale,
         options.target_frame_rate,
     )
-    env = SubprocessEnvManager(env_factory, engine_config, options.num_envs)
+    env_manager = SubprocessEnvManager(env_factory, engine_config, options.num_envs)
     maybe_meta_curriculum = try_create_meta_curriculum(
-        curriculum_folder, env, options.lesson
+        curriculum_folder, env_manager, options.lesson
     )
     sampler_manager, resampling_interval = create_sampler_manager(
         options.sampler_file_path, run_seed
@@ -301,9 +301,9 @@ def run_training(
     process_queue.put(True)
     # Begin training
     try:
-        tc.start_learning(env)
+        tc.start_learning(env_manager)
     finally:
-        env.close()
+        env_manager.close()
 
 
 def create_sampler_manager(sampler_file_path, run_seed=None):

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -300,7 +300,10 @@ def run_training(
     # Signal that environment has been launched.
     process_queue.put(True)
     # Begin training
-    tc.start_learning(env)
+    try:
+        tc.start_learning(env)
+    finally:
+        env.close()
 
 
 def create_sampler_manager(sampler_file_path, run_seed=None):

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -120,7 +120,6 @@ def test_start_learning_trains_forever_if_no_train_model(tf_reset_graph):
     assert tc.advance.call_count == 11
     tc._export_graph.assert_not_called()
     tc._save_model.assert_not_called()
-    env_mock.close.assert_called_once()
 
 
 @patch.object(tf, "reset_default_graph")
@@ -138,7 +137,6 @@ def test_start_learning_trains_until_max_steps_then_saves(tf_reset_graph):
     tf_reset_graph.assert_called_once()
     env_mock.reset.assert_called_once()
     assert tc.advance.call_count == trainer_mock.get_max_steps + 1
-    env_mock.close.assert_called_once()
     tc._save_model.assert_called_once()
 
 

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -223,7 +223,6 @@ class TrainerController(object):
             self._write_training_metrics()
             self._export_graph()
         self._write_timing_tree()
-        env_manager.close()
 
     def end_trainer_episodes(
         self, env: EnvManager, lessons_incremented: Dict[str, bool]


### PR DESCRIPTION
In https://github.com/Unity-Technologies/ml-agents/pull/2988, that was raising with this callstack:
```
Traceback (most recent call last):
  File "/Users/chris.elion/code/ml-agents/venv/bin/mlagents-learn", line 11, in <module>
    load_entry_point('mlagents', 'console_scripts', 'mlagents-learn')()
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 422, in main
    run_training(0, run_seed, options, Queue())
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 266, in run_training
    tc.start_learning(env)
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/trainer_controller.py", line 209, in start_learning
    n_steps = self.advance(env_manager)
  File "/Users/chris.elion/code/ml-agents/ml-agents-envs/mlagents/envs/timers.py", line 262, in wrapped
    return func(*args, **kwargs)
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/trainer_controller.py", line 283, in advance
    step_info.brain_name_to_action_info[brain_name].outputs,
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/rl_trainer.py", line 131, in add_experiences
    curr_to_use, take_action_outputs["action"], next_info
TypeError: 'NoneType' object is not subscriptable
```
The actual error isn't that important, but the thing to note is that the worker process stuck was waiting  for the main process :
https://github.com/Unity-Technologies/ml-agents/blob/2a0bb710672e978dd35bc2689958edb8291c8510/ml-agents-envs/mlagents/envs/subprocess_env_manager.py#L104
(I think, may have been somewhere different).
This means that the process never exited and basically deadlocked.

This change tries to call EnvManager.close() even if training raised an exception. I confirmed by undoing the fix from #2988 that this at least lets python exit and Unity stops playing (instead of having a spinning beach ball).