### PR TITLE
update flake8 plugin version and fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
                 .*_pb2_grpc.py
             )$
         # flake8-tidy-imports is used for banned-modules, not actually tidying
-        additional_dependencies: [flake8-comprehensions==3.1.4, flake8-tidy-imports==3.1.0, flake8-bugbear==20.1.2]
+        additional_dependencies: [flake8-comprehensions==3.1.4, flake8-tidy-imports==4.0.0, flake8-bugbear==20.1.2]
     -   id: trailing-whitespace
         name: trailing-whitespace-markdown
         types: [markdown]

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 import numpy as np
 

--- a/ml-agents-envs/mlagents_envs/tests/test_envs.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_envs.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 
 import numpy as np

--- a/ml-agents/mlagents/trainers/tests/mock_brain.py
+++ b/ml-agents/mlagents/trainers/tests/mock_brain.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import numpy as np
 
 from mlagents.trainers.brain import CameraResolution, BrainParameters

--- a/ml-agents/mlagents/trainers/tests/test_agent_processor.py
+++ b/ml-agents/mlagents/trainers/tests/test_agent_processor.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 import mlagents.trainers.tests.mock_brain as mb
 import numpy as np

--- a/ml-agents/mlagents/trainers/tests/test_bcmodule.py
+++ b/ml-agents/mlagents/trainers/tests/test_bcmodule.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 import mlagents.trainers.tests.mock_brain as mb
 

--- a/ml-agents/mlagents/trainers/tests/test_multigpu.py
+++ b/ml-agents/mlagents/trainers/tests/test_multigpu.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 
 from mlagents.tf_utils import tf

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 
 import numpy as np

--- a/ml-agents/mlagents/trainers/tests/test_reward_signals.py
+++ b/ml-agents/mlagents/trainers/tests/test_reward_signals.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 import yaml
 import os

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import pytest
 import yaml
 

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 import os
 import pytest
 import tempfile

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest import mock
 from unittest.mock import Mock, MagicMock
 import unittest
 from queue import Empty as EmptyQueue

--- a/ml-agents/mlagents/trainers/tests/test_trainer_util.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_util.py
@@ -3,7 +3,7 @@ import yaml
 import io
 from unittest.mock import patch
 
-import mlagents.trainers.trainer_util as trainer_util
+from mlagents.trainers import trainer_util
 from mlagents.trainers.trainer_util import load_config, _load_config
 from mlagents.trainers.ppo.trainer import PPOTrainer
 from mlagents.trainers.exception import TrainerConfigError


### PR DESCRIPTION
The newest version of flake8-tidy-imports was (correctly) complaining that
``` python
import unittest.mock as mock
```
was redundant. This changes all of those to `from unittest import mock`