### PR TITLE
Get step from policy

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -258,6 +258,7 @@ class PPOTrainer(RLTrainer):
         if not isinstance(policy, PPOPolicy):
             raise RuntimeError("Non-PPOPolicy passed to PPOTrainer.add_policy()")
         self.policy = policy
+        self.step = policy.get_current_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -340,6 +340,7 @@ class SACTrainer(RLTrainer):
         if not isinstance(policy, SACPolicy):
             raise RuntimeError("Non-SACPolicy passed to SACTrainer.add_policy()")
         self.policy = policy
+        self.step = policy.get_current_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:
         """


### PR DESCRIPTION
Fix for #3201 

Get current trainer steps from the policy checkpoint when loaded. Note: ideally we'd move the function into a common file (e.g. RLTrainer) but this is a minimal fix for hotfix. 