### PR TITLE
Only send previous action and current BrainInfo

### DIFF
--- a/ml-agents/mlagents/trainers/action_info.py
+++ b/ml-agents/mlagents/trainers/action_info.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Any, Dict
+from typing import NamedTuple, Any, Dict, List
 import numpy as np
 
 ActionInfoOutputs = Dict[str, np.ndarray]
@@ -8,3 +8,4 @@ class ActionInfo(NamedTuple):
     action: Any
     value: Any
     outputs: ActionInfoOutputs
+    agents: List[str]

--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -73,8 +73,10 @@ class AgentProcessor:
 
         for next_idx, agent_id in enumerate(curr_info.agents):
             stored_info = self.last_brain_info.get(agent_id, None)
-            if stored_info is not None:
-                stored_take_action_outputs = self.last_take_action_outputs[agent_id]
+            stored_take_action_outputs = self.last_take_action_outputs.get(
+                agent_id, None
+            )
+            if stored_info is not None and stored_take_action_outputs is not None:
                 idx = stored_info.agents.index(agent_id)
                 obs = []
                 if not stored_info.local_done[idx]:

--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -36,10 +36,11 @@ class AgentProcessor:
         """
         self.experience_buffers: Dict[str, List[AgentExperience]] = defaultdict(list)
         self.last_brain_info: Dict[str, BrainInfo] = {}
+        # last_take_action_outputs stores the action a_t taken before the current observation s_(t+1), while
+        # grabbing previous_action from the policy grabs the action PRIOR to that, a_(t-1).
         self.last_take_action_outputs: Dict[str, ActionInfoOutputs] = {}
-        # Note: this is needed until we switch to AgentExperiences as the data input type.
-        # We still need some info from the policy (memories, previous actions)
-        # that really should be gathered by the env-manager.
+        # Note: In the future this policy reference will be the policy of the env_manager and not the trainer.
+        # We can in that case just grab the action from the policy rather than having it passed in.
         self.policy = policy
         self.episode_steps: Counter = Counter()
         self.episode_rewards: Dict[str, float] = defaultdict(float)

--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -58,9 +58,8 @@ class AgentProcessor:
         """
         take_action_outputs = previous_action.outputs
         if take_action_outputs:
-            self.stats_reporter.add_stat(
-                "Policy/Entropy", take_action_outputs["entropy"].mean()
-            )
+            for _entropy in take_action_outputs["entropy"]:
+                self.stats_reporter.add_stat("Policy/Entropy", _entropy)
             self.stats_reporter.add_stat(
                 "Policy/Learning Rate", take_action_outputs["learning_rate"]
             )

--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -151,7 +151,7 @@ class AgentProcessor:
                 elif not curr_info.local_done[next_idx]:
                     self.episode_steps[agent_id] += 1
 
-        self.last_brain_info[agent_id] = curr_info
+            self.last_brain_info[agent_id] = curr_info
 
         if "action" in take_action_outputs:
             self.policy.save_previous_action(

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -6,7 +6,6 @@ from mlagents.trainers.action_info import ActionInfo
 
 
 class EnvironmentStep(NamedTuple):
-    previous_all_brain_info: AllBrainInfo
     current_all_brain_info: AllBrainInfo
     brain_name_to_action_info: Dict[str, ActionInfo]
 

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -11,7 +11,7 @@ class EnvironmentStep(NamedTuple):
 
     @property
     def name_behavior_ids(self) -> Iterable[str]:
-        return self.brain_name_to_action_info.keys()
+        return self.current_all_brain_info.keys()
 
 
 class EnvManager(ABC):

--- a/ml-agents/mlagents/trainers/simple_env_manager.py
+++ b/ml-agents/mlagents/trainers/simple_env_manager.py
@@ -22,7 +22,7 @@ class SimpleEnvManager(EnvManager):
         super().__init__()
         self.shared_float_properties = float_prop_channel
         self.env = env
-        self.previous_step: EnvironmentStep = EnvironmentStep({}, {}, {})
+        self.previous_step: EnvironmentStep = EnvironmentStep({}, {})
         self.previous_all_action_info: Dict[str, ActionInfo] = {}
 
     def step(self) -> List[EnvironmentStep]:
@@ -35,11 +35,7 @@ class SimpleEnvManager(EnvManager):
         all_brain_info = self._generate_all_brain_info()
         step_brain_info = all_brain_info
 
-        step_info = EnvironmentStep(
-            self.previous_step.current_all_brain_info,
-            step_brain_info,
-            self.previous_all_action_info,
-        )
+        step_info = EnvironmentStep(step_brain_info, self.previous_all_action_info)
         self.previous_step = step_info
         return [step_info]
 
@@ -51,7 +47,7 @@ class SimpleEnvManager(EnvManager):
                 self.shared_float_properties.set_property(k, v)
         self.env.reset()
         all_brain_info = self._generate_all_brain_info()
-        self.previous_step = EnvironmentStep({}, all_brain_info, {})
+        self.previous_step = EnvironmentStep(all_brain_info, {})
         return [self.previous_step]
 
     @property

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -53,7 +53,7 @@ class UnityEnvWorker:
         self.process = process
         self.worker_id = worker_id
         self.conn = conn
-        self.previous_step: EnvironmentStep = EnvironmentStep({}, {}, {})
+        self.previous_step: EnvironmentStep = EnvironmentStep({}, {})
         self.previous_all_action_info: Dict[str, ActionInfo] = {}
         self.waiting = False
 
@@ -253,7 +253,7 @@ class SubprocessEnvManager(EnvManager):
             ew.send("reset", config)
         # Next (synchronously) collect the reset observations from each worker in sequence
         for ew in self.env_workers:
-            ew.previous_step = EnvironmentStep({}, ew.recv().payload, {})
+            ew.previous_step = EnvironmentStep(ew.recv().payload, {})
         return list(map(lambda ew: ew.previous_step, self.env_workers))
 
     @property
@@ -282,9 +282,7 @@ class SubprocessEnvManager(EnvManager):
             payload: StepResponse = step.payload
             env_worker = self.env_workers[step.worker_id]
             new_step = EnvironmentStep(
-                env_worker.previous_step.current_all_brain_info,
-                payload.all_brain_info,
-                env_worker.previous_all_action_info,
+                payload.all_brain_info, env_worker.previous_all_action_info
             )
             step_infos.append(new_step)
             env_worker.previous_step = new_step

--- a/ml-agents/mlagents/trainers/tests/test_agent_processor.py
+++ b/ml-agents/mlagents/trainers/tests/test_agent_processor.py
@@ -65,7 +65,7 @@ def test_agentprocessor(num_vis_obs):
     )
     processor.publish_trajectory_queue(tqueue)
     # This is like the initial state after the env reset
-    processor.add_experiences(mock_braininfo, {})
+    processor.add_experiences(mock_braininfo, ActionInfo([], [], {}, []))
     for _ in range(5):
         processor.add_experiences(mock_braininfo, fake_action_info)
 

--- a/ml-agents/mlagents/trainers/tests/test_agent_processor.py
+++ b/ml-agents/mlagents/trainers/tests/test_agent_processor.py
@@ -7,6 +7,7 @@ from mlagents.trainers.agent_processor import (
     AgentManager,
     AgentManagerQueue,
 )
+from mlagents.trainers.action_info import ActionInfo
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.stats import StatsReporter
 
@@ -42,6 +43,7 @@ def test_agentprocessor(num_vis_obs):
         max_trajectory_length=5,
         stats_reporter=StatsReporter("testcat"),
     )
+
     fake_action_outputs = {
         "action": [0.1, 0.1],
         "entropy": np.array([1.0], dtype=np.float32),
@@ -55,9 +57,17 @@ def test_agentprocessor(num_vis_obs):
         num_vector_acts=2,
         num_vis_observations=num_vis_obs,
     )
+    fake_action_info = ActionInfo(
+        action=[0.1, 0.1],
+        value=[0.1, 0.1],
+        outputs=fake_action_outputs,
+        agents=mock_braininfo.agents,
+    )
     processor.publish_trajectory_queue(tqueue)
+    # This is like the initial state after the env reset
+    processor.add_experiences(mock_braininfo, {})
     for _ in range(5):
-        processor.add_experiences(mock_braininfo, mock_braininfo, fake_action_outputs)
+        processor.add_experiences(mock_braininfo, fake_action_info)
 
     # Assert that two trajectories have been added to the Trainer
     assert len(tqueue.put.call_args_list) == 2

--- a/ml-agents/mlagents/trainers/tests/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/test_policy.py
@@ -20,7 +20,7 @@ def test_take_action_returns_empty_with_no_agents():
     policy = TFPolicy(test_seed, basic_mock_brain(), basic_params())
     no_agent_brain_info = BrainInfo([], [], [], agents=[])
     result = policy.get_action(no_agent_brain_info)
-    assert result == ActionInfo([], [], {})
+    assert result == ActionInfo([], [], {}, [])
 
 
 def test_take_action_returns_nones_on_missing_values():
@@ -32,7 +32,7 @@ def test_take_action_returns_nones_on_missing_values():
         [], [], [], agents=["an-agent-id"], local_done=[False]
     )
     result = policy.get_action(brain_info_with_agents)
-    assert result == ActionInfo(None, None, {})
+    assert result == ActionInfo(None, None, {}, ["an-agent-id"])
 
 
 def test_take_action_returns_action_info_when_available():
@@ -49,6 +49,9 @@ def test_take_action_returns_action_info_when_available():
     )
     result = policy.get_action(brain_info_with_agents)
     expected = ActionInfo(
-        policy_eval_out["action"], policy_eval_out["value"], policy_eval_out
+        policy_eval_out["action"],
+        policy_eval_out["value"],
+        policy_eval_out,
+        ["an-agent-id"],
     )
     assert result == expected

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -102,10 +102,6 @@ class SubprocessEnvManagerTest(unittest.TestCase):
                 self.assertEqual(
                     manager.env_workers[i].previous_step.current_all_brain_info, i
                 )
-                self.assertEqual(
-                    manager.env_workers[i].previous_step.previous_all_brain_info,
-                    last_steps[i].current_all_brain_info,
-                )
         assert res == [
             manager.env_workers[0].previous_step,
             manager.env_workers[1].previous_step,

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -142,8 +142,8 @@ def test_take_step_adds_experiences_to_trainer_and_trains(
     action_info_dict = {brain_name: MagicMock()}
 
     brain_info_dict = {brain_name: Mock()}
-    old_step_info = EnvironmentStep(brain_info_dict, brain_info_dict, action_info_dict)
-    new_step_info = EnvironmentStep(brain_info_dict, brain_info_dict, action_info_dict)
+    old_step_info = EnvironmentStep(brain_info_dict, action_info_dict)
+    new_step_info = EnvironmentStep(brain_info_dict, action_info_dict)
     trainer_mock._is_ready_update = MagicMock(return_value=True)
 
     env_mock = MagicMock()
@@ -159,9 +159,8 @@ def test_take_step_adds_experiences_to_trainer_and_trains(
 
     manager_mock = tc.managers[brain_name]
     manager_mock.add_experiences.assert_called_once_with(
-        new_step_info.previous_all_brain_info[brain_name],
         new_step_info.current_all_brain_info[brain_name],
-        new_step_info.brain_name_to_action_info[brain_name].outputs,
+        new_step_info.brain_name_to_action_info[brain_name],
     )
 
     trainer_mock.advance.assert_called_once()
@@ -175,8 +174,8 @@ def test_take_step_if_not_training(trainer_controller_with_take_step_mocks):
     action_info_dict = {brain_name: MagicMock()}
 
     brain_info_dict = {brain_name: Mock()}
-    old_step_info = EnvironmentStep(brain_info_dict, brain_info_dict, action_info_dict)
-    new_step_info = EnvironmentStep(brain_info_dict, brain_info_dict, action_info_dict)
+    old_step_info = EnvironmentStep(brain_info_dict, action_info_dict)
+    new_step_info = EnvironmentStep(brain_info_dict, action_info_dict)
 
     trainer_mock._is_ready_update = MagicMock(return_value=False)
 
@@ -191,8 +190,7 @@ def test_take_step_if_not_training(trainer_controller_with_take_step_mocks):
     env_mock.step.assert_called_once()
     manager_mock = tc.managers[brain_name]
     manager_mock.add_experiences.assert_called_once_with(
-        new_step_info.previous_all_brain_info[brain_name],
         new_step_info.current_all_brain_info[brain_name],
-        new_step_info.brain_name_to_action_info[brain_name].outputs,
+        new_step_info.brain_name_to_action_info[brain_name],
     )
     trainer_mock.advance.assert_called_once()

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -129,7 +129,7 @@ class TFPolicy(Policy):
         to be passed to add experiences
         """
         if len(brain_info.agents) == 0:
-            return ActionInfo([], [], {})
+            return ActionInfo([], [], {}, [])
 
         agents_done = [
             agent
@@ -143,7 +143,10 @@ class TFPolicy(Policy):
         run_out = self.evaluate(brain_info)  # pylint: disable=assignment-from-no-return
         self.save_memories(brain_info.agents, run_out.get("memory_out"))
         return ActionInfo(
-            action=run_out.get("action"), value=run_out.get("value"), outputs=run_out
+            action=run_out.get("action"),
+            value=run_out.get("value"),
+            outputs=run_out,
+            agents=brain_info.agents,
         )
 
     def update(self, mini_batch, num_sequences):

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -290,9 +290,8 @@ class TrainerController(object):
                     )
                     continue
                 self.managers[name_behavior_id].add_experiences(
-                    step_info.previous_all_brain_info[name_behavior_id],
                     step_info.current_all_brain_info[name_behavior_id],
-                    step_info.brain_name_to_action_info[name_behavior_id].outputs,
+                    step_info.brain_name_to_action_info[name_behavior_id],
                 )
         return len(new_step_infos)
 

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -22,6 +22,7 @@ from mlagents_envs.timers import hierarchical_timer, get_timer_tree, timed
 from mlagents.trainers.trainer import Trainer
 from mlagents.trainers.meta_curriculum import MetaCurriculum
 from mlagents.trainers.trainer_util import TrainerFactory
+from mlagents.trainers.action_info import ActionInfo
 from mlagents.trainers.agent_processor import AgentManager, AgentManagerQueue
 
 
@@ -195,18 +196,28 @@ class TrainerController(object):
         trainer.subscribe_trajectory_queue(agent_manager.trajectory_queue)
         self.managers[name_behavior_id] = agent_manager
 
+    def _create_trainers_and_managers(
+        self, env_manager: EnvManager, behavior_ids: Set[str]
+    ) -> None:
+        for behavior_id in behavior_ids:
+            self._create_trainer_and_manager(env_manager, behavior_id)
+
     def start_learning(self, env_manager: EnvManager) -> None:
         self._create_model_path(self.model_path)
         tf.reset_default_graph()
         global_step = 0
         last_brain_behavior_ids: Set[str] = set()
         try:
-            self._reset_env(env_manager)
+            initial_step = self._reset_env(env_manager)
+            # Create the initial set of trainers and managers
+            initial_brain_behaviors = set(env_manager.external_brains.keys())
+            self._create_trainers_and_managers(env_manager, initial_brain_behaviors)
+            last_brain_behavior_ids = initial_brain_behaviors
+            self._process_step_infos(initial_step)
             while self._not_done_training():
                 external_brain_behavior_ids = set(env_manager.external_brains.keys())
                 new_behavior_ids = external_brain_behavior_ids - last_brain_behavior_ids
-                for name_behavior_id in new_behavior_ids:
-                    self._create_trainer_and_manager(env_manager, name_behavior_id)
+                self._create_trainers_and_managers(env_manager, new_behavior_ids)
                 last_brain_behavior_ids = external_brain_behavior_ids
                 n_steps = self.advance(env_manager)
                 for _ in range(n_steps):
@@ -229,7 +240,8 @@ class TrainerController(object):
     def end_trainer_episodes(
         self, env: EnvManager, lessons_incremented: Dict[str, bool]
     ) -> None:
-        self._reset_env(env)
+        reset_step = self._reset_env(env)
+        self._process_step_infos(reset_step)
         # Reward buffers reset takes place only for curriculum learning
         # else no reset.
         for trainer in self.trainers.values():
@@ -280,7 +292,11 @@ class TrainerController(object):
             # Step the environment
             new_step_infos = env.step()
         # Add to AgentProcessor
-        for step_info in new_step_infos:
+        num_step_infos = self._process_step_infos(new_step_infos)
+        return num_step_infos
+
+    def _process_step_infos(self, step_infos: List[EnvironmentStep]) -> int:
+        for step_info in step_infos:
             for name_behavior_id in step_info.name_behavior_ids:
                 if name_behavior_id not in self.managers:
                     self.logger.warning(
@@ -291,9 +307,11 @@ class TrainerController(object):
                     continue
                 self.managers[name_behavior_id].add_experiences(
                     step_info.current_all_brain_info[name_behavior_id],
-                    step_info.brain_name_to_action_info[name_behavior_id],
+                    step_info.brain_name_to_action_info.get(
+                        name_behavior_id, ActionInfo([], [], {}, [])
+                    ),
                 )
-        return len(new_step_infos)
+        return len(step_infos)
 
     @timed
     def advance(self, env: EnvManager) -> int:


### PR DESCRIPTION
Small but potentially dangerous PR here. in `add_experiences`, It looks like the previous BrainInfo was only used to get the list of agents, and nothing else. 

This PR makes it so that the env_manager only sends one current BrainInfo and the previous actions (if any) to the AgentManager. The list of agents was added to the `ActionInfo` and used appropriately.

We also have to handle resets properly, as we aren't sending the BrainInfo here as the previous anymore. We now process the result of the reset right after reset. 

This makes our code more similar to that of baselines or other RL libraries. 