### PR TITLE
Fix Windows IL2CPP compilation with dlopen/dlsym stubs

### DIFF
--- a/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
+++ b/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
@@ -1,4 +1,5 @@
 // These stubs fix an issue compiling GRPC on Windows with IL2CPP.
+// For the moment, only Inference works. (training doesn't)
 
 void * dlopen(const char *filename, int flags) {
     return 0;

--- a/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
+++ b/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
@@ -1,3 +1,5 @@
+// These stubs fix an issue compiling GRPC on Windows with IL2CPP.
+
 void * dlopen(const char *filename, int flags) {
     return 0;
 }

--- a/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
+++ b/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c
@@ -1,0 +1,7 @@
+void * dlopen(const char *filename, int flags) {
+    return 0;
+}
+
+void * dlsym(void *handle, const char *symbol) {
+    return 0;
+}

--- a/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c.meta
+++ b/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c.meta
@@ -12,12 +12,14 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      : Any
+      '': Any
     second:
       enabled: 0
       settings:
         Exclude Editor: 1
+        Exclude Linux: 1
         Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
         Exclude OSXUniversal: 1
         Exclude Win: 0
         Exclude Win64: 0
@@ -35,7 +37,31 @@ PluginImporter:
         DefaultValueInitialized: true
         OS: AnyOS
   - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
       Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
     second:
       enabled: 0
       settings:
@@ -51,13 +77,13 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86
+        CPU: AnyCPU
   - first:
       Standalone: Win64
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c.meta
+++ b/com.unity.ml-agents/Plugins/IL2CPP.DL.Stubs.c.meta
@@ -1,0 +1,63 @@
+fileFormatVersion: 2
+guid: 3509a8908cf600c4f914a0705123a363
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 1
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request fixes and issue with IL2CPP and Windows, where GRPC needs the `dlopen` and `dlsym` functions. (see #2595)

Since we don't want to recompile GRPC from scratch or include it fully, the solution here is to make stubs for the missing functions. The .meta makes it so it's only compiled on Windows by IL2CPP.

This sounds like an ugly hack and may not be wanted. Thoughts?

_Help wanted:_ I don't really know how to properly name this file. Any suggestion?