### PR TITLE
[Bug fix] Gym last reward before Done

### DIFF
--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -392,7 +392,8 @@ class UnityEnv(gym.Env):
         for index, agent_id in enumerate(step_result.agent_id):
             if not self._previous_step_result.contains_agent(agent_id):
                 # insert the id in the current id list:
-                self._gym_id_order[self._gym_id_order.index(-1)] = agent_id
+                original_index = self._gym_id_order.index(-1)
+                self._gym_id_order[original_index] = agent_id
                 # This is a new agent
                 step_result.done[index] = True
                 # The index of the agent among not-done agents is
@@ -405,8 +406,9 @@ class UnityEnv(gym.Env):
         self._previous_step_result = step_result  # store the new original
 
         new_id_order = []
+        agent_id_list = list(step_result.agent_id)
         for agent_id in self._gym_id_order:
-            new_id_order.append(list(step_result.agent_id).index(agent_id))
+            new_id_order.append(agent_id_list.index(agent_id))
 
         _mask: Optional[List[np.array]] = None
         if step_result.action_mask is not None:

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -397,7 +397,6 @@ class UnityEnv(gym.Env):
                 # This is a new agent
                 step_result.done[index] = True
                 # The index of the agent among not-done agents is
-                original_index = self._gym_id_order.index(agent_id)
                 step_result.reward[index] = self._done_agents_index_to_last_reward[
                     original_index
                 ]
@@ -431,9 +430,12 @@ class UnityEnv(gym.Env):
         sanitized_action = np.zeros(
             (self._previous_step_result.n_agents(), self.group_spec.action_size)
         )
+        agent_id_to_gym_index = {
+            agent_id: gym_index for gym_index, agent_id in enumerate(self._gym_id_order)
+        }
         for index, agent_id in enumerate(self._previous_step_result.agent_id):
             if not self._previous_step_result.done[index]:
-                array_index = self._gym_id_order.index(agent_id)
+                array_index = agent_id_to_gym_index[agent_id]
                 sanitized_action[index, :] = action[array_index, :]
         return sanitized_action
 

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -213,7 +213,7 @@ def test_agent_id_index_mapper(mapper_cls):
     assert set(permutation) == set(range(0, 4))
 
     # For initial agents that were in the initial group, they need to be in the same slot.
-    # Agents that were added later can be anywhere.
+    # Agents that were added later can appear in any free slot.
     permuted_ids = [new_agent_ids[i] for i in permutation]
     for idx, agent_id in enumerate(initial_agent_ids):
         if agent_id in permuted_ids:


### PR DESCRIPTION
### Proposed change(s)

Second attempt at fixing gym.
This time we explicitly keep track of the agent_ids that gym has and their order.
When an agent is done, we replace its id in the current list with -1 and we wait for a new agent to take on the id.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

#3460 
MLA-651

### Types of change(s)

- [x] Bug fix
- ~[ ] New feature~
- [x] Code refactor
- ~[ ] Breaking change~
- ~[ ] Documentation update~
- ~[ ] Other (please describe)~

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added updated the changelog (if applicable)~
- ~[ ] I have added necessary documentation (if applicable)~
- ~[ ] I have updated the migration guide (if applicable)~

### Other comments
