### PR TITLE
Fix barracuda assembly references.

### DIFF
--- a/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
+++ b/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
@@ -1,14 +1,17 @@
 {
     "name": "Unity.ML-Agents",
-    "references": [
-    ],
+    "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "System.IO.Abstractions.dll",
+        "Google.Protobuf.dll",
+        "Barracuda.dll",
+        "Grpc.Core.dll"
+    ],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }


### PR DESCRIPTION
Need to add the precompiled assembly ref to the runtime asmdef to fix standalone builds.