### PR TITLE
Change checkpoint suffix to "ckpt"

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Academy.RegisterSideChannel and UnregisterSideChannel methods were added. (#3391)
  - A tutorial on adding custom SideChannels was added (#3391)
  - Update Barracuda to 0.6.0-preview
+ - The checkpoint file suffix was changed from `.cptk` to `.ckpt` (#3470)
 
 ### Bugfixes
 - Fixed an issue which caused self-play training sessions to consume a lot of memory. (#3451)

--- a/ml-agents/mlagents/trainers/tf_policy.py
+++ b/ml-agents/mlagents/trainers/tf_policy.py
@@ -309,7 +309,7 @@ class TFPolicy(Policy):
         :return:
         """
         with self.graph.as_default():
-            last_checkpoint = self.model_path + "/model-" + str(steps) + ".cptk"
+            last_checkpoint = self.model_path + "/model-" + str(steps) + ".ckpt"
             self.saver.save(self.sess, last_checkpoint)
             tf.train.write_graph(
                 self.graph, self.model_path, "raw_graph_def.pb", as_text=False


### PR DESCRIPTION
Tensorflow doesn't prescribe any particular file suffix for checkpoint files, but they 
are commonly referred to as "ckpt" as a shorthand for "checkpoint".  However ours 
is somewhat confusingly "cptk".  This change simply changes our checkpoint suffix 
to "ckpt".

### Proposed change(s)

Change the checkpoint file suffix to "ckpt".

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Brought up in #3456

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

Minor interface change.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature 
This should be covered by existing testing.

- [x] I have added updated the changelog (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the migration guide (if applicable)

For the above, I believe this should not affect loading or saving existing training runs, 
and probably is below the threshold of requiring an entry in the changelog (but open 
to disagreement on this).

### Other comments
