### PR TITLE
Enable child GameObjects to have a SensorComponent as well

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/BehaviorParametersEditor.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/BehaviorParametersEditor.cs
@@ -33,6 +33,7 @@ namespace MLAgents
             EditorGUILayout.PropertyField(so.FindProperty("m_InferenceDevice"), true);
             EditorGUI.indentLevel--;
             EditorGUILayout.PropertyField(so.FindProperty("m_BehaviorType"));
+            EditorGUILayout.PropertyField(so.FindProperty("m_useChildSensors"), true);
             // EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Heuristic"), true);
             EditorGUI.indentLevel--;
             if (EditorGUI.EndChangeCheck())
@@ -58,7 +59,15 @@ namespace MLAgents
             Model barracudaModel = null;
             var model = (NNModel)serializedObject.FindProperty("m_Model").objectReferenceValue;
             var behaviorParameters = (BehaviorParameters)target;
-            var sensorComponents = behaviorParameters.GetComponents<SensorComponent>();
+            SensorComponent[] sensorComponents;
+            if(behaviorParameters.useChildSensors)
+            {
+                sensorComponents = behaviorParameters.GetComponentsInChildren<SensorComponent>();
+            }
+            else
+            {
+                sensorComponents = behaviorParameters.GetComponents<SensorComponent>();
+            }
             var brainParameters = behaviorParameters.brainParameters;
             if (model != null)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Agent.cs
@@ -496,7 +496,16 @@ namespace MLAgents
         public void InitializeSensors()
         {
             // Get all attached sensor components
-            var attachedSensorComponents = GetComponents<SensorComponent>();
+            SensorComponent[] attachedSensorComponents;
+            if(m_PolicyFactory.useChildSensors)
+            {
+                attachedSensorComponents = GetComponentsInChildren<SensorComponent>();
+            }
+            else
+            {
+                attachedSensorComponents = GetComponents<SensorComponent>();
+            }
+
             sensors.Capacity += attachedSensorComponents.Length;
             foreach (var component in attachedSensorComponents)
             {

--- a/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
@@ -6,7 +6,7 @@ namespace MLAgents
 {
 
     /// <summary>
-    /// The Factory to generate policies. 
+    /// The Factory to generate policies.
     /// </summary>
     public class BehaviorParameters : MonoBehaviour
     {
@@ -34,10 +34,19 @@ namespace MLAgents
         [HideInInspector]
         [SerializeField]
         string m_BehaviorName = "My Behavior";
+        [HideInInspector]
+        [SerializeField]
+        [Tooltip("Use all Sensor components attached to child GameObjects of this Agent.")]
+        bool m_useChildSensors = true;
 
         public BrainParameters brainParameters
         {
             get { return m_BrainParameters; }
+        }
+
+        public bool useChildSensors
+        {
+            get { return m_useChildSensors; }
         }
 
         public string behaviorName


### PR DESCRIPTION
In many cases, we want to add Sensors to child GameObjects of the Agent - this could be when the Agent is made up of many GameObjects, or if we want to apply a transform to e.g. a RayPerception component. 

However, in the case of hierarchical agents, we don't necessarily want this. This PR makes whether or not we search children for Sensors optional. 