### PR TITLE
Fix Walker bug with dirToTarget

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -147,6 +147,7 @@ public class WalkerAgent : Agent
         // b. Rotation alignment with goal direction.
         // c. Encourage head height.
         // d. Discourage head movement.
+        m_DirToTarget = target.position - m_JdController.bodyPartsDict[hips].rb.position;
         AddReward(
             +0.03f * Vector3.Dot(m_DirToTarget.normalized, m_JdController.bodyPartsDict[hips].rb.velocity)
             + 0.01f * Vector3.Dot(m_DirToTarget.normalized, hips.forward)


### PR DESCRIPTION
`m_DirToTarget` for Walker wasn't being updated and it ended up with a Walker that learned how to stand upright but not walk. This PR updates it at every FixedUpdate. 