### PR TITLE
run tensorflow 2.1 in CI

### DIFF
--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -63,7 +63,7 @@ setup(
         "Pillow>=4.2.1",
         "protobuf>=3.6",
         "pyyaml",
-        "tensorflow>=1.7,<2.1",
+        "tensorflow>=1.7,<2.2",
         'pypiwin32==223;platform_system=="Windows"',
     ],
     python_requires=">=3.6.1",

--- a/test_constraints_max_tf2_version.txt
+++ b/test_constraints_max_tf2_version.txt
@@ -2,5 +2,5 @@
 # For projects with upper bounds, we should periodically update this list to the latest release version
 grpcio>=1.23.0
 numpy>=1.17.2
-tensorflow>=2.0.0,<2.1.0
+tensorflow>=2.1.0,<2.2.0
 h5py>=2.10.0


### PR DESCRIPTION
Tensorflow 2.1 was just released: https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0

This is the first pass at checking support for it - if this passes, I'll retrain some scenes with it and make sure inference is OK. 