### PR TITLE
Check has_actions_for_brains properly

### DIFF
--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -11,9 +11,8 @@ class EnvironmentStep(NamedTuple):
     brain_name_to_action_info: Dict[str, ActionInfo]
 
     def has_actions_for_brain(self, brain_name: str) -> bool:
-        return (
-            brain_name in self.brain_name_to_action_info
-            and self.brain_name_to_action_info[brain_name].outputs
+        return brain_name in self.brain_name_to_action_info and bool(
+            self.brain_name_to_action_info[brain_name].outputs
         )
 
 

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -13,7 +13,7 @@ class EnvironmentStep(NamedTuple):
     def has_actions_for_brain(self, brain_name: str) -> bool:
         return (
             brain_name in self.brain_name_to_action_info
-            and self.brain_name_to_action_info[brain_name].outputs is not None
+            and self.brain_name_to_action_info[brain_name].outputs
         )
 
 


### PR DESCRIPTION
In a recent mypy fix, we now output an empty Dict when there are no actions for a particular brain. However our check only checked if the Dict was None and this caused an error in WallJump. 

We now check the dict itself, whether it is empty or None. 