### PR TITLE
barracuda 0.5.0 compatibility

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Editor/BehaviorParametersEditor.cs
+++ b/UnitySDK/Assets/ML-Agents/Editor/BehaviorParametersEditor.cs
@@ -72,7 +72,7 @@ namespace MLAgents
             var brainParameters = behaviorParameters.brainParameters;
             if (model != null)
             {
-                barracudaModel = ModelLoader.Load(model.Value);
+                barracudaModel = ModelLoader.Load(model);
             }
             if (brainParameters != null)
             {

--- a/UnitySDK/Assets/ML-Agents/Examples/3DBall/TFModels/3DBall.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/3DBall/TFModels/3DBall.nn.meta
@@ -3,6 +3,7 @@ guid: 20a7b83be6b0c493d9271c65c897eb9b
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/3DBall/TFModels/3DBallHard.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/3DBall/TFModels/3DBallHard.nn.meta
@@ -3,6 +3,7 @@ guid: 27d49984757ed46b181090a532ef48e5
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Basic/TFModels/Basic.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Basic/TFModels/Basic.nn.meta
@@ -3,6 +3,7 @@ guid: 468c183196f1844f69e125c99dd135a1
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Bouncer/TFModels/Bouncer.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Bouncer/TFModels/Bouncer.nn.meta
@@ -3,6 +3,7 @@ guid: 6c4ee6ab37d9b49b492a5cc49ed47ca0
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Crawler/TFModels/CrawlerDynamic.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Crawler/TFModels/CrawlerDynamic.nn.meta
@@ -3,6 +3,7 @@ guid: 039557e683d584183a2a82cf8b1904c0
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Crawler/TFModels/CrawlerStatic.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Crawler/TFModels/CrawlerStatic.nn.meta
@@ -3,6 +3,7 @@ guid: ac4a23ff4713140198629ae0844926ee
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/TFModels/FoodCollector.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/FoodCollector/TFModels/FoodCollector.nn.meta
@@ -3,6 +3,7 @@ guid: 36ab3e93020504f48858d0856f939685
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/GridWorld/TFModels/GridWorld.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/GridWorld/TFModels/GridWorld.nn.meta
@@ -3,6 +3,7 @@ guid: a812f1ce7763a4a0c912717f3594fe20
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Hallway/TFModels/Hallway.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Hallway/TFModels/Hallway.nn.meta
@@ -3,6 +3,7 @@ guid: 317f4f8da7e4846b3aae0969781824a2
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/PushBlock/TFModels/PushBlock.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/PushBlock/TFModels/PushBlock.nn.meta
@@ -3,6 +3,7 @@ guid: 70db47ab276e44fe0beb677ff8d69382
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Pyramids/TFModels/Pyramids.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Pyramids/TFModels/Pyramids.nn.meta
@@ -3,6 +3,7 @@ guid: aa3fa19a09ec44a41be3da037783ad41
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Reacher/TFModels/Reacher.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Reacher/TFModels/Reacher.nn.meta
@@ -3,6 +3,7 @@ guid: d7bdb6a78154f4cf99437d67e4a569a8
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Tennis/TFModels/Tennis.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Tennis/TFModels/Tennis.nn.meta
@@ -3,6 +3,7 @@ guid: d6c5e749e4ceb4cf79640a5955706d3d
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/Walker/TFModels/Walker.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/Walker/TFModels/Walker.nn.meta
@@ -3,6 +3,7 @@ guid: 4e86a19e012da43bfa5ab97ae8089b98
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/WallJump/TFModels/BigWallJump.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/WallJump/TFModels/BigWallJump.nn.meta
@@ -3,6 +3,7 @@ guid: 0468bf44b1efd4992b6bf22cadb50d89
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Examples/WallJump/TFModels/SmallWallJump.nn.meta
+++ b/UnitySDK/Assets/ML-Agents/Examples/WallJump/TFModels/SmallWallJump.nn.meta
@@ -3,6 +3,7 @@ guid: fb2ce36eb40b6480e94ea0b5d7573e47
 ScriptedImporter:
   fileIDToRecycleName:
     11400000: main obj
+    11400002: model data
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/ModelRunner.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/InferenceBrain/ModelRunner.cs
@@ -53,11 +53,11 @@ namespace MLAgents.InferenceBrain
 
                 D.logEnabled = m_Verbose;
 
-                barracudaModel = ModelLoader.Load(model.Value);
+                barracudaModel = ModelLoader.Load(model);
                 var executionDevice = inferenceDevice == InferenceDevice.GPU
-                    ? BarracudaWorkerFactory.Type.ComputePrecompiled
-                    : BarracudaWorkerFactory.Type.CSharp;
-                m_Engine = BarracudaWorkerFactory.CreateWorker(executionDevice, barracudaModel, m_Verbose);
+                    ? WorkerFactory.Type.ComputePrecompiled
+                    : WorkerFactory.Type.CSharp;
+                m_Engine = WorkerFactory.CreateWorker(executionDevice, barracudaModel, m_Verbose);
             }
             else
             {
@@ -96,7 +96,7 @@ namespace MLAgents.InferenceBrain
             var outputs = new List<TensorProxy>();
             foreach (var n in names)
             {
-                var output = m_Engine.Peek(n);
+                var output = m_Engine.PeekOutput(n);
                 outputs.Add(TensorUtils.TensorProxyFromBarracuda(output, n));
             }
 

--- a/UnitySDK/Packages/manifest.json
+++ b/UnitySDK/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.2.2",
+    "com.unity.barracuda": "0.5.0-preview",
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.8",
     "com.unity.purchasing": "2.0.3",
@@ -35,7 +36,6 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-    "com.unity.barracuda": "0.3.2-preview"
+    "com.unity.modules.xr": "1.0.0"
   }
 }

--- a/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
+++ b/ml-agents/mlagents/trainers/tensorflow_to_barracuda.py
@@ -592,9 +592,12 @@ def get_attr(node, attr_name, default=None):
     val = node.attr[attr_name]
 
     if val.HasField("list"):
-        return val.list.i
         # NOTE: can't find way to identify type of list BUT it is almost always list(int)
         # except list(float) in FractionalAvg/MaxPool
+        if len(val.list.shape) > 0:
+            return val.list.shape
+        else:
+            return val.list.i
     if val.HasField("b"):
         return val.b
     if val.HasField("i"):
@@ -618,6 +621,10 @@ def get_epsilon(layer):
 
 def get_layer_rank(layer):
     shape = get_attr(layer, "shape")
+    if not shape:
+        outputShapes = get_attr(layer, "_output_shapes")
+        if outputShapes:
+            shape = outputShapes[0]
     if not shape:
         return None
     if isinstance(shape, list):
@@ -753,7 +760,7 @@ def axis_to_barracuda(axis, input_rank):
     W = 2
     C = 3
     if axis < 0:
-        axis = input_rank - axis
+        axis = input_rank + axis
     assert axis >= 0
     assert axis < input_rank
     if input_rank == 4:


### PR DESCRIPTION
This applies the compile fixes necessary for barracuda 0.5.0 to the 0.13.1 release.

Not planning on merging this; may tag it as a "release" later.