### PR TITLE
Bugfix: Fix lost trajectories when they are produced faster than they are consumed

### DIFF
--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -192,12 +192,13 @@ class AgentManagerQueue(Generic[T]):
 
         pass
 
-    def __init__(self, behavior_id: str):
+    def __init__(self, behavior_id: str, maxlen: int = 1000):
         """
         Initializes an AgentManagerQueue. Note that we can give it a behavior_id so that it can be identified
         separately from an AgentManager.
         """
-        self.queue: Deque[T] = deque()
+        self.maxlen: int = maxlen
+        self.queue: Deque[T] = deque(maxlen=self.maxlen)
         self.behavior_id = behavior_id
 
     def empty(self) -> bool:

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -290,11 +290,12 @@ class Trainer(abc.ABC):
         """
         with hierarchical_timer("process_trajectory"):
             for traj_queue in self.trajectory_queues:
-                try:
-                    t = traj_queue.get_nowait()
-                    self._process_trajectory(t)
-                except AgentManagerQueue.Empty:
-                    pass
+                while True:
+                    try:
+                        t = traj_queue.get_nowait()
+                        self._process_trajectory(t)
+                    except AgentManagerQueue.Empty:
+                        break
         if self.should_still_train:
             if self._is_ready_update():
                 with hierarchical_timer("_update_policy"):

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -290,7 +290,10 @@ class Trainer(abc.ABC):
         """
         with hierarchical_timer("process_trajectory"):
             for traj_queue in self.trajectory_queues:
-                while True:
+                # We grab at most the maximum length of the queue.
+                # This ensures that even if the queue is being filled faster than it is
+                # being emptied, the trajectories in the queue are on-policy.
+                for _ in range(traj_queue.maxlen):
                     try:
                         t = traj_queue.get_nowait()
                         self._process_trajectory(t)


### PR DESCRIPTION
We were only consuming one trajectory at most during each `trainer.advance()` call. Some environments with a very short time horizon could produce many trajectories per step (e.g. GridWorld). This meant many trajectories were going unused (and, in fact, caused a memory leak). 

This change forces all trajectories to be consumed each time `trainer.advance()` is called. ~In a future multithreaded implementation, we will most likely need to cap the length of the AgentManagerQueues (and scale the # of environments respectively) to avoid this issue, but this fix is suitable for the single-threaded case.~ 