### PR TITLE
Track reward for inference

### DIFF
--- a/Project/.gitignore
+++ b/Project/.gitignore
@@ -7,6 +7,7 @@
 /Assets/AssetStoreTools*
 /Assets/Plugins*
 /Assets/Demonstrations*
+/Assets/ML-Agents/Timers*
 /csharp_timers.json
 
 # Environemnt logfile

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -245,6 +245,9 @@ namespace MLAgents
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately
             m_Brain?.RequestDecision(m_Info, sensors, (a) => {});
+
+            UpdateRewardStats();
+
             // The Agent is done, so we give it a new episode Id
             m_EpisodeId = EpisodeIdCounter.GetEpisodeId();
             m_Reward = 0f;
@@ -326,6 +329,12 @@ namespace MLAgents
         public float GetCumulativeReward()
         {
             return m_CumulativeReward;
+        }
+
+        void UpdateRewardStats()
+        {
+            var gaugeName = $"{m_PolicyFactory.behaviorName}.CumulativeReward";
+            TimerStack.Instance.SetGauge(gaugeName, GetCumulativeReward());
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using UnityEngine.Profiling;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
+using UnityEngine.SceneManagement;
 
 namespace MLAgents
 {
@@ -383,14 +384,26 @@ namespace MLAgents
         /// <param name="filename"></param>
         public void SaveJsonTimers(string filename = null)
         {
-            if (filename == null)
+            try
             {
-                var fullpath = Path.GetFullPath(".");
-                filename = $"{fullpath}/csharp_timers.json";
+                if (filename == null)
+                {
+                    var activeScene = SceneManager.GetActiveScene();
+                    var timerDir = Path.Combine(Application.dataPath, "ML-Agents", "Timers");
+                    Directory.CreateDirectory(timerDir);
+
+                    filename = Path.Combine(timerDir, $"{activeScene.name}_timers.json");
+                }
+
+                var fs = new FileStream(filename, FileMode.Create, FileAccess.Write);
+                SaveJsonTimers(fs);
+                fs.Close();
             }
-            var fs = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            SaveJsonTimers(fs);
-            fs.Close();
+            catch (IOException)
+            {
+                // It's possible we don't have write access to the directory.
+                Debug.LogWarning($"Unable to save timers to file {filename}");
+            }
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -224,17 +224,22 @@ namespace MLAgents
     [DataContract]
     public class GaugeNode
     {
+        static float s_SmoothingFactor = .25f; // weight for exponential moving average.
+
         [DataMember]
         public float value;
         [DataMember(Name = "min")]
         public float minValue;
         [DataMember(Name = "max")]
         public float maxValue;
+        [DataMember(Name = "weightedAverage")]
+        public float weightedAverage;
         [DataMember]
         public uint count;
         public GaugeNode(float value)
         {
             this.value = value;
+            weightedAverage = value;
             minValue = value;
             maxValue = value;
             count = 1;
@@ -244,6 +249,8 @@ namespace MLAgents
         {
             minValue = Mathf.Min(minValue, newValue);
             maxValue = Mathf.Max(maxValue, newValue);
+            // update exponential moving average
+            weightedAverage = (s_SmoothingFactor * newValue) + ((1f - s_SmoothingFactor) * weightedAverage);
             value = newValue;
             ++count;
         }

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -225,7 +225,7 @@ namespace MLAgents
     [DataContract]
     public class GaugeNode
     {
-        static float s_SmoothingFactor = .25f; // weight for exponential moving average.
+        const float k_SmoothingFactor = .25f; // weight for exponential moving average.
 
         [DataMember]
         public float value;
@@ -251,7 +251,7 @@ namespace MLAgents
             minValue = Mathf.Min(minValue, newValue);
             maxValue = Mathf.Max(maxValue, newValue);
             // update exponential moving average
-            weightedAverage = (s_SmoothingFactor * newValue) + ((1f - s_SmoothingFactor) * weightedAverage);
+            weightedAverage = (k_SmoothingFactor * newValue) + ((1f - k_SmoothingFactor) * weightedAverage);
             value = newValue;
             ++count;
         }
@@ -384,6 +384,7 @@ namespace MLAgents
         /// <param name="filename"></param>
         public void SaveJsonTimers(string filename = null)
         {
+# if UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_LINUX
             try
             {
                 if (filename == null)
@@ -404,6 +405,7 @@ namespace MLAgents
                 // It's possible we don't have write access to the directory.
                 Debug.LogWarning($"Unable to save timers to file {filename}");
             }
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
* Change the default timer path to use Application.dataPath, and use the active scene name
* Track the [exponential moving average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average) of gauges in the timer system.
* Update the gauge with the cumulative reward when the Agent is done.

This will let us track inference rewards and make sure they're close to training rewards in CI. Here's how the gauge section of the timers looks now:
```
    "gauges": {
        "3DBall.CumulativeReward": {
            "count": 12,
            "max": 99.99905,
            "min": 99.99905,
            "value": 99.99905,
            "weightedAverage": 99.99905
        }
    },
```