### PR TITLE
Fix issue with different decision intervals for different brains

### DIFF
--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -153,6 +153,7 @@ class AgentProcessor:
                         del self.episode_rewards[agent_id]
                 elif not next_info.local_done[next_idx]:
                     self.episode_steps[agent_id] += 1
-        self.policy.save_previous_action(
-            curr_info.agents, take_action_outputs["action"]
-        )
+        if "action" in take_action_outputs:
+            self.policy.save_previous_action(
+                curr_info.agents, take_action_outputs["action"]
+            )

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict, NamedTuple
+from typing import List, Dict, NamedTuple, Iterable
 from mlagents.trainers.brain import AllBrainInfo, BrainParameters
 from mlagents.trainers.policy import Policy
 from mlagents.trainers.action_info import ActionInfo
@@ -9,6 +9,10 @@ class EnvironmentStep(NamedTuple):
     previous_all_brain_info: AllBrainInfo
     current_all_brain_info: AllBrainInfo
     brain_name_to_action_info: Dict[str, ActionInfo]
+
+    @property
+    def name_behavior_ids(self) -> Iterable[str]:
+        return self.brain_name_to_action_info.keys()
 
 
 class EnvManager(ABC):

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -10,11 +10,6 @@ class EnvironmentStep(NamedTuple):
     current_all_brain_info: AllBrainInfo
     brain_name_to_action_info: Dict[str, ActionInfo]
 
-    def has_actions_for_brain(self, brain_name: str) -> bool:
-        return brain_name in self.brain_name_to_action_info and bool(
-            self.brain_name_to_action_info[brain_name].outputs
-        )
-
 
 class EnvManager(ABC):
     def __init__(self):

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -294,14 +294,15 @@ class TrainerController(object):
         with hierarchical_timer("env_step"):
             new_step_infos = env.step()
         for step_info in new_step_infos:
-            for brain_name in self.trainers.keys():
-                for name_behavior_id in self.brain_name_to_identifier[brain_name]:
-                    _processor = self.managers[name_behavior_id].processor
-                    _processor.add_experiences(
-                        step_info.previous_all_brain_info[name_behavior_id],
-                        step_info.current_all_brain_info[name_behavior_id],
-                        step_info.brain_name_to_action_info[name_behavior_id].outputs,
-                    )
+            for name_behavior_id in step_info.name_behavior_ids:
+                if name_behavior_id not in self.managers:
+                    continue
+                _processor = self.managers[name_behavior_id].processor
+                _processor.add_experiences(
+                    step_info.previous_all_brain_info[name_behavior_id],
+                    step_info.current_all_brain_info[name_behavior_id],
+                    step_info.brain_name_to_action_info[name_behavior_id].outputs,
+                )
 
         for brain_name, trainer in self.trainers.items():
             if self.train_model and trainer.get_step <= trainer.get_max_steps:

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -296,15 +296,12 @@ class TrainerController(object):
         for step_info in new_step_infos:
             for brain_name in self.trainers.keys():
                 for name_behavior_id in self.brain_name_to_identifier[brain_name]:
-                    if step_info.has_actions_for_brain(name_behavior_id):
-                        _processor = self.managers[name_behavior_id].processor
-                        _processor.add_experiences(
-                            step_info.previous_all_brain_info[name_behavior_id],
-                            step_info.current_all_brain_info[name_behavior_id],
-                            step_info.brain_name_to_action_info[
-                                name_behavior_id
-                            ].outputs,
-                        )
+                    _processor = self.managers[name_behavior_id].processor
+                    _processor.add_experiences(
+                        step_info.previous_all_brain_info[name_behavior_id],
+                        step_info.current_all_brain_info[name_behavior_id],
+                        step_info.brain_name_to_action_info[name_behavior_id].outputs,
+                    )
 
         for brain_name, trainer in self.trainers.items():
             if self.train_model and trainer.get_step <= trainer.get_max_steps:

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -296,6 +296,11 @@ class TrainerController(object):
         for step_info in new_step_infos:
             for name_behavior_id in step_info.name_behavior_ids:
                 if name_behavior_id not in self.managers:
+                    self.logger.warning(
+                        "Agent manager was not created for behavior id {}.".format(
+                            name_behavior_id
+                        )
+                    )
                     continue
                 _processor = self.managers[name_behavior_id].processor
                 _processor.add_experiences(


### PR DESCRIPTION
If there is more than one brain each with a different decision interval, only one of the brains would be updated. This was because we were checking if we had any actions present for each EnvironmentStep - and in the error case there would be no actions but still a braininfo present. 

We now process all the steps, but don't withdraw previous step unless there is an action. 