### PR TITLE
Tennis: Avoid scores and Unity logo overlap

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
+++ b/Project/Assets/ML-Agents/Examples/Tennis/Scenes/Tennis.unity
@@ -1271,9 +1271,9 @@ RectTransform:
   m_Father: {fileID: 1184319693}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -20, y: -50}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -20, y: 50}
   m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1871669623
@@ -1545,9 +1545,9 @@ RectTransform:
   m_Father: {fileID: 1184319693}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -50}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 100, y: 50}
   m_SizeDelta: {x: 100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2073469452


### PR DESCRIPTION
In the Tennis env, the Unity branding overlaps agentB score. I've moved the scores so they're properly readable again.

Before:
![image](https://user-images.githubusercontent.com/6735195/73436027-093f3680-434a-11ea-8cb7-455cca23734a.png)

After:
![image](https://user-images.githubusercontent.com/6735195/73436041-0fcdae00-434a-11ea-8768-419472f25e6e.png)
