### PR TITLE
Fix logging on newer versions of Tensorflow

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -458,6 +458,8 @@ def run_cli(options: RunOptions) -> None:
         trainer_logger.setLevel("DEBUG")
         env_logger.setLevel("DEBUG")
     else:
+        trainer_logger.setLevel("INFO")
+        env_logger.setLevel("INFO")
         # disable noisy warnings from tensorflow.
         tf_utils.set_warnings_enabled(False)
 


### PR DESCRIPTION
It seems with newer versions of TF (e.g. 1.15, 2.01) the logging level is being set to 20 (WARNING). This means that none of the hyperparameters and summaries are being printed during training. 

This PR sets it back to INFO as is the default before. 