### PR TITLE
check min size for visual encoders

### DIFF
--- a/ml-agents/mlagents/trainers/models.py
+++ b/ml-agents/mlagents/trainers/models.py
@@ -34,7 +34,7 @@ class LearningModel:
 
     # Minimum supported side for each encoder type. If refactoring an encoder, please
     # adjust these also.
-    MIS_RESOLUTION_FOR_ENCODER = {
+    MIN_RESOLUTION_FOR_ENCODER = {
         EncoderType.SIMPLE: 20,
         EncoderType.NATURE_CNN: 36,
         EncoderType.RESNET: 15,
@@ -500,7 +500,7 @@ class LearningModel:
     def _check_resolution_for_encoder(
         camera_res: CameraResolution, vis_encoder_type: EncoderType
     ) -> None:
-        min_res = LearningModel.MIS_RESOLUTION_FOR_ENCODER[vis_encoder_type]
+        min_res = LearningModel.MIN_RESOLUTION_FOR_ENCODER[vis_encoder_type]
         if camera_res.height < min_res or camera_res.width < min_res:
             raise UnityTrainerException(
                 f"Visual observation resolution ({camera_res.width}x{camera_res.height}) is too small for"

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -503,11 +503,11 @@ def test_normalization(dummy_config):
 
 def test_min_visual_size():
     # Make sure each EncoderType has an entry in MIS_RESOLUTION_FOR_ENCODER
-    assert set(LearningModel.MIS_RESOLUTION_FOR_ENCODER.keys()) == set(EncoderType)
+    assert set(LearningModel.MIN_RESOLUTION_FOR_ENCODER.keys()) == set(EncoderType)
 
     for encoder_type in EncoderType:
         with tf.Graph().as_default():
-            good_size = LearningModel.MIS_RESOLUTION_FOR_ENCODER[encoder_type]
+            good_size = LearningModel.MIN_RESOLUTION_FOR_ENCODER[encoder_type]
             good_res = CameraResolution(
                 width=good_size, height=good_size, num_channels=3
             )
@@ -521,7 +521,7 @@ def test_min_visual_size():
         # Anything under the min size should raise an exception. If not, decrease the min size!
         with pytest.raises(Exception):
             with tf.Graph().as_default():
-                bad_size = LearningModel.MIS_RESOLUTION_FOR_ENCODER[encoder_type] - 1
+                bad_size = LearningModel.MIN_RESOLUTION_FOR_ENCODER[encoder_type] - 1
                 bad_res = CameraResolution(
                     width=bad_size, height=bad_size, num_channels=3
                 )


### PR DESCRIPTION
The visual encoders have a minimum usable size due to the strides. Currently, if you go below this size, we get an ugly looking exception in keras.

This PR adds a friendlier exception when you go under the min size, and adds tests to make sure the min is actually the min.