### PR TITLE
BehaviorParameters - accessors for undecorated behavior name

### DIFF
--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -31,7 +31,6 @@ namespace MLAgentsExamples
         void GetAssetPathFromCommandLine()
         {
             m_BehaviorNameOverrides.Clear();
-            m_BehaviorNameOverrides["3DBall"] = "/Users/chris.elion/code/ml-agents/models/ppo/3DBall.nn"; // TODO REMOVE ME
 
             var args = Environment.GetCommandLineArgs();
             for (var i = 0; i < args.Length-2; i++)
@@ -98,12 +97,10 @@ namespace MLAgentsExamples
             agent.LazyInitialize();
             var bp = agent.GetComponent<BehaviorParameters>();
 
-            var behaviorNameAndTeamId = bp.behaviorName;
-            var behaviorName = behaviorNameAndTeamId.Split('?')[0];
-            var nnModel = GetModelForBehaviorName(behaviorName);
-            Debug.Log($"Overriding behavior {behaviorName} for agent with model {nnModel?.name}");
+            var nnModel = GetModelForBehaviorName(bp.behaviorName);
+            Debug.Log($"Overriding behavior {bp.behaviorName} for agent with model {nnModel?.name}");
             // This might give a null model; that's better because we'll fall back to the Heuristic
-            agent.GiveModel($"Override_{behaviorName}", nnModel, InferenceDevice.CPU);
+            agent.GiveModel($"Override_{bp.behaviorName}", nnModel, InferenceDevice.CPU);
 
         }
     }

--- a/com.unity.ml-agents/Runtime/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/DemonstrationRecorder.cs
@@ -48,7 +48,7 @@ namespace MLAgents
             m_DemoStore.Initialize(
                 demonstrationName,
                 behaviorParams.brainParameters,
-                behaviorParams.behaviorName);
+                behaviorParams.fullyQualifiedBehaviorName);
             Monitor.Log("Recording Demonstration of Agent: ", m_RecordingAgent.name);
         }
 

--- a/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
@@ -54,6 +54,14 @@ namespace MLAgents
 
         public string behaviorName
         {
+            get { return m_BehaviorName;}
+        }
+
+        /// <summary>
+        /// Returns the behavior name, concatenated with any other metadata (i.e. team id).
+        /// </summary>
+        public string fullyQualifiedBehaviorName
+        {
             get { return m_BehaviorName + "?team=" + m_TeamID;}
         }
 
@@ -68,7 +76,7 @@ namespace MLAgents
                 case BehaviorType.Default:
                     if (Academy.Instance.IsCommunicatorOn)
                     {
-                        return new RemotePolicy(m_BrainParameters, behaviorName);
+                        return new RemotePolicy(m_BrainParameters, fullyQualifiedBehaviorName);
                     }
                     if (m_Model != null)
                     {

--- a/com.unity.ml-agents/Runtime/Policy/RemotePolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policy/RemotePolicy.cs
@@ -11,7 +11,7 @@ namespace MLAgents
     /// </summary>
     public class RemotePolicy : IPolicy
     {
-        string m_BehaviorName;
+        string m_FullyQualifiedBehaviorName;
         protected ICommunicator m_Communicator;
 
         /// <summary>
@@ -22,17 +22,17 @@ namespace MLAgents
         /// <inheritdoc />
         public RemotePolicy(
             BrainParameters brainParameters,
-            string behaviorName)
+            string fullyQualifiedFullyQualifiedBehaviorName)
         {
-            m_BehaviorName = behaviorName;
+            m_FullyQualifiedBehaviorName = fullyQualifiedFullyQualifiedBehaviorName;
             m_Communicator = Academy.Instance.Communicator;
-            m_Communicator.SubscribeBrain(m_BehaviorName, brainParameters);
+            m_Communicator.SubscribeBrain(m_FullyQualifiedBehaviorName, brainParameters);
         }
 
         /// <inheritdoc />
         public void RequestDecision(AgentInfo info, List<ISensor> sensors, Action<AgentAction> action)
         {
-            m_Communicator?.PutObservations(m_BehaviorName, info, sensors, action);
+            m_Communicator?.PutObservations(m_FullyQualifiedBehaviorName, info, sensors, action);
         }
 
         /// <inheritdoc />

--- a/com.unity.ml-agents/Runtime/Policy/RemotePolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policy/RemotePolicy.cs
@@ -22,9 +22,9 @@ namespace MLAgents
         /// <inheritdoc />
         public RemotePolicy(
             BrainParameters brainParameters,
-            string fullyQualifiedFullyQualifiedBehaviorName)
+            string fullyQualifiedBehaviorName)
         {
-            m_FullyQualifiedBehaviorName = fullyQualifiedFullyQualifiedBehaviorName;
+            m_FullyQualifiedBehaviorName = fullyQualifiedBehaviorName;
             m_Communicator = Academy.Instance.Communicator;
             m_Communicator.SubscribeBrain(m_FullyQualifiedBehaviorName, brainParameters);
         }


### PR DESCRIPTION
Add separate accessors for behavior name (e.g. "3DBall") and the "fully qualified" name (e.g. "3DBall?teamId=0"). Rename RemotePolicy field accordingly.

I'm open to better naming ideas, but I think we definitely need accessors for both.