### PR TITLE
Fix reference to UnityEnvironment's location

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -49,7 +49,7 @@ release._
 ## Loading a Unity Environment
 
 Python-side communication happens through `UnityEnvironment` which is located in
-[`environment.py`](../ml-agents-envs/mlagents_envs/environment.py). To load 
+[`environment.py`](../ml-agents-envs/mlagents_envs/environment.py). To load
 a Unity environment from a built binary file, put the file in the same directory
 as `envs`. For example, if the filename of your Unity environment is 3DBall.app, in python, run:
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -49,9 +49,9 @@ release._
 ## Loading a Unity Environment
 
 Python-side communication happens through `UnityEnvironment` which is located in
-`ml-agents/mlagents_envs`. To load a Unity environment from a built binary
-file, put the file in the same directory as `envs`. For example, if the filename
-of your Unity environment is 3DBall.app, in python, run:
+[`environment.py`](../ml-agents-envs/mlagents_envs/environment.py). To load 
+a Unity environment from a built binary file, put the file in the same directory
+as `envs`. For example, if the filename of your Unity environment is 3DBall.app, in python, run:
 
 ```python
 from mlagents_envs.environment import UnityEnvironment


### PR DESCRIPTION
Reported in https://github.com/Unity-Technologies/ml-agents/issues/3085

This links to the file so that tests will catch it if the file moves :)