### PR TITLE
fix MissingReferenceException in GridWorld

### DIFF
--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -113,7 +113,7 @@ public class GridAgent : Agent
                 SetReward(1f);
                 Done();
             }
-            if (hit.Where(col => col.gameObject.CompareTag("pit")).ToArray().Length == 1)
+            else if (hit.Where(col => col.gameObject.CompareTag("pit")).ToArray().Length == 1)
             {
                 SetReward(-1f);
                 Done();


### PR DESCRIPTION
Currently getting 
```
MissingReferenceException: The object of type 'BoxCollider' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
GridAgent+<>c.<AgentAction>b__13_2 (UnityEngine.Collider col) (at Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs:116)
System.Linq.Enumerable+WhereArrayIterator`1[TSource].ToArray () (at <fbb5ed17eb6e46c680000f8910ebb50c>:0)
System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) (at <fbb5ed17eb6e46c680000f8910ebb50c>:0)
GridAgent.AgentAction (System.Single[] vectorAction) (at Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs:116)
MLAgents.Agent.AgentStep () (at /Users/chris.elion/code/ml-agents/com.unity.ml-agents/Runtime/Agent.cs:772)
MLAgents.Academy.EnvironmentStep () (at /Users/chris.elion/code/ml-agents/com.unity.ml-agents/Runtime/Academy.cs:402)
MLAgents.AcademyFixedUpdateStepper.FixedUpdate () (at /Users/chris.elion/code/ml-agents/com.unity.ml-agents/Runtime/Academy.cs:32)
```
because Done() triggers AgentReset(), which resets the physics.