### PR TITLE
Make RayPerception sensor work better with transforms that have scale

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensor.cs
@@ -40,6 +40,7 @@ namespace MLAgents.Sensor
                 public Vector3 worldEnd;
                 public bool castHit;
                 public float hitFraction;
+                public float castRadius;
             }
 
             public void Reset()
@@ -231,7 +232,7 @@ namespace MLAgents.Sensor
                             scaledRayLength, layerMask);
                     }
 
-                    // If scaledRayLength is 0, we still could have a hit with spherecasts.
+                    // If scaledRayLength is 0, we still could have a hit with sphere casts (maybe?).
                     // To avoid 0/0, set the fraction to 0.
                     hitFraction = castHit ? (scaledRayLength > 0 ? rayHit.distance / scaledRayLength : 0.0f) : 1.0f;
                     hitObject = castHit ? rayHit.collider.gameObject : null;
@@ -262,6 +263,7 @@ namespace MLAgents.Sensor
                     debugInfo.rayInfos[rayIndex].worldEnd = endPositionWorld;
                     debugInfo.rayInfos[rayIndex].castHit = castHit;
                     debugInfo.rayInfos[rayIndex].hitFraction = hitFraction;
+                    debugInfo.rayInfos[rayIndex].castRadius = scaledCastRadius;
                 }
                 else if (Application.isEditor)
                 {

--- a/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensorComponentBase.cs
@@ -130,14 +130,14 @@ namespace MLAgents.Sensor
                 // hit fraction ^2 will shift "far" hits closer to the hit color
                 var lerpT = rayInfo.hitFraction * rayInfo.hitFraction;
                 var color = Color.Lerp(rayHitColor, rayMissColor, lerpT);
-                color.a = alpha;
+                color.a *= alpha;
                 Gizmos.color = color;
                 Gizmos.DrawRay(startPositionWorld, rayDirection);
 
                 // Draw the hit point as a sphere. If using rays to cast (0 radius), use a small sphere.
                 if (rayInfo.castHit)
                 {
-                    var hitRadius = Mathf.Max(sphereCastRadius, .05f);
+                    var hitRadius = Mathf.Max(rayInfo.castRadius, .05f);
                     Gizmos.DrawWireSphere(startPositionWorld + rayDirection, hitRadius);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/Unity-Technologies/ml-agents/issues/3321

Thanks @WanNJ for reporting.

This makes the Agent's transform scale behave more sensibly for raycasts; the ray length and sphere sizes are also scaled. It handles non-uniform scale reasonably, by using the length of the transforms ray to adjust these.

Also adds a few checks for division by zero.

Note that existing trained models for agents that have scale will need to be retrained, since the hit fractions will differ at runtime.

![image](https://user-images.githubusercontent.com/6877802/73585042-ff085f80-4451-11ea-8141-eed9a79885b6.png)
