### PR TITLE
fix BehaviorParametersEditor for m_UseChildSensors

### DIFF
--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -34,7 +34,7 @@ namespace MLAgents
             EditorGUI.indentLevel--;
             EditorGUILayout.PropertyField(so.FindProperty("m_BehaviorType"));
             EditorGUILayout.PropertyField(so.FindProperty("m_TeamID"));
-            EditorGUILayout.PropertyField(so.FindProperty("m_useChildSensors"), true);
+            EditorGUILayout.PropertyField(so.FindProperty("m_UseChildSensors"), true);
             // EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Heuristic"), true);
             EditorGUI.indentLevel--;
             if (EditorGUI.EndChangeCheck())


### PR DESCRIPTION
Missed this rename in https://github.com/Unity-Technologies/ml-agents/pull/3395