### PR TITLE
Reduce max steps for Bouncer, summary for Hallway

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -34,7 +34,7 @@ FoodCollector:
 
 Bouncer:
     normalize: true
-    max_steps: 2.0e7
+    max_steps: 2.0e6
     num_layers: 2
     hidden_units: 64
     summary_freq: 20000
@@ -217,7 +217,7 @@ Hallway:
     memory_size: 256
     init_entcoef: 0.1
     max_steps: 1.0e7
-    summary_freq: 1000
+    summary_freq: 10000
     time_horizon: 64
     use_recurrent: true
 

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -32,7 +32,7 @@ FoodCollector:
 
 Bouncer:
     normalize: true
-    max_steps: 2.0e7
+    max_steps: 7.0e6
     num_layers: 2
     hidden_units: 64
 


### PR DESCRIPTION
Bouncer was running for too many timesteps - this PR cuts the max steps by a factor of 3 for PPO, and a factor of 10 for SAC. 

Hallway SAC was also writing summaries too frequently. 