### PR TITLE
pass file mode to h5py.File()

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -226,7 +226,7 @@ class AgentBuffer(dict):
         """
         Saves the AgentBuffer to a file-like object.
         """
-        with h5py.File(file_object) as write_file:
+        with h5py.File(file_object, "w") as write_file:
             for key, data in self.items():
                 write_file.create_dataset(key, data=data, dtype="f", compression="gzip")
 
@@ -234,7 +234,7 @@ class AgentBuffer(dict):
         """
         Loads the AgentBuffer from a file-like object.
         """
-        with h5py.File(file_object) as read_file:
+        with h5py.File(file_object, "r") as read_file:
             for key in list(read_file.keys()):
                 self[key] = AgentBuffer.AgentBufferField()
                 # extend() will convert the numpy array's first dimension into list

--- a/test_constraints_max_tf1_version.txt
+++ b/test_constraints_max_tf1_version.txt
@@ -4,3 +4,4 @@
 grpcio>=1.23.0
 numpy>=1.17.2
 tensorflow>=1.14.0,<2.0
+h5py>=2.10.0

--- a/test_constraints_max_tf2_version.txt
+++ b/test_constraints_max_tf2_version.txt
@@ -3,3 +3,4 @@
 grpcio>=1.23.0
 numpy>=1.17.2
 tensorflow>=2.0.0,<2.1.0
+h5py>=2.10.0

--- a/test_constraints_min_version.txt
+++ b/test_constraints_min_version.txt
@@ -4,3 +4,4 @@ numpy==1.13.3
 Pillow==4.2.1
 protobuf==3.6
 tensorflow==1.7
+h5py==2.9.0


### PR DESCRIPTION
Reported in https://github.com/Unity-Technologies/ml-agents/issues/3164

I can't reproduce the exception but do get the deprecation warning. This passes the mode to where we write and read the files. It also forces CI to use both h5py 2.9 and 2.10.