### PR TITLE
WIP: Move all non-public methods out of Trainer class

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -171,7 +171,7 @@ class PPOTrainer(RLTrainer):
 
     def _update_policy(self):
         """
-        Uses demonstration_buffer to update the policy.
+        Uses update buffer to update the policy.
         The reward signal generators must be updated in this method at their own pace.
         """
         buffer_length = self.update_buffer.num_experiences

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -81,9 +81,6 @@ class PPOTrainer(RLTrainer):
         super()._process_trajectory(trajectory)
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 
-        # Add to episode_steps
-        self.episode_steps[agent_id] += len(trajectory.steps)
-
         agent_buffer_trajectory = trajectory.to_agentbuffer()
         # Update the normalization
         if self.is_training:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -175,7 +175,6 @@ class PPOTrainer(RLTrainer):
         The reward signal generators must be updated in this method at their own pace.
         """
         buffer_length = self.update_buffer.num_experiences
-        self.cumulative_returns_since_policy_update.clear()
 
         # Make sure batch_size is a multiple of sequence length. During training, we
         # will need to reshape the data into a batch_size x sequence_length tensor.

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -28,7 +28,6 @@ class RLTrainer(Trainer, abc.ABC):  # pylint: disable=abstract-method
     def __init__(self, *args, **kwargs):
         super(RLTrainer, self).__init__(*args, **kwargs)
         self.param_keys: List[str] = []
-        self.cumulative_returns_since_policy_update: List[float] = []
         self.step: int = 0
         self.training_start_time = time.time()
         self.summary_freq = self.trainer_parameters["summary_freq"]
@@ -120,19 +119,13 @@ class RLTrainer(Trainer, abc.ABC):  # pylint: disable=abstract-method
         A signal that the Episode has ended. The buffer must be reset.
         Get only called when the academy resets.
         """
-        for agent_id in self.episode_steps:
-            self.episode_steps[agent_id] = 0
         for rewards in self.collected_rewards.values():
             for agent_id in rewards:
                 rewards[agent_id] = 0
 
     def _update_end_episode_stats(self, agent_id: str, policy: TFPolicy) -> None:
-        self.episode_steps[agent_id] = 0
         for name, rewards in self.collected_rewards.items():
             if name == "environment":
-                self.cumulative_returns_since_policy_update.append(
-                    rewards.get(agent_id, 0)
-                )
                 self.reward_buffer.appendleft(rewards.get(agent_id, 0))
                 rewards[agent_id] = 0
             else:

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -46,7 +46,6 @@ class RLTrainer(Trainer, abc.ABC):  # pylint: disable=abstract-method
             "environment": defaultdict(lambda: 0)
         }
         self.update_buffer: AgentBuffer = AgentBuffer()
-        self.episode_steps: Dict[str, int] = defaultdict(lambda: 0)
         # Write hyperparameters to Tensorboard
         if self.is_training:
             self.write_tensorboard_text("Hyperparameters", self.trainer_parameters)

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -1,25 +1,38 @@
 # # Unity ML-Agents Toolkit
 import logging
-from typing import Dict
+from typing import Dict, List, Any
 from collections import defaultdict
+import abc
+import time
 
+from mlagents.tf_utils import tf
 from mlagents.trainers.tf_policy import TFPolicy
+from mlagents_envs.timers import set_gauge
 from mlagents.trainers.buffer import AgentBuffer
+from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.trainer import Trainer, UnityTrainerException
+from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.components.reward_signals import RewardSignalResult
+from mlagents_envs.timers import hierarchical_timer
 
 LOGGER = logging.getLogger("mlagents.trainers")
 
 RewardSignalResults = Dict[str, RewardSignalResult]
 
 
-class RLTrainer(Trainer):  # pylint: disable=abstract-method
+class RLTrainer(Trainer, abc.ABC):  # pylint: disable=abstract-method
     """
     This class is the base class for trainers that use Reward Signals.
     """
 
     def __init__(self, *args, **kwargs):
         super(RLTrainer, self).__init__(*args, **kwargs)
+        self.param_keys: List[str] = []
+        self.cumulative_returns_since_policy_update: List[float] = []
+        self.step: int = 0
+        self.training_start_time = time.time()
+        self.summary_freq = self.trainer_parameters["summary_freq"]
+        self.next_update_step = self.summary_freq
         # Make sure we have at least one reward_signal
         if not self.trainer_parameters["reward_signals"]:
             raise UnityTrainerException(
@@ -35,6 +48,72 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         }
         self.update_buffer: AgentBuffer = AgentBuffer()
         self.episode_steps: Dict[str, int] = defaultdict(lambda: 0)
+        # Write hyperparameters to Tensorboard
+        if self.is_training:
+            self.write_tensorboard_text("Hyperparameters", self.trainer_parameters)
+
+    def _check_param_keys(self):
+        for k in self.param_keys:
+            if k not in self.trainer_parameters:
+                raise UnityTrainerException(
+                    "The hyper-parameter {0} could not be found for the {1} trainer of "
+                    "brain {2}.".format(k, self.__class__, self.brain_name)
+                )
+
+    def _increment_step(self, n_steps: int, name_behavior_id: str) -> None:
+        """
+        Increment the step count of the trainer
+        :param n_steps: number of steps to increment the step count by
+        """
+        self.step += n_steps
+        self.next_update_step = self.step + (
+            self.summary_freq - self.step % self.summary_freq
+        )
+        p = self.get_policy(name_behavior_id)
+        if p:
+            p.increment_step(n_steps)
+
+    def _write_summary(self, step: int) -> None:
+        """
+        Saves training statistics to Tensorboard.
+        """
+        is_training = "Training." if self.training_progress < 1.0 else "Not Training."
+        stats_summary = self.stats_reporter.get_stats_summaries(
+            "Environment/Cumulative Reward"
+        )
+        if stats_summary.num > 0:
+            LOGGER.info(
+                " {}: {}: Step: {}. "
+                "Time Elapsed: {:0.3f} s "
+                "Mean "
+                "Reward: {:0.3f}"
+                ". Std of Reward: {:0.3f}. {}".format(
+                    self.run_id,
+                    self.brain_name,
+                    step,
+                    time.time() - self.training_start_time,
+                    stats_summary.mean,
+                    stats_summary.std,
+                    is_training,
+                )
+            )
+            set_gauge(f"{self.brain_name}.mean_reward", stats_summary.mean)
+        else:
+            LOGGER.info(
+                " {}: {}: Step: {}. No episode was completed since last summary. {}".format(
+                    self.run_id, self.brain_name, step, is_training
+                )
+            )
+        self.stats_reporter.write_stats(int(step))
+
+    def _maybe_write_summary(self, step_after_process: int) -> None:
+        """
+        If processing the trajectory will make the step exceed the next summary write,
+        write the summary. This logic ensures summaries are written on the update step and not in between.
+        :param step_after_process: the step count after processing the next trajectory.
+        """
+        if step_after_process >= self.next_update_step and self.step != 0:
+            self._write_summary(self.next_update_step)
 
     def end_episode(self) -> None:
         """
@@ -72,6 +151,89 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         """
         Steps the trainer, taking in trajectories and updates if ready
         """
-        super().advance()
+        with hierarchical_timer("process_trajectory"):
+            for traj_queue in self.trajectory_queues:
+                try:
+                    t = traj_queue.get_nowait()
+                    self._process_trajectory(t)
+                except AgentManagerQueue.Empty:
+                    pass
+        if self.training_progress < 1.0:
+            if self._is_ready_update():
+                with hierarchical_timer("update_policy"):
+                    self._update_policy()
+                    for q in self.policy_queues:
+                        # Get policies that correspond to the policy queue in question
+                        q.put(self.get_policy(q.behavior_id))
         if not self.is_training:
             self.clear_update_buffer()
+
+    @property
+    def training_progress(self) -> float:
+        """
+        Returns a float between 0 and 1 indicating how far along in the training progress the Trainer is.
+        If 1, the Trainer wasn't training to begin with, or max_steps
+        is reached.
+        """
+        if self.is_training:
+            return min(self.step / float(self.trainer_parameters["max_steps"]), 1.0)
+        else:
+            return 1.0
+
+    def write_tensorboard_text(self, key: str, input_dict: Dict[str, Any]) -> None:
+        """
+        Saves text to Tensorboard.
+        Note: Only works on tensorflow r1.2 or above.
+        :param key: The name of the text.
+        :param input_dict: A dictionary that will be displayed in a table on Tensorboard.
+        """
+        try:
+            with tf.Session() as sess:
+                s_op = tf.summary.text(
+                    key,
+                    tf.convert_to_tensor(
+                        ([[str(x), str(input_dict[x])] for x in input_dict])
+                    ),
+                )
+                s = sess.run(s_op)
+                self.stats_reporter.write_text(s, self.step)
+        except Exception:
+            LOGGER.info("Could not write text summary for Tensorboard.")
+            pass
+
+    def save_model(self, name_behavior_id: str) -> None:
+        """
+        Saves the model
+        """
+        self.get_policy(name_behavior_id).save_model(self.step)
+
+    def export_model(self, name_behavior_id: str) -> None:
+        """
+        Exports the model
+        """
+        self.get_policy(name_behavior_id).export_model()
+
+    @abc.abstractmethod
+    def _update_policy(self) -> None:
+        """
+        Uses update buffer to update the policy.
+        The reward signal generators must be updated in this method at their own pace.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _process_trajectory(self, trajectory: Trajectory) -> None:
+        """
+        Takes a trajectory and processes it, putting it into the update buffer.
+        :param trajectory: The Trajectory tuple containing the steps to be processed.
+        """
+        self._maybe_write_summary(self.step + len(trajectory.steps))
+        self._increment_step(len(trajectory.steps), trajectory.behavior_id)
+
+    @abc.abstractmethod
+    def _is_ready_update(self):
+        """
+        Returns whether or not the trainer has enough elements to run update model
+        :return: A boolean corresponding to wether or not update_model() can be run
+        """
+        return False

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -141,9 +141,6 @@ class SACTrainer(RLTrainer):
         last_step = trajectory.steps[-1]
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 
-        # Add to episode_steps
-        self.episode_steps[agent_id] += len(trajectory.steps)
-
         agent_buffer_trajectory = trajectory.to_agentbuffer()
 
         # Update the normalization

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -102,7 +102,7 @@ class SACTrainer(RLTrainer):
         Saves the model. Overrides the default save_model since we want to save
         the replay buffer as well.
         """
-        self.policy.save_model(self.get_step)
+        super().save_model(name_behavior_id)
         if self.checkpoint_replay_buffer:
             self.save_replay_buffer()
 

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -247,8 +247,6 @@ class SACTrainer(RLTrainer):
         N times, then the reward signals are updated N times, then reward_signal_updates_per_train
         is greater than 1 and the reward signals are not updated in parallel.
         """
-
-        self.cumulative_returns_since_policy_update.clear()
         n_sequences = max(
             int(self.trainer_parameters["batch_size"] / self.policy.sequence_length), 1
         )

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -58,12 +58,9 @@ def create_rl_trainer():
 def test_rl_trainer():
     trainer = create_rl_trainer()
     agent_id = "0"
-    trainer.episode_steps[agent_id] = 3
     trainer.collected_rewards["extrinsic"] = {agent_id: 3}
     # Test end episode
     trainer.end_episode()
-    for agent_id in trainer.episode_steps:
-        assert trainer.episode_steps[agent_id] == 0
     for rewards in trainer.collected_rewards.values():
         for agent_id in rewards:
             assert rewards[agent_id] == 0

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -48,7 +48,7 @@ def trainer_controller_with_start_learning_mocks(basic_trainer_controller):
     trainer_mock = MagicMock()
     trainer_mock.get_step = 0
     trainer_mock.get_max_steps = 5
-    trainer_mock.should_still_train = True
+    trainer_mock.training_progress = 0.0
     trainer_mock.parameters = {"some": "parameter"}
     trainer_mock.write_tensorboard_text = MagicMock()
 
@@ -64,7 +64,7 @@ def trainer_controller_with_start_learning_mocks(basic_trainer_controller):
             not tc.trainers["testbrain"].get_step
             <= tc.trainers["testbrain"].get_max_steps
         ):
-            tc.trainers["testbrain"].should_still_train = False
+            tc.trainers["testbrain"].training_progress = 1.0
         if tc.trainers["testbrain"].get_step > 10:
             raise KeyboardInterrupt
         return 1

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -1,22 +1,17 @@
 # # Unity ML-Agents Toolkit
 import logging
 from typing import Dict, List, Deque, Any
-import time
 import abc
-
-from mlagents.tf_utils import tf
 
 from collections import deque
 
 from mlagents_envs.exception import UnityException
-from mlagents_envs.timers import set_gauge
 from mlagents.trainers.tf_policy import TFPolicy
 from mlagents.trainers.stats import StatsReporter
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.brain import BrainParameters
 from mlagents.trainers.policy import Policy
-from mlagents_envs.timers import hierarchical_timer
 
 LOGGER = logging.getLogger("mlagents.trainers")
 
@@ -48,50 +43,15 @@ class Trainer(abc.ABC):
         :str run_id: The identifier of the current run
         :int reward_buff_cap:
         """
-        self.param_keys: List[str] = []
         self.brain_name = brain_name
         self.run_id = run_id
         self.trainer_parameters = trainer_parameters
+        self.is_training = training
         self.summary_path = trainer_parameters["summary_path"]
         self.stats_reporter = StatsReporter(self.summary_path)
-        self.cumulative_returns_since_policy_update: List[float] = []
-        self.is_training = training
         self._reward_buffer: Deque[float] = deque(maxlen=reward_buff_cap)
         self.policy_queues: List[AgentManagerQueue[Policy]] = []
         self.trajectory_queues: List[AgentManagerQueue[Trajectory]] = []
-        self.step: int = 0
-        self.training_start_time = time.time()
-        self.summary_freq = self.trainer_parameters["summary_freq"]
-        self.next_update_step = self.summary_freq
-
-    def _check_param_keys(self):
-        for k in self.param_keys:
-            if k not in self.trainer_parameters:
-                raise UnityTrainerException(
-                    "The hyper-parameter {0} could not be found for the {1} trainer of "
-                    "brain {2}.".format(k, self.__class__, self.brain_name)
-                )
-
-    def write_tensorboard_text(self, key: str, input_dict: Dict[str, Any]) -> None:
-        """
-        Saves text to Tensorboard.
-        Note: Only works on tensorflow r1.2 or above.
-        :param key: The name of the text.
-        :param input_dict: A dictionary that will be displayed in a table on Tensorboard.
-        """
-        try:
-            with tf.Session() as sess:
-                s_op = tf.summary.text(
-                    key,
-                    tf.convert_to_tensor(
-                        ([[str(x), str(input_dict[x])] for x in input_dict])
-                    ),
-                )
-                s = sess.run(s_op)
-                self.stats_reporter.write_text(s, self.get_step)
-        except Exception:
-            LOGGER.info("Could not write text summary for Tensorboard.")
-            pass
 
     def _dict_to_str(self, param_dict: Dict[str, Any], num_tabs: int) -> str:
         """
@@ -123,36 +83,14 @@ class Trainer(abc.ABC):
         )
 
     @property
-    def parameters(self) -> Dict[str, Any]:
+    @abc.abstractmethod
+    def training_progress(self) -> float:
         """
-        Returns the trainer parameters of the trainer.
-        """
-        return self.trainer_parameters
-
-    @property
-    def get_max_steps(self) -> int:
-        """
-        Returns the maximum number of steps. Is used to know when the trainer should be stopped.
-        :return: The maximum number of steps of the trainer
-        """
-        return int(float(self.trainer_parameters["max_steps"]))
-
-    @property
-    def get_step(self) -> int:
-        """
-        Returns the number of steps the trainer has performed
-        :return: the step count of the trainer
-        """
-        return self.step
-
-    @property
-    def should_still_train(self) -> bool:
-        """
-        Returns whether or not the trainer should train. A Trainer could
-        stop training if it wasn't training to begin with, or if max_steps
+        Returns a float between 0 and 1 indicating how far along in the training progress the Trainer is.
+        If 1, the Trainer wasn't training to begin with, or max_steps
         is reached.
         """
-        return self.is_training and self.get_step <= self.get_max_steps
+        pass
 
     @property
     def reward_buffer(self) -> Deque[float]:
@@ -164,81 +102,19 @@ class Trainer(abc.ABC):
         """
         return self._reward_buffer
 
-    def _increment_step(self, n_steps: int, name_behavior_id: str) -> None:
-        """
-        Increment the step count of the trainer
-        :param n_steps: number of steps to increment the step count by
-        """
-        self.step += n_steps
-        self.next_update_step = self.step + (
-            self.summary_freq - self.step % self.summary_freq
-        )
-        p = self.get_policy(name_behavior_id)
-        if p:
-            p.increment_step(n_steps)
-
+    @abc.abstractmethod
     def save_model(self, name_behavior_id: str) -> None:
         """
         Saves the model
         """
-        self.get_policy(name_behavior_id).save_model(self.get_step)
+        pass
 
+    @abc.abstractmethod
     def export_model(self, name_behavior_id: str) -> None:
         """
         Exports the model
         """
-        self.get_policy(name_behavior_id).export_model()
-
-    def _write_summary(self, step: int) -> None:
-        """
-        Saves training statistics to Tensorboard.
-        """
-        is_training = "Training." if self.should_still_train else "Not Training."
-        stats_summary = self.stats_reporter.get_stats_summaries(
-            "Environment/Cumulative Reward"
-        )
-        if stats_summary.num > 0:
-            LOGGER.info(
-                " {}: {}: Step: {}. "
-                "Time Elapsed: {:0.3f} s "
-                "Mean "
-                "Reward: {:0.3f}"
-                ". Std of Reward: {:0.3f}. {}".format(
-                    self.run_id,
-                    self.brain_name,
-                    step,
-                    time.time() - self.training_start_time,
-                    stats_summary.mean,
-                    stats_summary.std,
-                    is_training,
-                )
-            )
-            set_gauge(f"{self.brain_name}.mean_reward", stats_summary.mean)
-        else:
-            LOGGER.info(
-                " {}: {}: Step: {}. No episode was completed since last summary. {}".format(
-                    self.run_id, self.brain_name, step, is_training
-                )
-            )
-        self.stats_reporter.write_stats(int(step))
-
-    @abc.abstractmethod
-    def _process_trajectory(self, trajectory: Trajectory) -> None:
-        """
-        Takes a trajectory and processes it, putting it into the update buffer.
-        :param trajectory: The Trajectory tuple containing the steps to be processed.
-        """
-        self._maybe_write_summary(self.get_step + len(trajectory.steps))
-        self._increment_step(len(trajectory.steps), trajectory.behavior_id)
-
-    def _maybe_write_summary(self, step_after_process: int) -> None:
-        """
-        If processing the trajectory will make the step exceed the next summary write,
-        write the summary. This logic ensures summaries are written on the update step and not in between.
-        :param step_after_process: the step count after processing the next trajectory.
-        """
-        if step_after_process >= self.next_update_step and self.get_step != 0:
-            self._write_summary(self.next_update_step)
+        pass
 
     @abc.abstractmethod
     def end_episode(self):
@@ -270,38 +146,11 @@ class Trainer(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _is_ready_update(self):
-        """
-        Returns whether or not the trainer has enough elements to run update model
-        :return: A boolean corresponding to wether or not update_model() can be run
-        """
-        return False
-
-    @abc.abstractmethod
-    def _update_policy(self):
-        """
-        Uses demonstration_buffer to update model.
-        """
-        pass
-
     def advance(self) -> None:
         """
-        Steps the trainer, taking in trajectories and updates if ready.
+        Steps the trainer, taking in trajectories and updates if ready
         """
-        with hierarchical_timer("process_trajectory"):
-            for traj_queue in self.trajectory_queues:
-                try:
-                    t = traj_queue.get_nowait()
-                    self._process_trajectory(t)
-                except AgentManagerQueue.Empty:
-                    pass
-        if self.should_still_train:
-            if self._is_ready_update():
-                with hierarchical_timer("_update_policy"):
-                    self._update_policy()
-                    for q in self.policy_queues:
-                        # Get policies that correspond to the policy queue in question
-                        q.put(self.get_policy(q.behavior_id))
+        pass
 
     def publish_policy_queue(self, policy_queue: AgentManagerQueue[Policy]) -> None:
         """


### PR DESCRIPTION
The current Trainer class contains a lot of common logic. This PR would move the non-public methods (_ methods) out of Trainer and into RLTrainer. This leaves the Trainer a true abstract class/interface. 

The Trainer now has these exposed methods:

- training_progress (abstract, replaces get_step and get_max_step)
- reward_buffer (Used by curriculum, can we remove this?)
- save_model (abstract)
- export_model (abstract)
- end_episode (abstract - can we remove this?)
- create_policy (abstract)
- add_policy (abstract)
- get_policy (abstract)
- advance (abstract) 
- publish_policy_queue
- subscribe_trajectory_queue

@andrewcoh if this helps with the GhostTrainer, it would be a good reason to merge it. 