### PR TITLE
landing page links to latest_release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="docs/images/image-banner.png" align="middle" width="3000"/>
 
 # Unity ML-Agents Toolkit (Beta)
-[![docs badge](https://img.shields.io/badge/docs-reference-blue.svg)](docs/Readme.md)
+[![docs badge](https://img.shields.io/badge/docs-reference-blue.svg)](https://github.com/Unity-Technologies/ml-agents/tree/latest_release/docs/)
 [![license badge](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 
 ([latest release](https://github.com/Unity-Technologies/ml-agents/releases/tag/latest_release))
@@ -28,8 +28,12 @@ developer communities.
 
 * Unity environment control from Python
 * 10+ sample Unity environments
-* Two deep reinforcement learning algorithms, [Proximal Policy Optimization](docs/Training-PPO.md) (PPO) and [Soft Actor-Critic](docs/Training-SAC.md) (SAC)
+* Two deep reinforcement learning algorithms,
+[Proximal Policy Optimization](https://github.com/Unity-Technologies/ml-agents/tree/latest_release/docs/Training-PPO.md)
+ (PPO) and [Soft Actor-Critic](https://github.com/Unity-Technologies/ml-agents/tree/latest_release/docs/Training-SAC.md)
+ (SAC)
 * Support for multiple environment configurations and training scenarios
+* Self-play mechanism for training agents in adversarial scenarios
 * Train memory-enhanced agents using deep reinforcement learning
 * Easily definable Curriculum Learning and Generalization scenarios
 * Built-in support for Imitation Learning
@@ -43,7 +47,7 @@ developer communities.
 ## Documentation
 
 * For more information, in addition to installation and usage instructions, see
-  our [documentation home](docs/Readme.md).
+  the [documentation for the latest release](https://github.com/Unity-Technologies/ml-agents/tree/latest_release/docs/Readme.md).
 * If you are a researcher interested in a discussion of Unity as an AI platform, see a pre-print of our [reference paper on Unity and the ML-Agents Toolkit](https://arxiv.org/abs/1809.02627). Also, see below for instructions on citing this paper.
 * If you have used an earlier version of the ML-Agents toolkit, we strongly
   recommend our [guide on migrating from earlier versions](docs/Migrating.md).
@@ -83,22 +87,11 @@ and make sure to include as much detail as possible.
 If you run into any other problems using the ML-Agents toolkit, or have a specific
 feature requests, please [submit a GitHub issue](https://github.com/Unity-Technologies/ml-agents/issues).
 
-Your opinion matters a great deal to us. Only by hearing your thoughts on the Unity ML-Agents Toolkit can we continue to improve and grow. Please take a few minutes to [let us know about it](https://github.com/Unity-Technologies/ml-agents/issues/1454).
+Your opinion matters a great deal to us. Only by hearing your thoughts on the Unity ML-Agents Toolkit can we continue
+to improve and grow. Please take a few minutes to [let us know about it](https://github.com/Unity-Technologies/ml-agents/issues/1454).
 
 For any other questions or feedback, connect directly with the ML-Agents
 team at ml-agents@unity3d.com.
-
-## Translations
-
-To make the Unity ML-Agents toolkit accessible to the global research and
-Unity developer communities, we're attempting to create and maintain
-translations of our documentation. We've started with translating a subset
-of the documentation to one language (Chinese), but we hope to continue
-translating more pages and to other languages. Consequently,
-we welcome any enhancements and improvements from the community.
-
-* [Chinese](docs/localized/zh-CN/)
-* [Korean](docs/localized/KR/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ to improve and grow. Please take a few minutes to [let us know about it](https:/
 For any other questions or feedback, connect directly with the ML-Agents
 team at ml-agents@unity3d.com.
 
+## Releases
+The current version of the release is 0.14.0. Previous releases can be found below:
+
+| **Version** | **Source** | **Documentation** | **Download** |
+|:-------:|:------:|:-------------:|:-------:|
+| **0.13.1**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.13.1) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.13.1/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.13.1.zip) |
+| **0.13.0**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.13.0) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.13.0/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.13.0.zip) |
+| **0.12.1**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.12.1) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.12.1/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.12.1.zip) |
+| **0.12.0**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.12.0) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.12.0/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.12.0.zip) |
+| **0.11.0**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.11.0) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.11.0/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.11.0.zip) |
+| **0.10.1**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.10.1) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.10.1/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.10.1.zip) |
+| **0.10.0**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/0.10.0) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/0.10.0/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/0.10.0.zip) |
+
+See the [GitHub releases](https://github.com/Unity-Technologies/ml-agents/releases) for more details of the changes
+between versions.
+
+Please note that the `master` branch is under active development, so the documentation there may differ from the code
+of a previous release. Always use the documentation that corresponds to the release version you're using.
+
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For any other questions or feedback, connect directly with the ML-Agents
 team at ml-agents@unity3d.com.
 
 ## Releases
-The current version of the release is 0.14.0. Previous releases can be found below:
+The latest release is 0.14.0. Previous releases can be found below:
 
 | **Version** | **Source** | **Documentation** | **Download** |
 |:-------:|:------:|:-------------:|:-------:|

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -60,6 +60,18 @@
 * [How to use the Python API](Python-API.md)
 * [Wrapping Learning Environment as a Gym (+Baselines/Dopamine Integration)](../gym-unity/README.md)
 
+## Translations
+
+To make the Unity ML-Agents toolkit accessible to the global research and
+Unity developer communities, we're attempting to create and maintain
+translations of our documentation. We've started with translating a subset
+of the documentation to one language (Chinese), but we hope to continue
+translating more pages and to other languages. Consequently,
+we welcome any enhancements and improvements from the community.
+
+* [Chinese](docs/localized/zh-CN/)
+* [Korean](docs/localized/KR/)
+
 ## Deprecated Docs
 We no longer use them ourselves and so they may not be up-to-date.
 We've decided to keep them up just in case they are helpful to you.

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -69,8 +69,8 @@ of the documentation to one language (Chinese), but we hope to continue
 translating more pages and to other languages. Consequently,
 we welcome any enhancements and improvements from the community.
 
-* [Chinese](docs/localized/zh-CN/)
-* [Korean](docs/localized/KR/)
+* [Chinese](localized/zh-CN/)
+* [Korean](localized/KR/)
 
 ## Deprecated Docs
 We no longer use them ourselves and so they may not be up-to-date.

--- a/utils/make_readme_table.py
+++ b/utils/make_readme_table.py
@@ -1,0 +1,17 @@
+"""
+Generate the "Releases" table on the main readme. Update the versions lists, run this script, and copy the output
+into the markdown file.
+"""
+from distutils.version import LooseVersion
+
+
+def table_line(version):
+    return f"| **{version}**  | [source](https://github.com/Unity-Technologies/ml-agents/tree/{version}) |  [docs](https://github.com/Unity-Technologies/ml-agents/tree/{version}/docs) | [download](https://github.com/Unity-Technologies/ml-agents/archive/{version}.zip) |"  # noqa
+
+
+versions = ["0.10.0", "0.10.1", "0.11.0", "0.12.0", "0.12.1", "0.13.0", "0.13.1"]
+
+sorted_versions = sorted((LooseVersion(v) for v in versions), reverse=True)
+
+for v in sorted_versions:
+    print(table_line(str(v)))


### PR DESCRIPTION
Replace relative `/docs` links to the `latest_release`, in order to hopefully get people looking at the right version. Also moved the `Translation` to the docs page.

Do we want to move the `## Additional Resources` section to the `/docs/Readme.md` too?