### PR TITLE
Revert back to barracuda 0.3.2-preview.

### DIFF
--- a/com.unity.ml-agents/Editor/Unity.ML-Agents.Editor.asmdef
+++ b/com.unity.ml-agents/Editor/Unity.ML-Agents.Editor.asmdef
@@ -1,8 +1,7 @@
 {
     "name": "Unity.ML-Agents.Editor",
     "references": [
-        "Unity.ML-Agents",
-        "Barracuda"
+        "Unity.ML-Agents"
     ],
     "includePlatforms": [
         "Editor"

--- a/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
+++ b/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
@@ -1,7 +1,6 @@
 {
     "name": "Unity.ML-Agents",
     "references": [
-        "Barracuda"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/com.unity.ml-agents/Tests/Editor/Unity.ML-Agents.Editor.Tests.asmdef
+++ b/com.unity.ml-agents/Tests/Editor/Unity.ML-Agents.Editor.Tests.asmdef
@@ -2,8 +2,7 @@
     "name": "Unity.ML-Agents.Editor.Tests",
     "references": [
         "Unity.ML-Agents.Editor",
-        "Unity.ML-Agents",
-        "Barracuda"
+        "Unity.ML-Agents"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"
@@ -17,7 +16,8 @@
     "precompiledReferences": [
         "System.IO.Abstractions.dll",
         "System.IO.Abstractions.TestingHelpers.dll",
-        "Google.Protobuf.dll"
+        "Google.Protobuf.dll",
+        "Barracuda.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/com.unity.ml-agents/Tests/Runtime/Unity.ML-Agents.Tests.asmdef
+++ b/com.unity.ml-agents/Tests/Runtime/Unity.ML-Agents.Tests.asmdef
@@ -1,8 +1,7 @@
 {
     "name": "Unity.ML-Agents.Tests",
     "references": [
-        "Unity.ML-Agents",
-        "Barracuda"
+        "Unity.ML-Agents"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/com.unity.ml-agents/csharp_timers.json.meta
+++ b/com.unity.ml-agents/csharp_timers.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d0b30a07226cb466d814e9351b8c231e
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,6 +5,6 @@
 	"unity": "2018.4",
 	"description": "Add interactivity to your game with ML-Agents trained using Deep Reinforcement Learning. \n\nFor best results, use this text to summarize: \n\u25AA What the package does \n\u25AA How it can benefit the user \n\nNote: Special formatting characters are supported, including line breaks ('\\n') and bullets ('\\u25AA').",
 	"dependencies": {
-		"com.unity.barracuda": "0.4.0-preview"
+		"com.unity.barracuda": "0.3.2-preview"
 	}
 }


### PR DESCRIPTION
The cloudbuild windows config was failing due to a cross-compilation issue.  This is not supported until burst package 1.3.0-preview which isn't released yet.  The version Barracuda is depending on also doesn't have the option to disable cross-compilation from the project settings.  The only option we were left with was to downgrade the barracuda version back to 0.3.2-preview to get our tests passing again. 