### PR TITLE
better logging for ports and versions

### DIFF
--- a/ml-agents-envs/mlagents/envs/environment.py
+++ b/ml-agents-envs/mlagents/envs/environment.py
@@ -103,7 +103,8 @@ class UnityEnvironment(BaseUnityEnvironment):
             self.executable_launcher(file_name, docker_training, no_graphics, args)
         else:
             logger.info(
-                "Start training by pressing the Play button in the Unity Editor."
+                f"Listening on port {self.port}. "
+                f"Start training by pressing the Play button in the Unity Editor."
             )
         self._loaded = True
 
@@ -119,9 +120,10 @@ class UnityEnvironment(BaseUnityEnvironment):
         if self._unity_version != self._version_:
             self._close()
             raise UnityEnvironmentException(
-                "The API number is not compatible between Unity and python. Python API : {0}, Unity API : "
-                "{1}.\nPlease go to https://github.com/Unity-Technologies/ml-agents to download the latest version "
-                "of ML-Agents.".format(self._version_, self._unity_version)
+                f"The API number is not compatible between Unity and python. "
+                f"Python API: {self._version_}, Unity API: {self._unity_version}.\n"
+                f"Please go to https://github.com/Unity-Technologies/ml-agents/releases/tag/latest_release"
+                f"to download the latest version of ML-Agents."
             )
         self._n_agents: Dict[str, int] = {}
         self._is_first_message = True

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -59,12 +59,11 @@ class CommandLineOptions(NamedTuple):
 
 
 def get_version_string() -> str:
-    return f""" Version information:\n
-    ml-agents: {mlagents.trainers.__version__},
-    ml-agents-envs: {mlagents.envs.__version__},
-    Communicator API: {UnityEnvironment.API_VERSION},
-    TensorFlow: {tf_utils.tf.__version__}
-"""
+    return f""" Version information:
+  ml-agents: {mlagents.trainers.__version__},
+  ml-agents-envs: {mlagents.envs.__version__},
+  Communicator API: {UnityEnvironment.API_VERSION},
+  TensorFlow: {tf_utils.tf.__version__}"""
 
 
 def parse_command_line(argv: Optional[List[str]] = None) -> CommandLineOptions:
@@ -170,7 +169,7 @@ def parse_command_line(argv: Optional[List[str]] = None) -> CommandLineOptions:
         "--cpu", default=False, action="store_true", help="Run with CPU only"
     )
 
-    parser.add_argument("--version", action="version", version=get_version_string())
+    parser.add_argument("--version", action="version", version="")
 
     eng_conf = parser.add_argument_group(title="Engine Configuration")
     eng_conf.add_argument(
@@ -438,6 +437,7 @@ def main():
         )
     except Exception:
         print("\n\n\tUnity Technologies\n")
+    print(get_version_string())
     options = parse_command_line()
     trainer_logger = logging.getLogger("mlagents.trainers")
     env_logger = logging.getLogger("mlagents.envs")


### PR DESCRIPTION
* Clean up (IMHO) the port decision logic on C# side
* Always print the version information on python
* Print the port number when waiting for editor connection
* If editor doesn't connect, print the port and API version.