### PR TITLE
pin flake8 plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
                 .*_pb2_grpc.py
             )$
         # flake8-tidy-imports is used for banned-modules, not actually tidying
-        additional_dependencies: [flake8-comprehensions, flake8-tidy-imports, flake8-bugbear]
+        additional_dependencies: [flake8-comprehensions==3.1.4, flake8-tidy-imports==3.1.0, flake8-bugbear==20.1.2]
     -   id: trailing-whitespace
         name: trailing-whitespace-markdown
         types: [markdown]


### PR DESCRIPTION
These started showing up due to the latest version of https://pypi.org/project/flake8-tidy-imports/#history
```
ml-agents/mlagents/trainers/tests/test_agent_processor.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_multigpu.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_trainer_util.py:6:1: I250 Unnecessary import alias - rewrite as 'from mlagents.trainers import trainer_util'.
gym-unity/gym_unity/tests/test_gym.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/mock_brain.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_sac.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_reward_signals.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents-envs/mlagents_envs/tests/test_envs.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_stats.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_bcmodule.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
ml-agents/mlagents/trainers/tests/test_ppo.py:1:1: I250 Unnecessary import alias - rewrite as 'from unittest import mock'.
``` 
Pin the plugins so that we don't get surprises like these.