### PR TITLE
Clarify curriculum and behavior name

### DIFF
--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -532,6 +532,9 @@ called independently of the `Max Step` property.
 
 * `Behavior Parameters` - The parameters dictating what Policy the Agent will
 receive.
+  * `Behavior Name` - The identifier for the behavior. Agents with the same behavior name
+  will learn the same policy. If you're using [curriculum learning](Training-Curriculum-Learning.md),
+   this is used as the top-level key in the config.
   * `Vector Observation`
     * `Space Size` - Length of vector observation for the Agent.
     * `Stacked Vectors` - The number of previous vector observations that will

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -551,8 +551,13 @@ receive.
   * `Model` - The neural network model used for inference (obtained after
   training)
   * `Inference Device` - Whether to use CPU or GPU to run the model during inference
-  * `Use Heuristic` - If checked, the Agent will use its 'Heuristic()' method for
-  decisions.
+  * `Behavior Type` - Determines whether the Agent will do training, inference, or use its
+  Heuristic() method:
+    * `Default` - the Agent will train if they connect to a python trainer, otherwise they will performance inference.
+    * `Heuristic Only` - the Agent will always use the `Heuristic()` method.
+    * `Inference Only` - the Agent will always perform inference.
+  * `Team ID` - Used to define the team for [self-play](Training-Self-Play.md)
+  * `Use Child Sensors` - Whether to use all Sensor components attached to child GameObjects of this Agent.
 * `Max Step` - The per-agent maximum number of steps. Once this number is
   reached, the Agent will be reset.
 

--- a/docs/Training-Curriculum-Learning.md
+++ b/docs/Training-Curriculum-Learning.md
@@ -68,7 +68,9 @@ SmallWallJump:
     small_wall_height: [1.5, 2.0, 2.5, 4.0]
 ```
 
-At the top level of the config is the behavior name.  The curriculum for each
+At the top level of the config is the behavior name. Note that this must be the
+same as the Behavior Name in the [Agent's Behavior Parameters](Learning-Environment-Design-Agents.md#agent-properties).
+ The curriculum for each
 behavior has the following parameters:
 * `measure` - What to measure learning progress, and advancement in lessons by.
   * `reward` - Uses a measure received reward.


### PR DESCRIPTION
This started out as a followup from https://forum.unity.com/threads/keyerror-when-training-with-curriculum.821835/#post-5445543
> The documentation is also a bit unclear about the point that the behavior name also has an influence and is not only meant to find the .nn model.
> maybe the parameter behavior name could be added and clarified here.

But then noticed some other missing fields.