### PR TITLE
Run precommit in its own job, cache the data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,9 @@ jobs:
     steps:
       - checkout
 
-      #- restore_cache:
-      #    keys:
-      #    - v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+      - restore_cache:
+          keys:
+          - v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Install Dependencies
@@ -108,10 +108,10 @@ jobs:
             pip install --upgrade setuptools
             pip install pre-commit
 
-      #- save_cache:
-      #    paths:
-      #      - ./venv
-      #    key: v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+      - save_cache:
+          paths:
+            - ~/.cache/pre-commit
+          key: v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Check Code Style using pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,6 @@ jobs:
             pytest --cov=ml-agents --cov=ml-agents-envs --cov=gym-unity --cov-report html --junitxml=test-reports/junit.xml -p no:warnings
 
       - run:
-          name: Check Code Style using pre-commit
-          command: |
-            . venv/bin/activate
-            pre-commit run --show-diff-on-failure --all-files
-
-      - run:
           name: Verify there are no hidden/missing metafiles.
           # Renaming files or deleting files can leave metafiles behind that makes Unity very unhappy.
           command: |
@@ -88,6 +82,42 @@ jobs:
           path: htmlcov
           destination: htmlcov
 
+  pre-commit:
+    parameters:
+      pyversion:
+        type: string
+        description: python version to being used (currently only affects caching).
+
+    docker:
+      - image: circleci/python:3.7.3
+    working_directory: ~/repo/
+
+    steps:
+      - checkout
+
+      #- restore_cache:
+      #    keys:
+      #    - v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+
+      - run:
+          name: Install Dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade setuptools
+            pip install pre-commit
+              -
+      #- save_cache:
+      #    paths:
+      #      - ./venv
+      #    key: v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+
+      - run:
+          name: Check Code Style using pre-commit
+          command: |
+            . venv/bin/activate
+            pre-commit run --show-diff-on-failure --all-files
 
   markdown_link_check:
     parameters:
@@ -241,6 +271,8 @@ workflows:
           pip_constraints: test_constraints_max_tf2_version.txt
       - markdown_link_check
       - protobuf_generation_check
+      - pre-commit:
+          pyversion: 3.7.3
       - deploy:
           name: deploy ml-agents-envs
           directory: ml-agents-envs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,6 @@ jobs:
           command: |
             cat .pre-commit-config.yaml > pre-commit-deps.txt
             python -VV >> pre-commit-deps.txt
-            # TODO REMOVE - no-op change
-            echo test1 >> pre-commit-deps.txt
 
       - restore_cache:
           keys:
@@ -115,6 +113,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.cache/pre-commit
+            - ./venv
           key: v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,21 +83,23 @@ jobs:
           destination: htmlcov
 
   pre-commit:
-    parameters:
-      pyversion:
-        type: string
-        description: python version to being used (currently only affects caching).
-
     docker:
       - image: circleci/python:3.7.3
     working_directory: ~/repo/
 
     steps:
       - checkout
+      - run:
+          name: Combine precommit config and python versions for caching
+          command: |
+            cat .pre-commit-config.yaml > pre-commit-deps.txt
+            python -VV >> pre-commit-deps.txt
+            # TODO REMOVE
+            echo test1 >> pre-commit-deps.txt
 
       - restore_cache:
           keys:
-          - v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+          - v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
 
       - run:
           name: Install Dependencies
@@ -107,11 +109,13 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade setuptools
             pip install pre-commit
+            # Install the hooks now so that they'll be cached
+            pre-commit install-hooks
 
       - save_cache:
           paths:
             - ~/.cache/pre-commit
-          key: v1-precommit-deps-py<< parameters.pyversion >>-{{ checksum ".pre-commit-config.yaml" }}
+          key: v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
 
       - run:
           name: Check Code Style using pre-commit
@@ -271,8 +275,7 @@ workflows:
           pip_constraints: test_constraints_max_tf2_version.txt
       - markdown_link_check
       - protobuf_generation_check
-      - pre-commit:
-          pyversion: 3.7.3
+      - pre-commit
       - deploy:
           name: deploy ml-agents-envs
           directory: ml-agents-envs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             cat .pre-commit-config.yaml > pre-commit-deps.txt
             python -VV >> pre-commit-deps.txt
-            # TODO REMOVE
+            # TODO REMOVE - no-op change
             echo test1 >> pre-commit-deps.txt
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade setuptools
             pip install pre-commit
-              -
+
       #- save_cache:
       #    paths:
       #      - ./venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
     -   id: check-merge-conflict
         args: [--assume-in-merge]
     -   id: check-yaml
+        # Won't handle the templating in yamato
         exclude: \.yamato/*
 
 -   repo: https://github.com/pre-commit/pygrep-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,8 +63,6 @@ repos:
     hooks:
     -   id: python-check-mock-methods
 
-
-
 -   repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.4.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,8 @@ repos:
         types: [markdown]
     -   id: check-merge-conflict
         args: [--assume-in-merge]
+    -   id: check-yaml
+        exclude: \.yamato/*
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.4.2

--- a/config/offline_bc_config.yaml
+++ b/config/offline_bc_config.yaml
@@ -10,7 +10,8 @@ default:
     num_layers: 2
     sequence_length: 32
     memory_size: 256
-    demo_path: ./UnitySDK/Assets/Demonstrations/<Your_Demo_File>.demo
+    # Change the path here to point to your demo files
+    demo_path: ./UnitySDK/Assets/Demonstrations/Your_Demo_File.demo
 
 FoodCollector:
     trainer: offline_bc
@@ -34,7 +35,6 @@ Hallway:
     batches_per_epoch: 5
     num_layers: 2
     hidden_units: 128
-    sequence_length: 16
     use_recurrent: true
     memory_size: 256
     sequence_length: 32

--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -206,7 +206,6 @@ Reacher:
     summary_freq: 3000
 
 Hallway:
-    use_recurrent: true
     sequence_length: 32
     num_layers: 2
     hidden_units: 128
@@ -218,7 +217,6 @@ Hallway:
     use_recurrent: true
 
 VisualHallway:
-    use_recurrent: true
     sequence_length: 32
     num_layers: 1
     hidden_units: 128

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 # Test-only dependencies should go here, not in setup.py
 pytest>=3.2.2,<4.0.0
-pre-commit
 pytest-cov==2.6.1


### PR DESCRIPTION
* Move pre-commit to it's own job. Currently it runs on all 3 python testing jobs.
* Cache the pre-commit cache (and venv). Timings below.

Should we also make the python unit test jobs dependent on precommit job?

Resolves:
https://jira.unity3d.com/browse/MLA-17
https://jira.unity3d.com/browse/MLA-394