### PR TITLE
[bug-fix] Use correct agent_ids for demo loader

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfixes
 - Fixed an issue which caused self-play training sessions to consume a lot of memory. (#3451)
+- Fixed an IndexError when using GAIL or behavioral cloning with demonstrations recorded with 0.14.0 or later (#3464)
 
 ## [0.14.0-preview] - 2020-02-13
 

--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -51,9 +51,10 @@ def make_demo_buffer(
             previous_action = np.array(
                 pair_infos[idx - 1].action_info.vector_actions, dtype=np.float32
             )
-        agent_id = current_step_info.agent_id[0]
-        current_agent_step_info = current_step_info.get_agent_step_result(agent_id)
-        next_agent_step_info = next_step_info.get_agent_step_result(agent_id)
+        curr_agent_id = current_step_info.agent_id[0]
+        current_agent_step_info = current_step_info.get_agent_step_result(curr_agent_id)
+        next_agent_id = next_step_info.agent_id[0]
+        next_agent_step_info = next_step_info.get_agent_step_result(next_agent_id)
 
         demo_raw_buffer["done"].append(next_agent_step_info.done)
         demo_raw_buffer["rewards"].append(next_agent_step_info.reward)


### PR DESCRIPTION
### Proposed change(s)

When the agent_id changes, the demo loader tries to use the old agent_id to access the agent in the BatchedAgentStep. This caused a crash in 0.14.0 onwards. We now just always use the first agent so that changes in agent_id don't cause a crash. 

Note that this fix will have to be coupled with a fix on the C# DemonstrationRecorder to properly log the done signals in the demo. After the C# fix happens, we will add new test demos so that we can catch similar issues in the future. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Github issue: #3455 
Unity Forum: https://forum.unity.com/threads/imitation-learning-error-message.829188/

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works - **will re-record demos after C# fix is implemented**
- [x] I have added updated the changelog (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the migration guide (if applicable)
