### PR TITLE
Allow curricula to be created without files

### DIFF
--- a/ml-agents/mlagents/trainers/curriculum.py
+++ b/ml-agents/mlagents/trainers/curriculum.py
@@ -13,13 +13,12 @@ class Curriculum:
     def __init__(self, brain_name: str, config: Dict):
         """
         Initializes a Curriculum object.
-        :param location: Path to JSON defining curriculum.
+        :param brain_name: Name of the brain this Curriculum is associated with
+        :param config: Dictionary of fields needed to configure the Curriculum
         """
         self.max_lesson_num = 0
         self.measure = None
         self._lesson_num = 0
-        # The name of the brain should be the basename of the file without the
-        # extension.
         self.brain_name = brain_name
         self.config = config
 

--- a/ml-agents/mlagents/trainers/curriculum.py
+++ b/ml-agents/mlagents/trainers/curriculum.py
@@ -1,4 +1,3 @@
-import os
 import json
 import math
 from typing import Dict, Any, TextIO
@@ -10,8 +9,8 @@ import logging
 logger = logging.getLogger("mlagents.trainers")
 
 
-class Curriculum(object):
-    def __init__(self, location):
+class Curriculum:
+    def __init__(self, brain_name: str, config: Dict):
         """
         Initializes a Curriculum object.
         :param location: Path to JSON defining curriculum.
@@ -21,10 +20,10 @@ class Curriculum(object):
         self._lesson_num = 0
         # The name of the brain should be the basename of the file without the
         # extension.
-        self._brain_name = os.path.basename(location).split(".")[0]
-        self.data = Curriculum.load_curriculum_file(location)
+        self.brain_name = brain_name
+        self.config = config
 
-        self.smoothing_value = 0
+        self.smoothing_value = 0.0
         for key in [
             "parameters",
             "measure",
@@ -32,23 +31,21 @@ class Curriculum(object):
             "min_lesson_length",
             "signal_smoothing",
         ]:
-            if key not in self.data:
+            if key not in self.config:
                 raise CurriculumConfigError(
-                    "{0} does not contain a " "{1} field.".format(location, key)
+                    f"{brain_name} curriculum config does not contain a {key} field."
                 )
         self.smoothing_value = 0
-        self.measure = self.data["measure"]
-        self.min_lesson_length = self.data["min_lesson_length"]
-        self.max_lesson_num = len(self.data["thresholds"])
+        self.measure = self.config["measure"]
+        self.min_lesson_length = self.config["min_lesson_length"]
+        self.max_lesson_num = len(self.config["thresholds"])
 
-        parameters = self.data["parameters"]
+        parameters = self.config["parameters"]
         for key in parameters:
             if len(parameters[key]) != self.max_lesson_num + 1:
                 raise CurriculumConfigError(
-                    "The parameter {0} in Curriculum {1} must have {2} values "
-                    "but {3} were found".format(
-                        key, location, self.max_lesson_num + 1, len(parameters[key])
-                    )
+                    f"The parameter {key} in {brain_name}'s curriculum must have {self.max_lesson_num + 1} values "
+                    f"but {len(parameters[key])} were found"
                 )
 
     @property
@@ -66,21 +63,21 @@ class Curriculum(object):
                steps completed).
         :return Whether the lesson was incremented.
         """
-        if not self.data or not measure_val or math.isnan(measure_val):
+        if not self.config or not measure_val or math.isnan(measure_val):
             return False
-        if self.data["signal_smoothing"]:
+        if self.config["signal_smoothing"]:
             measure_val = self.smoothing_value * 0.25 + 0.75 * measure_val
             self.smoothing_value = measure_val
         if self.lesson_num < self.max_lesson_num:
-            if measure_val > self.data["thresholds"][self.lesson_num]:
+            if measure_val > self.config["thresholds"][self.lesson_num]:
                 self.lesson_num += 1
                 config = {}
-                parameters = self.data["parameters"]
+                parameters = self.config["parameters"]
                 for key in parameters:
                     config[key] = parameters[key][self.lesson_num]
                 logger.info(
                     "{0} lesson changed. Now in lesson {1}: {2}".format(
-                        self._brain_name,
+                        self.brain_name,
                         self.lesson_num,
                         ", ".join([str(x) + " -> " + str(config[x]) for x in config]),
                     )
@@ -95,33 +92,33 @@ class Curriculum(object):
                current lesson is returned.
         :return: The configuration of the reset parameters.
         """
-        if not self.data:
+        if not self.config:
             return {}
         if lesson is None:
             lesson = self.lesson_num
         lesson = max(0, min(lesson, self.max_lesson_num))
         config = {}
-        parameters = self.data["parameters"]
+        parameters = self.config["parameters"]
         for key in parameters:
             config[key] = parameters[key][lesson]
         return config
 
     @staticmethod
-    def load_curriculum_file(location: str) -> None:
+    def load_curriculum_file(config_path: str) -> Dict:
         try:
-            with open(location) as data_file:
+            with open(config_path) as data_file:
                 return Curriculum._load_curriculum(data_file)
         except IOError:
             raise CurriculumLoadingError(
-                "The file {0} could not be found.".format(location)
+                "The file {0} could not be found.".format(config_path)
             )
         except UnicodeDecodeError:
             raise CurriculumLoadingError(
-                "There was an error decoding {}".format(location)
+                "There was an error decoding {}".format(config_path)
             )
 
     @staticmethod
-    def _load_curriculum(fp: TextIO) -> None:
+    def _load_curriculum(fp: TextIO) -> Dict:
         try:
             return json.load(fp)
         except json.decoder.JSONDecodeError as e:

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -349,10 +349,10 @@ def try_create_meta_curriculum(
         return None
 
     else:
-        meta_curriculum = MetaCurriculum.from_folder(curriculum_folder)
+        meta_curriculum = MetaCurriculum.from_directory(curriculum_folder)
         # TODO: Should be able to start learning at different lesson numbers
         # for each curriculum.
-        meta_curriculum.set_all_curriculums_to_lesson_num(lesson)
+        meta_curriculum.set_all_curricula_to_lesson_num(lesson)
 
         return meta_curriculum
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -349,7 +349,7 @@ def try_create_meta_curriculum(
         return None
 
     else:
-        meta_curriculum = MetaCurriculum(curriculum_folder)
+        meta_curriculum = MetaCurriculum.from_folder(curriculum_folder)
         # TODO: Should be able to start learning at different lesson numbers
         # for each curriculum.
         meta_curriculum.set_all_curriculums_to_lesson_num(lesson)

--- a/ml-agents/mlagents/trainers/tests/test_curriculum.py
+++ b/ml-agents/mlagents/trainers/tests/test_curriculum.py
@@ -21,6 +21,7 @@ dummy_curriculum_json_str = """
     }
     """
 
+dummy_curriculum_config = json.loads(dummy_curriculum_json_str)
 
 bad_curriculum_json_str = """
     {
@@ -38,9 +39,7 @@ bad_curriculum_json_str = """
     """
 
 
-@pytest.fixture
-def location():
-    return "TestBrain.json"
+dummy_curriculum_config_path = "TestBrain.json"
 
 
 @pytest.fixture
@@ -48,26 +47,24 @@ def default_reset_parameters():
     return {"param1": 1, "param2": 1, "param3": 1}
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=dummy_curriculum_json_str)
-def test_init_curriculum_happy_path(mock_file, location, default_reset_parameters):
-    curriculum = Curriculum(location)
+def test_init_curriculum_happy_path():
+    curriculum = Curriculum("TestBrain", dummy_curriculum_config)
 
-    assert curriculum._brain_name == "TestBrain"
+    assert curriculum.brain_name == "TestBrain"
     assert curriculum.lesson_num == 0
     assert curriculum.measure == "reward"
 
 
 @patch("builtins.open", new_callable=mock_open, read_data=bad_curriculum_json_str)
-def test_init_curriculum_bad_curriculum_raises_error(
-    mock_file, location, default_reset_parameters
-):
+def test_load_bad_curriculum_file_raises_error(mock_file):
     with pytest.raises(CurriculumConfigError):
-        Curriculum(location)
+        Curriculum(
+            "TestBrain", Curriculum.load_curriculum_file(dummy_curriculum_config_path)
+        )
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=dummy_curriculum_json_str)
-def test_increment_lesson(mock_file, location, default_reset_parameters):
-    curriculum = Curriculum(location)
+def test_increment_lesson():
+    curriculum = Curriculum("TestBrain", dummy_curriculum_config)
     assert curriculum.lesson_num == 0
 
     curriculum.lesson_num = 1
@@ -86,9 +83,8 @@ def test_increment_lesson(mock_file, location, default_reset_parameters):
     assert curriculum.lesson_num == 3
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=dummy_curriculum_json_str)
-def test_get_config(mock_file):
-    curriculum = Curriculum("TestBrain.json")
+def test_get_parameters():
+    curriculum = Curriculum("TestBrain", dummy_curriculum_config)
     assert curriculum.get_config() == {"param1": 0.7, "param2": 100, "param3": 0.2}
 
     curriculum.lesson_num = 2
@@ -97,8 +93,6 @@ def test_get_config(mock_file):
 
 
 # Test json loading and error handling. These examples don't need to valid config files.
-
-
 def test_curriculum_load_good():
     expected = {"x": 1}
     value = json.dumps(expected)

--- a/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
@@ -45,12 +45,12 @@ def reward_buff_sizes():
 def test_init_meta_curriculum_happy_path(
     listdir, mock_curriculum_init, mock_curriculum_get_config, default_reset_parameters
 ):
-    meta_curriculum = MetaCurriculum.from_folder("test/")
+    meta_curriculum = MetaCurriculum.from_directory("test/")
 
-    assert len(meta_curriculum.brains_to_curriculums) == 2
+    assert len(meta_curriculum.brains_to_curricula) == 2
 
-    assert "Brain1" in meta_curriculum.brains_to_curriculums
-    assert "Brain2.test" in meta_curriculum.brains_to_curriculums
+    assert "Brain1" in meta_curriculum.brains_to_curricula
+    assert "Brain2.test" in meta_curriculum.brains_to_curricula
 
     calls = [call("test/Brain1.json"), call("test/Brain2.test.json")]
 
@@ -60,7 +60,7 @@ def test_init_meta_curriculum_happy_path(
 @patch("os.listdir", side_effect=NotADirectoryError())
 def test_init_meta_curriculum_bad_curriculum_folder_raises_error(listdir):
     with pytest.raises(MetaCurriculumError):
-        MetaCurriculum.from_folder("test/")
+        MetaCurriculum.from_directory("test/")
 
 
 @patch("mlagents.trainers.curriculum.Curriculum")
@@ -105,7 +105,7 @@ def test_increment_lessons_with_reward_buff_sizes(
 def test_set_all_curriculums_to_lesson_num(curriculum_a, curriculum_b):
     meta_curriculum = MetaCurriculum({"Brain1": curriculum_a, "Brain2": curriculum_b})
 
-    meta_curriculum.set_all_curriculums_to_lesson_num(2)
+    meta_curriculum.set_all_curricula_to_lesson_num(2)
 
     assert curriculum_a.lesson_num == 2
     assert curriculum_b.lesson_num == 2

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -78,7 +78,7 @@ class TrainerController(object):
             for (
                 brain_name,
                 curriculum,
-            ) in self.meta_curriculum.brains_to_curriculums.items():
+            ) in self.meta_curriculum.brains_to_curricula.items():
                 # Skip brains that are in the metacurriculum but no trainer yet.
                 if brain_name not in self.trainers:
                     continue
@@ -174,9 +174,9 @@ class TrainerController(object):
             delta_train_start = time() - self.training_start_time
             if (
                 self.meta_curriculum
-                and brain_name in self.meta_curriculum.brains_to_curriculums
+                and brain_name in self.meta_curriculum.brains_to_curricula
             ):
-                lesson_num = self.meta_curriculum.brains_to_curriculums[
+                lesson_num = self.meta_curriculum.brains_to_curricula[
                     brain_name
                 ].lesson_num
                 trainer.stats_reporter.add_stat("Environment/Lesson", lesson_num)

--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -102,14 +102,14 @@ def initialize_trainer(
 
     min_lesson_length = 1
     if meta_curriculum:
-        if brain_name in meta_curriculum.brains_to_curriculums:
-            min_lesson_length = meta_curriculum.brains_to_curriculums[
+        if brain_name in meta_curriculum.brains_to_curricula:
+            min_lesson_length = meta_curriculum.brains_to_curricula[
                 brain_name
             ].min_lesson_length
         else:
             logger.warning(
                 f"Metacurriculum enabled, but no curriculum for brain {brain_name}. "
-                f"Brains with curricula: {meta_curriculum.brains_to_curriculums.keys()}. "
+                f"Brains with curricula: {meta_curriculum.brains_to_curricula.keys()}. "
             )
 
     trainer: Trainer = None  # type: ignore  # will be set to one of these, or raise


### PR DESCRIPTION
Previously the Curriculum and MetaCurriculum classes required file / folder
paths for initialization.  These methods loaded the configuration for the
curricula from the filesystem.  Requiring files for configuring curricula
makes testing and updating our config format more difficult.

This change moves the file loading into static methods, so that Curricula /
MetaCurricula can be initialized from dictionaries only.