### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
The goal of our issue templates was that all users should choose one
of these templates and fill it out to begin a discussion or report a
bug / feature request.  The "blank issues" option is a way around this,
and this change disables it as an option.