### PR TITLE
Fix extra summary being written when loading from checkpoint

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -259,7 +259,9 @@ class PPOTrainer(RLTrainer):
         if not isinstance(policy, PPOPolicy):
             raise RuntimeError("Non-PPOPolicy passed to PPOTrainer.add_policy()")
         self.policy = policy
+        # Needed to resume loads properly
         self.step = policy.get_current_step()
+        self.next_summary_step = self._get_next_summary_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -341,7 +341,9 @@ class SACTrainer(RLTrainer):
         if not isinstance(policy, SACPolicy):
             raise RuntimeError("Non-SACPolicy passed to SACTrainer.add_policy()")
         self.policy = policy
+        # Needed to resume loads properly
         self.step = policy.get_current_step()
+        self.next_summary_step = self._get_next_summary_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:
         """

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -445,6 +445,29 @@ def test_process_trajectory(dummy_config):
     assert trainer.stats_reporter.get_stats_summaries("Policy/Extrinsic Reward").num > 0
 
 
+def test_add_get_policy(dummy_config):
+    brain_params = make_brain_parameters(
+        discrete_action=False, visual_inputs=0, vec_obs_size=6
+    )
+    dummy_config["summary_path"] = "./summaries/test_trainer_summary"
+    dummy_config["model_path"] = "./models/test_trainer_models/TestModel"
+    trainer = PPOTrainer(brain_params, 0, dummy_config, True, False, 0, "0", False)
+    policy = mock.Mock(spec=PPOPolicy)
+    policy.get_current_step.return_value = 2000
+
+    trainer.add_policy(brain_params.brain_name, policy)
+    assert trainer.get_policy(brain_params.brain_name) == policy
+
+    # Make sure the summary steps were loaded properly
+    assert trainer.get_step == 2000
+    assert trainer.next_summary_step > 2000
+
+    # Test incorrect class of policy
+    policy = mock.Mock()
+    with pytest.raises(RuntimeError):
+        trainer.add_policy(brain_params, policy)
+
+
 def test_normalization(dummy_config):
     brain_params = BrainParameters(
         brain_name="test_brain",

--- a/ml-agents/mlagents/trainers/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer.py
@@ -63,7 +63,7 @@ class Trainer(abc.ABC):
         self.step: int = 0
         self.training_start_time = time.time()
         self.summary_freq = self.trainer_parameters["summary_freq"]
-        self.next_update_step = self.summary_freq
+        self.next_summary_step = self.summary_freq
 
     def _check_param_keys(self):
         for k in self.param_keys:
@@ -171,12 +171,16 @@ class Trainer(abc.ABC):
         :param n_steps: number of steps to increment the step count by
         """
         self.step += n_steps
-        self.next_update_step = self.step + (
-            self.summary_freq - self.step % self.summary_freq
-        )
+        self.next_summary_step = self._get_next_summary_step()
         p = self.get_policy(name_behavior_id)
         if p:
             p.increment_step(n_steps)
+
+    def _get_next_summary_step(self) -> int:
+        """
+        Get the next step count that should result in a summary write.
+        """
+        return self.step + (self.summary_freq - self.step % self.summary_freq)
 
     def save_model(self, name_behavior_id: str) -> None:
         """
@@ -238,8 +242,8 @@ class Trainer(abc.ABC):
         write the summary. This logic ensures summaries are written on the update step and not in between.
         :param step_after_process: the step count after processing the next trajectory.
         """
-        if step_after_process >= self.next_update_step and self.get_step != 0:
-            self._write_summary(self.next_update_step)
+        if step_after_process >= self.next_summary_step and self.get_step != 0:
+            self._write_summary(self.next_summary_step)
 
     @abc.abstractmethod
     def end_episode(self):


### PR DESCRIPTION
Note: This is the same bug fixed in hotfix-0.13.1, but it didn't merge properly with the Trainer changes. 

This PR fixes an issue where if a checkpoint its loaded, the next summary will be `summary_freq`, and not `current_step + summary_freq`. e.g. if you quit training at step 3000 and load it, and `summary_freq = 2000`, it will write once at 2000 and again at 5000 when it should skip the first write. 

Also renames `next_update_step` to `next_summary_step` for clarity. 