### PR TITLE
Reduce walljump max_steps

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -48,7 +48,7 @@ PushBlock:
     num_layers: 2
 
 SmallWallJump:
-    max_steps: 3e7
+    max_steps: 5e6
     hidden_units: 256
     summary_freq: 20000
     time_horizon: 128
@@ -57,7 +57,7 @@ SmallWallJump:
     normalize: false
 
 BigWallJump:
-    max_steps: 3e7
+    max_steps: 2e7
     hidden_units: 256
     summary_freq: 20000
     time_horizon: 128

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -47,7 +47,7 @@ PushBlock:
     num_layers: 2
 
 SmallWallJump:
-    max_steps: 3e7
+    max_steps: 5e6
     batch_size: 128
     buffer_size: 2048
     beta: 5.0e-3
@@ -58,7 +58,7 @@ SmallWallJump:
     normalize: false
 
 BigWallJump:
-    max_steps: 3e7
+    max_steps: 2e7
     batch_size: 128
     buffer_size: 2048
     beta: 5.0e-3


### PR DESCRIPTION
Walljump was running too long, as the max steps assumed the agent would always be in play (in Walljump, the brains swap in/out). 