### PR TITLE
[bug-fix] Empty ignored trajectory queues, make sure queues don't overflow

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Update Barracuda to 0.6.0-preview
 
 ### Bugfixes
-
+- Fixed an issue which caused self-play training sessions to consume a lot of memory. (#3451)
 
 ## [0.14.0-preview] - 2020-02-13
 

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -40,6 +40,7 @@ class GhostTrainer(Trainer):
 
         self.internal_policy_queues: List[AgentManagerQueue[Policy]] = []
         self.internal_trajectory_queues: List[AgentManagerQueue[Trajectory]] = []
+        self.ignored_trajectory_queues: List[AgentManagerQueue[Trajectory]] = []
         self.learning_policy_queues: Dict[str, AgentManagerQueue[Policy]] = {}
 
         # assign ghost's stats collection to wrapped trainer's
@@ -134,10 +135,14 @@ class GhostTrainer(Trainer):
             self.trajectory_queues, self.internal_trajectory_queues
         ):
             try:
-                t = traj_queue.get_nowait()
-                # adds to wrapped trainers queue
-                internal_traj_queue.put(t)
-                self._process_trajectory(t)
+                # We grab at most the maximum length of the queue.
+                # This ensures that even if the queue is being filled faster than it is
+                # being emptied, the trajectories in the queue are on-policy.
+                for _ in range(traj_queue.maxlen):
+                    t = traj_queue.get_nowait()
+                    # adds to wrapped trainers queue
+                    internal_traj_queue.put(t)
+                    self._process_trajectory(t)
             except AgentManagerQueue.Empty:
                 pass
 
@@ -161,6 +166,14 @@ class GhostTrainer(Trainer):
         if self.get_step - self.last_swap > self.steps_between_swap:
             self._swap_snapshots()
             self.last_swap = self.get_step
+
+        # Dump trajectories from non-learning policy
+        for traj_queue in self.ignored_trajectory_queues:
+            try:
+                for _ in range(traj_queue.maxlen):
+                    traj_queue.get_nowait()
+            except AgentManagerQueue.Empty:
+                pass
 
     def end_episode(self):
         self.trainer.end_episode()
@@ -256,6 +269,8 @@ class GhostTrainer(Trainer):
 
             self.internal_trajectory_queues.append(internal_trajectory_queue)
             self.trainer.subscribe_trajectory_queue(internal_trajectory_queue)
+        else:
+            self.ignored_trajectory_queues.append(trajectory_queue)
 
 
 # Taken from https://github.com/Unity-Technologies/ml-agents/pull/1975 and

--- a/ml-agents/mlagents/trainers/tests/test_ghost.py
+++ b/ml-agents/mlagents/trainers/tests/test_ghost.py
@@ -152,6 +152,8 @@ def test_process_trajectory(dummy_config):
 
     # Check that ghost trainer ignored off policy queue
     assert trainer.trainer.update_buffer.num_experiences == 15
+    # Check that it emptied the queue
+    assert trajectory_queue1.empty()
 
 
 def test_publish_queue(dummy_config):


### PR DESCRIPTION
# Proposed change(s)

The current GhostTrainer subscribes to all trajectory queues (both learning and ghost) but doesn't empty the ghost queues as it doesn't use those trajectories for learning. This leads to a memory leak, at least until the queue is full (1000 trajectories, for Soccer it was about 5 GB). 

This PR makes sure the GhostTrainer empties all queues (even if they are ignored) and also ensures queues are emptied even if they are filling faster than advance() is called (rare). 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added updated the changelog (if applicable)
- [ ] I have added necessary documentation (if applicable) - Not Applicable
- [ ] I have updated the migration guide (if applicable) - Not Applicable