### PR TITLE
use TensorShape for index calc

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/WriterAdapterTests.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/Tests/Sensor/WriterAdapterTests.cs
@@ -48,13 +48,13 @@ namespace MLAgents.Tests
                 valueType = TensorProxy.TensorType.FloatingPoint,
                 data = new Tensor(2, 3)
             };
-            var shape = new[] { 3 };
-            writer.SetTarget(t, shape, 0, 0);
+
+            writer.SetTarget(t, 0, 0);
             Assert.AreEqual(0f, t.data[0, 0]);
             writer[0] = 1f;
             Assert.AreEqual(1f, t.data[0, 0]);
 
-            writer.SetTarget(t, shape, 1, 1);
+            writer.SetTarget(t, 1, 1);
             writer[0] = 2f;
             writer[1] = 3f;
             // [0, 0] shouldn't change
@@ -69,7 +69,7 @@ namespace MLAgents.Tests
                 data = new Tensor(2, 3)
             };
 
-            writer.SetTarget(t, shape, 1, 1);
+            writer.SetTarget(t, 1, 1);
             writer.AddRange(new [] {-1f, -2f});
             Assert.AreEqual(0f, t.data[0, 0]);
             Assert.AreEqual(0f, t.data[0, 1]);
@@ -91,11 +91,11 @@ namespace MLAgents.Tests
 
             var shape = new[] { 2, 2, 3 };
 
-            writer.SetTarget(t, shape,  0, 0);
+            writer.SetTarget(t, 0, 0);
             writer[1, 0, 1] = 1f;
             Assert.AreEqual(1f, t.data[0, 1, 0, 1]);
 
-            writer.SetTarget(t, shape, 0, 1);
+            writer.SetTarget(t, 0, 1);
             writer[1, 0, 0] = 2f;
             Assert.AreEqual(2f, t.data[0, 1, 0, 1]);
         }

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/GeneratorImpl.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/GeneratorImpl.cs
@@ -106,8 +106,7 @@ namespace MLAgents.InferenceBrain
                 foreach (var sensorIndex in m_SensorIndices)
                 {
                     var sensor = agent.sensors[sensorIndex];
-                    var shape = sensor.GetObservationShape();
-                    m_WriteAdapter.SetTarget(tensorProxy, shape, agentIndex, tensorOffset);
+                    m_WriteAdapter.SetTarget(tensorProxy, agentIndex, tensorOffset);
                     var numWritten = sensor.Write(m_WriteAdapter);
                     tensorOffset += numWritten;
                 }
@@ -355,7 +354,7 @@ namespace MLAgents.InferenceBrain
             foreach (var agent in agents)
             {
                 var sensor = agent.sensors[m_SensorIndex];
-                m_WriteAdapter.SetTarget(tensorProxy, sensor.GetObservationShape(), agentIndex, 0);
+                m_WriteAdapter.SetTarget(tensorProxy, agentIndex, 0);
                 sensor.Write(m_WriteAdapter);
                 agentIndex++;
             }

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/WriteAdapter.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/WriteAdapter.cs
@@ -45,7 +45,6 @@ namespace MLAgents.Sensor
         /// Set the adapter to write to a TensorProxy at the given batch and channel offset.
         /// </summary>
         /// <param name="tensorProxy">Tensor proxy that will be writtent to.</param>
-        /// <param name="shape">Shape of the observations to be written.</param>
         /// <param name="batchIndex">Batch index in the tensor proxy (i.e. the index of the Agent)</param>
         /// <param name="channelOffset">Offset from the start of the channel to write to.</param>
         public void SetTarget(TensorProxy tensorProxy, int batchIndex, int channelOffset)


### PR DESCRIPTION
Followup from the last PR - save a TensorShape instead of the int[] in WriteAdapter to reuse the index calculation code from there

This also undoes a signature change, since we don't need the shape when passing a TensorProxy to write (since the tensor already knows its shape).