### PR TITLE
deregister the same method we registered

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -297,7 +297,7 @@ namespace MLAgents
                 academy.AgentSendState -= SendInfo;
                 academy.DecideAction -= DecideAction;
                 academy.AgentAct -= AgentStep;
-                academy.AgentForceReset -= ForceReset;
+                academy.AgentForceReset -= _AgentReset;
             }
             m_Brain?.Dispose();
         }


### PR DESCRIPTION
Currently we add one method in OnEnableHelper() but remove another in OnDisable()
https://github.com/Unity-Technologies/ml-agents/blob/1a240bb79d3950ab991601b4c16d9ee76bb28403/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs#L280-L300

The original intent was probably to add ForceReset(), but to keep behavior consistent, we'll remove _AgentReset() instead