### PR TITLE
Move stepping logic into advance() function

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -7,7 +7,7 @@ default:
     init_entcoef: 1.0
     learning_rate: 3.0e-4
     learning_rate_schedule: constant
-    max_steps: 5.0e4
+    max_steps: 5.0e5
     memory_size: 256
     normalize: false
     num_update: 1
@@ -15,7 +15,7 @@ default:
     num_layers: 2
     time_horizon: 64
     sequence_length: 64
-    summary_freq: 1000
+    summary_freq: 10000
     tau: 0.005
     use_recurrent: false
     vis_encode_type: simple
@@ -28,65 +28,65 @@ FoodCollector:
     normalize: false
     batch_size: 256
     buffer_size: 500000
-    max_steps: 1.0e5
+    max_steps: 2.0e6
     init_entcoef: 0.05
     train_interval: 1
 
 Bouncer:
     normalize: true
-    max_steps: 5.0e5
+    max_steps: 2.0e7
     num_layers: 2
     hidden_units: 64
-    summary_freq: 1000
+    summary_freq: 20000
 
 PushBlock:
-    max_steps: 5.0e4
+    max_steps: 1.5e7
     init_entcoef: 0.05
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 60000
     time_horizon: 64
     num_layers: 2
 
 SmallWallJump:
-    max_steps: 1.0e6
+    max_steps: 3e7
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     init_entcoef: 0.1
     num_layers: 2
     normalize: false
 
 BigWallJump:
-    max_steps: 1.0e6
+    max_steps: 3e7
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     num_layers: 2
     init_entcoef: 0.1
     normalize: false
 
 Striker:
-    max_steps: 5.0e5
+    max_steps: 5.0e6
     learning_rate: 1e-3
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     init_entcoef: 0.1
     num_layers: 2
     normalize: false
 
 Goalie:
-    max_steps: 5.0e5
+    max_steps: 5.0e6
     learning_rate: 1e-3
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     init_entcoef: 0.1
     num_layers: 2
     normalize: false
 
 Pyramids:
-    summary_freq: 2000
+    summary_freq: 30000
     time_horizon: 128
     batch_size: 128
     buffer_init_steps: 10000
@@ -94,7 +94,7 @@ Pyramids:
     hidden_units: 256
     num_layers: 2
     init_entcoef: 0.01
-    max_steps: 5.0e5
+    max_steps: 1.0e7
     sequence_length: 16
     tau: 0.01
     use_recurrent: false
@@ -115,7 +115,7 @@ VisualPyramids:
     hidden_units: 256
     buffer_init_steps: 1000
     num_layers: 1
-    max_steps: 5.0e5
+    max_steps: 1.0e7
     buffer_size: 500000
     init_entcoef: 0.01
     tau: 0.01
@@ -134,7 +134,7 @@ VisualPyramids:
     normalize: true
     batch_size: 64
     buffer_size: 12000
-    summary_freq: 1000
+    summary_freq: 12000
     time_horizon: 1000
     hidden_units: 64
     init_entcoef: 0.5
@@ -142,13 +142,13 @@ VisualPyramids:
 3DBallHard:
     normalize: true
     batch_size: 256
-    summary_freq: 1000
+    summary_freq: 12000
     time_horizon: 1000
 
 Tennis:
     buffer_size: 500000
     normalize: true
-    max_steps: 2e5
+    max_steps: 4e6
 
 CrawlerStatic:
     normalize: true
@@ -157,8 +157,8 @@ CrawlerStatic:
     train_interval: 2
     buffer_size: 500000
     buffer_init_steps: 2000
-    max_steps: 5e5
-    summary_freq: 3000
+    max_steps: 5e6
+    summary_freq: 30000
     init_entcoef: 1.0
     num_layers: 3
     hidden_units: 512
@@ -172,10 +172,10 @@ CrawlerDynamic:
     time_horizon: 1000
     batch_size: 256
     buffer_size: 500000
-    summary_freq: 3000
+    summary_freq: 30000
     train_interval: 2
     num_layers: 3
-    max_steps: 1e6
+    max_steps: 1e7
     hidden_units: 512
     reward_signals:
         extrinsic:
@@ -187,8 +187,8 @@ Walker:
     time_horizon: 1000
     batch_size: 256
     buffer_size: 500000
-    max_steps: 2e6
-    summary_freq: 3000
+    max_steps: 2e7
+    summary_freq: 30000
     num_layers: 4
     train_interval: 2
     hidden_units: 512
@@ -202,8 +202,8 @@ Reacher:
     time_horizon: 1000
     batch_size: 128
     buffer_size: 500000
-    max_steps: 2e5
-    summary_freq: 3000
+    max_steps: 2e7
+    summary_freq: 60000
 
 Hallway:
     sequence_length: 32
@@ -211,7 +211,7 @@ Hallway:
     hidden_units: 128
     memory_size: 256
     init_entcoef: 0.1
-    max_steps: 5.0e5
+    max_steps: 1.0e7
     summary_freq: 1000
     time_horizon: 64
     use_recurrent: true
@@ -223,8 +223,7 @@ VisualHallway:
     memory_size: 256
     gamma: 0.99
     batch_size: 64
-    max_steps: 5.0e5
-    summary_freq: 1000
+    max_steps: 1.0e7
     time_horizon: 64
     use_recurrent: true
 
@@ -237,8 +236,8 @@ VisualPushBlock:
     gamma: 0.99
     buffer_size: 1024
     batch_size: 64
-    max_steps: 5.0e5
-    summary_freq: 1000
+    max_steps: 3.0e6
+    summary_freq: 60000
     time_horizon: 64
 
 GridWorld:
@@ -249,8 +248,8 @@ GridWorld:
     init_entcoef: 0.5
     buffer_init_steps: 1000
     buffer_size: 50000
-    max_steps: 50000
-    summary_freq: 2000
+    max_steps: 500000
+    summary_freq: 20000
     time_horizon: 5
     reward_signals:
         extrinsic:

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -8,14 +8,14 @@ default:
     lambd: 0.95
     learning_rate: 3.0e-4
     learning_rate_schedule: linear
-    max_steps: 5.0e4
+    max_steps: 5.0e5
     memory_size: 256
     normalize: false
     num_epoch: 3
     num_layers: 2
     time_horizon: 64
     sequence_length: 64
-    summary_freq: 1000
+    summary_freq: 10000
     use_recurrent: false
     vis_encode_type: simple
     reward_signals:
@@ -28,81 +28,81 @@ FoodCollector:
     beta: 5.0e-3
     batch_size: 1024
     buffer_size: 10240
-    max_steps: 1.0e5
+    max_steps: 2.0e6
 
 Bouncer:
     normalize: true
-    max_steps: 1.0e6
+    max_steps: 2.0e7
     num_layers: 2
     hidden_units: 64
 
 PushBlock:
-    max_steps: 5.0e4
+    max_steps: 1.5e7
     batch_size: 128
     buffer_size: 2048
     beta: 1.0e-2
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 60000
     time_horizon: 64
     num_layers: 2
 
 SmallWallJump:
-    max_steps: 1.0e6
+    max_steps: 3e7
     batch_size: 128
     buffer_size: 2048
     beta: 5.0e-3
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     num_layers: 2
     normalize: false
 
 BigWallJump:
-    max_steps: 1.0e6
+    max_steps: 3e7
     batch_size: 128
     buffer_size: 2048
     beta: 5.0e-3
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     num_layers: 2
     normalize: false
 
 Striker:
-    max_steps: 5.0e5
+    max_steps: 5.0e6
     learning_rate: 1e-3
     batch_size: 128
     num_epoch: 3
     buffer_size: 2000
     beta: 1.0e-2
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     num_layers: 2
     normalize: false
 
 Goalie:
-    max_steps: 5.0e5
+    max_steps: 5.0e6
     learning_rate: 1e-3
     batch_size: 320
     num_epoch: 3
     buffer_size: 2000
     beta: 1.0e-2
     hidden_units: 256
-    summary_freq: 2000
+    summary_freq: 20000
     time_horizon: 128
     num_layers: 2
     normalize: false
 
 Pyramids:
-    summary_freq: 2000
+    summary_freq: 30000
     time_horizon: 128
     batch_size: 128
     buffer_size: 2048
     hidden_units: 512
     num_layers: 2
     beta: 1.0e-2
-    max_steps: 5.0e5
+    max_steps: 1.0e7
     num_epoch: 3
     reward_signals:
         extrinsic:
@@ -120,7 +120,7 @@ VisualPyramids:
     hidden_units: 256
     num_layers: 1
     beta: 1.0e-2
-    max_steps: 5.0e5
+    max_steps: 1.0e7
     num_epoch: 3
     reward_signals:
         extrinsic:
@@ -135,7 +135,7 @@ VisualPyramids:
     normalize: true
     batch_size: 64
     buffer_size: 12000
-    summary_freq: 1000
+    summary_freq: 12000
     time_horizon: 1000
     lambd: 0.99
     beta: 0.001
@@ -144,7 +144,7 @@ VisualPyramids:
     normalize: true
     batch_size: 1200
     buffer_size: 12000
-    summary_freq: 1000
+    summary_freq: 12000
     time_horizon: 1000
     max_steps: 5.0e5
     beta: 0.001
@@ -155,7 +155,7 @@ VisualPyramids:
 
 Tennis:
     normalize: true
-    max_steps: 2e5
+    max_steps: 4e6
 
 CrawlerStatic:
     normalize: true
@@ -163,8 +163,8 @@ CrawlerStatic:
     time_horizon: 1000
     batch_size: 2024
     buffer_size: 20240
-    max_steps: 1e6
-    summary_freq: 3000
+    max_steps: 1e7
+    summary_freq: 30000
     num_layers: 3
     hidden_units: 512
     reward_signals:
@@ -178,8 +178,8 @@ CrawlerDynamic:
     time_horizon: 1000
     batch_size: 2024
     buffer_size: 20240
-    max_steps: 1e6
-    summary_freq: 3000
+    max_steps: 1e7
+    summary_freq: 30000
     num_layers: 3
     hidden_units: 512
     reward_signals:
@@ -193,8 +193,8 @@ Walker:
     time_horizon: 1000
     batch_size: 2048
     buffer_size: 20480
-    max_steps: 2e6
-    summary_freq: 3000
+    max_steps: 2e7
+    summary_freq: 30000
     num_layers: 3
     hidden_units: 512
     reward_signals:
@@ -208,8 +208,8 @@ Reacher:
     time_horizon: 1000
     batch_size: 2024
     buffer_size: 20240
-    max_steps: 1e6
-    summary_freq: 3000
+    max_steps: 2e7
+    summary_freq: 60000
     reward_signals:
         extrinsic:
             strength: 1.0
@@ -225,8 +225,8 @@ Hallway:
     num_epoch: 3
     buffer_size: 1024
     batch_size: 128
-    max_steps: 5.0e5
-    summary_freq: 1000
+    max_steps: 1.0e7
+    summary_freq: 10000
     time_horizon: 64
 
 VisualHallway:
@@ -239,8 +239,8 @@ VisualHallway:
     num_epoch: 3
     buffer_size: 1024
     batch_size: 64
-    max_steps: 5.0e5
-    summary_freq: 1000
+    max_steps: 1.0e7
+    summary_freq: 10000
     time_horizon: 64
 
 VisualPushBlock:
@@ -253,8 +253,8 @@ VisualPushBlock:
     num_epoch: 3
     buffer_size: 1024
     batch_size: 64
-    max_steps: 5.0e5
-    summary_freq: 1000
+    max_steps: 3.0e6
+    summary_freq: 60000
     time_horizon: 64
 
 GridWorld:
@@ -264,8 +264,8 @@ GridWorld:
     hidden_units: 256
     beta: 5.0e-3
     buffer_size: 256
-    max_steps: 50000
-    summary_freq: 2000
+    max_steps: 500000
+    summary_freq: 20000
     time_horizon: 5
     reward_signals:
         extrinsic:

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -19,11 +19,13 @@ The versions can be found in
 * Offline Behavioral Cloning has been removed. To learn from demonstrations, use the GAIL and
 Behavioral Cloning features with either PPO or SAC. See [Imitation Learning](Training-Imitation-Learning.md) for more information.
 * `mlagents.envs` was renamed to `mlagents_envs`. The previous repo layout depended on [PEP420](https://www.python.org/dev/peps/pep-0420/), which caused problems with some of our tooling such as mypy and pylint.
+* Trainer steps are now counted per-Agent, not per-environment as in previous versions. For instance, if you have 10 Agents in the scene, 20 environment steps now corresponds to 200 steps as printed in the terminal and in Tensorboard.
 
 ### Steps to Migrate
  * If you had a custom `Training Configuration` in the Academy inspector, you will need to pass your custom configuration at every training run using the new command line arguments `--width`, `--height`, `--quality-level`, `--time-scale` and `--target-frame-rate`.
  * If you were using `--slow` in `mlagents-learn`, you will need to pass your old `Inference Configuration` of the Academy inspector with the new command line arguments `--width`, `--height`, `--quality-level`, `--time-scale` and `--target-frame-rate` instead.
  * Any imports from `mlagents.envs` should be replaced with `mlagents_envs`.
+ * Multiply `max_steps` and `summary_steps` in your `trainer_config.yaml` by the number of Agents in the scene.
 
 ## Migrating from ML-Agents toolkit v0.11.0 to v0.12.0
 

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -83,6 +83,7 @@ class PPOTrainer(RLTrainer):
         Processing involves calculating value and advantage targets for model updating step.
         :param trajectory: The Trajectory tuple containing the steps to be processed.
         """
+        super()._process_trajectory(trajectory)
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 
         # Add to episode_steps

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -15,7 +15,6 @@ RewardSignalResults = Dict[str, RewardSignalResult]
 class RLTrainer(Trainer):
     """
     This class is the base class for trainers that use Reward Signals.
-    Contains methods for adding BrainInfos to the Buffer.
     """
 
     def __init__(self, *args, **kwargs):

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -138,6 +138,7 @@ class SACTrainer(RLTrainer):
         """
         Takes a trajectory and processes it, putting it into the replay buffer.
         """
+        super()._process_trajectory(trajectory)
         last_step = trajectory.steps[-1]
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -336,7 +336,7 @@ def test_trainer_increment_step(dummy_config):
     policy_mock.increment_step = mock.Mock(return_value=step_count)
     trainer.policy = policy_mock
 
-    trainer.increment_step(5)
+    trainer._increment_step(5)
     policy_mock.increment_step.assert_called_with(5)
     assert trainer.step == 10
 

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -1,7 +1,5 @@
-import unittest.mock as mock
 import yaml
 import mlagents.trainers.tests.mock_brain as mb
-import numpy as np
 from mlagents.trainers.rl_trainer import RLTrainer
 from mlagents.trainers.tests.test_buffer import construct_fake_buffer
 
@@ -10,6 +8,7 @@ def dummy_config():
     return yaml.safe_load(
         """
         summary_path: "test/"
+        summary_freq: 1000
         reward_signals:
           extrinsic:
             strength: 1.0
@@ -28,24 +27,22 @@ def create_mock_brain():
     return mock_brain
 
 
+# Add concrete implementations of abstract methods
+class FakeTrainer(RLTrainer):
+    def is_ready_update(self):
+        return True
+
+    def update_policy(self):
+        pass
+
+    def _process_trajectory(self, trajectory):
+        super()._process_trajectory(trajectory)
+
+
 def create_rl_trainer():
     mock_brainparams = create_mock_brain()
-    trainer = RLTrainer(mock_brainparams, dummy_config(), True, 0)
+    trainer = FakeTrainer(mock_brainparams, dummy_config(), True, 0)
     return trainer
-
-
-def create_mock_all_brain_info(brain_info):
-    return {"MockBrain": brain_info}
-
-
-def create_mock_policy():
-    mock_policy = mock.Mock()
-    mock_policy.reward_signals = {}
-    mock_policy.retrieve_memories.return_value = np.zeros((1, 1), dtype=np.float32)
-    mock_policy.retrieve_previous_action.return_value = np.zeros(
-        (1, 1), dtype=np.float32
-    )
-    return mock_policy
 
 
 def test_rl_trainer():

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -165,7 +165,6 @@ def test_take_step_adds_experiences_to_trainer_and_trains(
     )
 
     trainer_mock.advance.assert_called_once()
-    trainer_mock.increment_step.assert_called_once()
 
 
 def test_take_step_if_not_training(trainer_controller_with_take_step_mocks):

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -166,10 +166,12 @@ class Trainer(object):
     def _increment_step(self, n_steps: int) -> None:
         """
         Increment the step count of the trainer
-
         :param n_steps: number of steps to increment the step count by
         """
         self.step = self.policy.increment_step(n_steps)
+        self.next_update_step = self.step + (
+            self.summary_freq - self.step % self.summary_freq
+        )
 
     def save_model(self) -> None:
         """
@@ -221,10 +223,8 @@ class Trainer(object):
         Takes a trajectory and processes it, putting it into the update buffer.
         :param trajectory: The Trajectory tuple containing the steps to be processed.
         """
-        trajectory_length = len(trajectory.steps)
-        step_after_process = self.get_step + trajectory_length
-        self._maybe_write_summary(step_after_process)
-        self._increment_step(trajectory_length)
+        self._maybe_write_summary(self.get_step + len(trajectory.steps))
+        self._increment_step(len(trajectory.steps))
 
     def _maybe_write_summary(self, step_after_process: int) -> None:
         """
@@ -234,9 +234,6 @@ class Trainer(object):
         """
         if step_after_process >= self.next_update_step and self.get_step != 0:
             self._write_summary(self.next_update_step)
-            self.next_update_step = step_after_process + (
-                self.summary_freq - step_after_process % self.summary_freq
-            )
 
     def end_episode(self):
         """

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -185,11 +185,9 @@ class Trainer(object):
     def _write_summary(self) -> None:
         """
         Saves training statistics to Tensorboard.
-        :param delta_train_start:  Time elapsed since training started.
-        :param global_step: The number of steps the simulation has been going for
         """
         is_training = "Training." if self.should_still_train else "Not Training."
-        step = min(self.get_step, self.get_max_steps)
+        step = self.get_step
         stats_summary = self.stats_reporter.get_stats_summaries(
             "Environment/Cumulative Reward"
         )

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Dict, List, Deque, Any
 import time
+import abc
 
 from mlagents.tf_utils import tf
 
@@ -27,7 +28,7 @@ class UnityTrainerException(UnityException):
     pass
 
 
-class Trainer(object):
+class Trainer(abc.ABC):
     """This class is the base class for the mlagents_envs.trainers"""
 
     def __init__(
@@ -218,6 +219,7 @@ class Trainer(object):
             )
         self.stats_reporter.write_stats(int(step))
 
+    @abc.abstractmethod
     def _process_trajectory(self, trajectory: Trajectory) -> None:
         """
         Takes a trajectory and processes it, putting it into the update buffer.
@@ -235,25 +237,28 @@ class Trainer(object):
         if step_after_process >= self.next_update_step and self.get_step != 0:
             self._write_summary(self.next_update_step)
 
+    @abc.abstractmethod
     def end_episode(self):
         """
         A signal that the Episode has ended. The buffer must be reset.
         Get only called when the academy resets.
         """
-        raise UnityTrainerException("The end_episode method was not implemented.")
+        pass
 
+    @abc.abstractmethod
     def is_ready_update(self):
         """
         Returns whether or not the trainer has enough elements to run update model
         :return: A boolean corresponding to wether or not update_model() can be run
         """
-        raise UnityTrainerException("The is_ready_update method was not implemented.")
+        return False
 
+    @abc.abstractmethod
     def update_policy(self):
         """
         Uses demonstration_buffer to update model.
         """
-        raise UnityTrainerException("The update_model method was not implemented.")
+        pass
 
     def advance(self) -> None:
         """


### PR DESCRIPTION
Separating this PR out of the queue PR as it's a major change in user experience, though it isn't much code. 

Basically, this PR moves the stats writing logic into the Trainer, and steps the global step based on the trajectories the Trainer has processed, rather than the global steps seen by the trainer controller. 

This means that for the user:
- Steps are seen "per-agent", i.e. if there are 10 agents and we take 20 steps in the environment, the Trainer sees (and prints and logs to TB) 200 steps. This has the nice property that scaling # of agents vs. # of environments is the same from a training perspective. The user will have to adjust their `trainer_config.yaml` as a result. 
~~- Summary frequency is "messy", since Trajectories aren't guaranteed to be of a fixed number of steps. For instance with a summary frequency of 12000,~~ 
**This has been fixed**

Wanted to get your thoughts on if this change is a detriment to user experience. If so, we can pass the global steps into the Trainer via the Trainer Controller (when `trainer.advance()`) is called and continue logging via global steps. 