### PR TITLE
use absolute path in error

### DIFF
--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -1,3 +1,4 @@
+import os
 import yaml
 from typing import Any, Dict, TextIO
 import logging
@@ -158,7 +159,8 @@ def load_config(config_path: str) -> Dict[str, Any]:
         with open(config_path) as data_file:
             return _load_config(data_file)
     except IOError:
-        raise TrainerConfigError(f"Config file could not be found at {config_path}.")
+        abs_path = os.path.abspath(config_path)
+        raise TrainerConfigError(f"Config file could not be found at {abs_path}.")
     except UnicodeDecodeError:
         raise TrainerConfigError(
             f"There was an error decoding Config file from {config_path}. "


### PR DESCRIPTION
I think conda might do something weird with the working directory; there have been a few issues with users passing bad paths to `mlagents-learn`. This replaces the relative path in the exception with the absolute path, so hopefully it's easier to see where it's trying (and failing) to load from.

before:
```
mlagents.trainers.exception.TrainerConfigError: Config file could not be found at bad.yaml.
```
after: 
```
mlagents.trainers.exception.TrainerConfigError: Config file could not be found at /Users/chris.elion/code/ml-agents/bad.yaml.
```