### PR TITLE
Split out 0.14 in the migration guide

### DIFF
--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -7,8 +7,11 @@ The versions can be found in
 
 # Migrating
 
+## Migrating from 0.14 to latest
+### Important changes
+### Steps to Migrate
 
-## Migrating from 0.13 to latest
+## Migrating from 0.13 to 0.14
 
 ### Important changes
 * The `UnitySDK` folder has been split into a Unity Package (`com.unity.ml-agents`) and an examples project (`Project`).  Please follow the [Installation Guide](Installation.md) to get up and running with this new repo structure.


### PR DESCRIPTION
We should add this to the release checklist.
Will cherrypick this to the release branch.