### PR TITLE
Fix clear update buffer when trainer stops training, add test

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -253,7 +253,7 @@ class AgentBuffer(dict):
         max_length -= max_length % sequence_length
         if current_length > max_length:
             for _key in self.keys():
-                self[_key] = self[_key][current_length - max_length :]
+                self[_key][:] = self[_key][current_length - max_length :]
 
     def resequence_and_append(
         self,

--- a/ml-agents/mlagents/trainers/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/rl_trainer.py
@@ -73,5 +73,5 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         Steps the trainer, taking in trajectories and updates if ready
         """
         super().advance()
-        if not self.is_training:
+        if not self.should_still_train:
             self.clear_update_buffer()

--- a/ml-agents/mlagents/trainers/tests/test_buffer.py
+++ b/ml-agents/mlagents/trainers/tests/test_buffer.py
@@ -152,3 +152,5 @@ def test_buffer_truncate():
     # Test LSTM, truncate should be some multiple of sequence_length
     update_buffer.truncate(4, sequence_length=3)
     assert update_buffer.num_experiences == 3
+    for buffer_field in update_buffer.values():
+        assert isinstance(buffer_field, AgentBuffer.AgentBufferField)


### PR DESCRIPTION
Clear update buffer when trainer isn't training to avoid memory leak. Note the right way would be not to add the trajectory at all (TBD for future release), but this is closest to existing functionality in 0.13.1.