### PR TITLE
Use AddComponentMenu for MonoBehaviours

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Constants.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Constants.cs
@@ -1,0 +1,11 @@
+namespace MLAgents
+{
+    /// <summary>
+    /// Grouping for use in AddComponentMenu (instead of nesting the menus).
+    /// </summary>
+    public enum MenuGroup
+    {
+        Default=0,
+        Sensors=50
+    }
+}

--- a/UnitySDK/Assets/ML-Agents/Scripts/Constants.cs.meta
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Constants.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0622d88401ec464d9d2cf2fb03ce17b5
+timeCreated: 1579215785

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -10,6 +10,7 @@ namespace MLAgents
     /// Demonstration Recorder Component.
     /// </summary>
     [RequireComponent(typeof(Agent))]
+    [AddComponentMenu("ML Agents/Demonstration Recorder")]
     public class DemonstrationRecorder : MonoBehaviour
     {
         public bool record;

--- a/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/DemonstrationRecorder.cs
@@ -10,7 +10,7 @@ namespace MLAgents
     /// Demonstration Recorder Component.
     /// </summary>
     [RequireComponent(typeof(Agent))]
-    [AddComponentMenu("ML Agents/Demonstration Recorder")]
+    [AddComponentMenu("ML Agents/Demonstration Recorder", (int) MenuGroup.Default)]
     public class DemonstrationRecorder : MonoBehaviour
     {
         public bool record;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Monitor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Monitor.cs
@@ -8,6 +8,7 @@ namespace MLAgents
     /// Monitor is used to display information about the Agent within the Unity
     /// scene. Use the log function to add information to your monitor.
     /// </summary>
+    [AddComponentMenu("ML Agents/Monitor")]
     public class Monitor : MonoBehaviour
     {
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Monitor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Monitor.cs
@@ -8,7 +8,6 @@ namespace MLAgents
     /// Monitor is used to display information about the Agent within the Unity
     /// scene. Use the log function to add information to your monitor.
     /// </summary>
-    [AddComponentMenu("ML Agents/Monitor")]
     public class Monitor : MonoBehaviour
     {
         /// <summary>

--- a/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
@@ -9,6 +9,8 @@ namespace MLAgents
     /// <summary>
     /// The Factory to generate policies.
     /// </summary>
+    ///
+    [AddComponentMenu("ML Agents/Behavior Parameters")]
     public class BehaviorParameters : MonoBehaviour
     {
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Policy/BehaviorParameters.cs
@@ -10,7 +10,7 @@ namespace MLAgents
     /// The Factory to generate policies.
     /// </summary>
     ///
-    [AddComponentMenu("ML Agents/Behavior Parameters")]
+    [AddComponentMenu("ML Agents/Behavior Parameters", (int) MenuGroup.Default)]
     public class BehaviorParameters : MonoBehaviour
     {
 

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensorComponent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensorComponent.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
-    [AddComponentMenu("ML Agents/Sensors/Camera Sensor")]
+    [AddComponentMenu("ML Agents/Camera Sensor", (int) MenuGroup.Sensors)]
     public class CameraSensorComponent : SensorComponent
     {
         public new Camera camera;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensorComponent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/CameraSensorComponent.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
+    [AddComponentMenu("ML Agents/Sensors/Camera Sensor")]
     public class CameraSensorComponent : SensorComponent
     {
         public new Camera camera;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/ISensor.cs
@@ -75,5 +75,4 @@ namespace MLAgents.Sensor
             return count;
         }
     }
-
 }

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent2D.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent2D.cs
@@ -1,5 +1,8 @@
+using UnityEngine;
+
 namespace MLAgents.Sensor
 {
+    [AddComponentMenu("ML Agents/Sensors/Ray Perception Sensor 2D")]
     public class RayPerceptionSensorComponent2D : RayPerceptionSensorComponentBase
     {
         public override RayPerceptionSensor.CastType GetCastType()

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent2D.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent2D.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
-    [AddComponentMenu("ML Agents/Sensors/Ray Perception Sensor 2D")]
+    [AddComponentMenu("ML Agents/Ray Perception Sensor 2D", (int) MenuGroup.Sensors)]
     public class RayPerceptionSensorComponent2D : RayPerceptionSensorComponentBase
     {
         public override RayPerceptionSensor.CastType GetCastType()

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent3D.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent3D.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
-    [AddComponentMenu("ML Agents/Sensors/Ray Perception Sensor 3D")]
+    [AddComponentMenu("ML Agents/Ray Perception Sensor 3D", (int) MenuGroup.Sensors)]
     public class RayPerceptionSensorComponent3D : RayPerceptionSensorComponentBase
     {
         [Header("3D Properties", order = 100)]

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent3D.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RayPerceptionSensorComponent3D.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
+    [AddComponentMenu("ML Agents/Sensors/Ray Perception Sensor 3D")]
     public class RayPerceptionSensorComponent3D : RayPerceptionSensorComponentBase
     {
         [Header("3D Properties", order = 100)]

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensorComponent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensorComponent.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
-    [AddComponentMenu("ML Agents/Sensors/Render Texture Sensor")]
+    [AddComponentMenu("ML Agents/Render Texture Sensor", (int) MenuGroup.Sensors)]
     public class RenderTextureSensorComponent : SensorComponent
     {
         public RenderTexture renderTexture;

--- a/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensorComponent.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Sensor/RenderTextureSensorComponent.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace MLAgents.Sensor
 {
+    [AddComponentMenu("ML Agents/Sensors/Render Texture Sensor")]
     public class RenderTextureSensorComponent : SensorComponent
     {
         public RenderTexture renderTexture;


### PR DESCRIPTION
There have been a few issues about missing menu items. 
https://github.com/Unity-Technologies/ml-agents/issues/2870
https://github.com/Unity-Technologies/ml-agents/issues/3227

These were probably from following a now-outdated tutorial, but I think adding menu items for the MonoBehaviours that we have probably makes things a bit more discoverable:

Menu bar:
![Screen Shot 2020-01-15 at 1 18 11 PM](https://user-images.githubusercontent.com/6877802/72472651-d453b100-3799-11ea-9769-ea1897017840.png)

Add Component in the inspector
![Screen Shot 2020-01-15 at 1 21 11 PM](https://user-images.githubusercontent.com/6877802/72472712-f3524300-3799-11ea-8d83-bc598104e78b.png)

Unfortunately, `Agent` doesn't qualify for this because it's abstract.