### PR TITLE
Make the timer output format consistent

### DIFF
--- a/docs/Profiling-Python.md
+++ b/docs/Profiling-Python.md
@@ -35,11 +35,10 @@ profiling calls to abstract methods that might not use decorator.
 ## Output
 By default, at the end of training, timers are collected and written in json format to
 `{summaries_dir}/{run_id}_timers.json`. The output consists of node objects with the following keys:
- * name (string): The name of the block of code.
  * total (float): The total time in seconds spent in the block, including child calls.
  * count (int): The number of times the block was called.
  * self (float): The total time in seconds spent in the block, excluding child calls.
- * children (list): A list of child nodes.
+ * children (dictionary): A dictionary of child nodes, keyed by the node name.
  * is_parallel (bool): Indicates that the block of code was executed in multiple threads or processes (see below). This
  is optional and defaults to false.
 

--- a/ml-agents-envs/mlagents_envs/tests/test_timers.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_timers.py
@@ -57,45 +57,30 @@ def test_timers() -> None:
             "total": mock.ANY,
             "count": 1,
             "self": mock.ANY,
-            "children": [
-                {
-                    "name": "top_level",
+            "children": {
+                "top_level": {
                     "total": mock.ANY,
                     "count": 1,
                     "self": mock.ANY,
-                    "children": [
-                        {
-                            "name": "multiple",
+                    "children": {
+                        "multiple": {
                             "total": mock.ANY,
                             "count": 3,
                             "self": mock.ANY,
-                            "children": [
-                                {
-                                    "name": "decorated_func",
+                            "children": {
+                                "decorated_func": {
                                     "total": mock.ANY,
                                     "count": 3,
                                     "self": mock.ANY,
                                 }
-                            ],
+                            },
                         },
-                        {
-                            "name": "raises",
-                            "total": mock.ANY,
-                            "count": 1,
-                            "self": mock.ANY,
-                        },
-                        {
-                            "name": "post_raise",
-                            "total": mock.ANY,
-                            "count": 1,
-                            "self": mock.ANY,
-                        },
-                    ],
+                        "raises": {"total": mock.ANY, "count": 1, "self": mock.ANY},
+                        "post_raise": {"total": mock.ANY, "count": 1, "self": mock.ANY},
+                    },
                 }
-            ],
-            "gauges": [
-                {"name": "my_gauge", "value": 4.0, "max": 4.0, "min": 0.0, "count": 3}
-            ],
+            },
+            "gauges": {"my_gauge": {"value": 4.0, "max": 4.0, "min": 0.0, "count": 3}},
         }
 
         assert timer_tree == expected_tree

--- a/ml-agents-envs/mlagents_envs/timers.py
+++ b/ml-agents-envs/mlagents_envs/timers.py
@@ -183,16 +183,16 @@ class TimerStack:
             res["is_parallel"] = True
 
         child_total = 0.0
-        child_list = {}
+        child_dict = {}
         for child_name, child_node in node.children.items():
             child_res: Dict[str, Any] = self.get_timing_tree(child_node)
-            child_list[child_name] = child_res
+            child_dict[child_name] = child_res
             child_total += child_res["total"]
 
         # "self" time is total time minus all time spent on children
         res["self"] = max(0.0, node.total - child_total)
-        if child_list:
-            res["children"] = child_list
+        if child_dict:
+            res["children"] = child_dict
 
         return res
 

--- a/ml-agents-envs/mlagents_envs/timers.py
+++ b/ml-agents-envs/mlagents_envs/timers.py
@@ -32,7 +32,7 @@ import math
 from time import perf_counter
 
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, List, TypeVar
+from typing import Any, Callable, Dict, Generator, TypeVar
 
 
 class TimerNode:
@@ -183,13 +183,10 @@ class TimerStack:
             res["is_parallel"] = True
 
         child_total = 0.0
-        child_list = []
+        child_list = {}
         for child_name, child_node in node.children.items():
-            child_res: Dict[str, Any] = {
-                "name": child_name,
-                **self.get_timing_tree(child_node),
-            }
-            child_list.append(child_res)
+            child_res: Dict[str, Any] = self.get_timing_tree(child_node)
+            child_list[child_name] = child_res
             child_total += child_res["total"]
 
         # "self" time is total time minus all time spent on children
@@ -208,11 +205,10 @@ class TimerStack:
         else:
             self.gauges[name] = GaugeNode(value)
 
-    def _get_gauges(self) -> List[Dict[str, Any]]:
-        gauges = []
+    def _get_gauges(self) -> Dict[str, Dict[str, float]]:
+        gauges = {}
         for gauge_name, gauge_node in self.gauges.items():
-            gauge_dict: Dict[str, Any] = {"name": gauge_name, **gauge_node.as_dict()}
-            gauges.append(gauge_dict)
+            gauges[gauge_name] = gauge_node.as_dict()
         return gauges
 
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -16,7 +16,12 @@ from mlagents import tf_utils
 from mlagents.trainers.trainer_controller import TrainerController
 from mlagents.trainers.meta_curriculum import MetaCurriculum
 from mlagents.trainers.trainer_util import load_config, TrainerFactory
-from mlagents.trainers.stats import TensorboardWriter, CSVWriter, StatsReporter
+from mlagents.trainers.stats import (
+    TensorboardWriter,
+    CSVWriter,
+    StatsReporter,
+    GaugeWriter,
+)
 from mlagents_envs.environment import UnityEnvironment
 from mlagents.trainers.sampler_class import SamplerManager
 from mlagents.trainers.exception import SamplerException
@@ -263,8 +268,10 @@ def run_training(run_seed: int, options: RunOptions) -> None:
         required_fields=["Environment/Cumulative Reward", "Environment/Episode Length"],
     )
     tb_writer = TensorboardWriter(summaries_dir)
+    gauge_write = GaugeWriter()
     StatsReporter.add_writer(tb_writer)
     StatsReporter.add_writer(csv_writer)
+    StatsReporter.add_writer(gauge_write)
 
     if options.env_path is None:
         port = UnityEnvironment.DEFAULT_EDITOR_PORT

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -6,6 +6,7 @@ import csv
 import os
 
 from mlagents.tf_utils import tf
+from mlagents_envs.timers import set_gauge
 
 
 class StatsSummary(NamedTuple):
@@ -31,6 +32,21 @@ class StatsWriter(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def write_text(self, category: str, text: str, step: int) -> None:
+        pass
+
+
+class GaugeWriter(StatsWriter):
+    """
+    Write all stats that we recieve to the timer gauges, so we can track them offline easily
+    """
+
+    def write_stats(
+        self, category: str, values: Dict[str, StatsSummary], step: int
+    ) -> None:
+        for val, stats_summary in values.items():
+            set_gauge(f"{category}.{val}.mean", float(stats_summary.mean))
+
     def write_text(self, category: str, text: str, step: int) -> None:
         pass
 

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -41,6 +41,13 @@ class GaugeWriter(StatsWriter):
     Write all stats that we recieve to the timer gauges, so we can track them offline easily
     """
 
+    @staticmethod
+    def sanitize_string(s: str) -> str:
+        """
+        Clean up special characters in the category and value names.
+        """
+        return s.replace("/", ".").replace(" ", "")
+
     def write_stats(
         self, category: str, values: Dict[str, StatsSummary], step: int
     ) -> None:

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -9,6 +9,7 @@ from mlagents.trainers.stats import (
     TensorboardWriter,
     CSVWriter,
     StatsSummary,
+    GaugeWriter,
 )
 
 
@@ -129,3 +130,11 @@ def test_csv_writer():
                     assert len(row) == 3
                     line_count += 1
             assert line_count == 3
+
+
+def test_gauge_stat_writer_sanitize():
+    assert GaugeWriter.sanitize_string("Policy/Learning Rate") == "Policy.LearningRate"
+    assert (
+        GaugeWriter.sanitize_string("Very/Very/Very Nested Stat")
+        == "Very.Very.VeryNestedStat"
+    )

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -109,7 +109,7 @@ class TrainerController(object):
         timing_path = f"{self.summaries_dir}/{self.run_id}_timers.json"
         try:
             with open(timing_path, "w") as f:
-                json.dump(get_timer_tree(), f, indent=2)
+                json.dump(get_timer_tree(), f, indent=4)
         except FileNotFoundError:
             self.logger.warning(
                 f"Unable to save to {timing_path}. Make sure the directory exists"


### PR DESCRIPTION
### Proposed change(s)

This changes the output format of the python timers. Instead of children nodes as a list with the child name in the node, the child names are keys in the dictionary. This makes the timers consistent with the C# timers (which are less flexible in the output format because we're using C#'s serialization).

It also adds new gauges when we report stats (e.g. policy value estimates). This should let us estimate the ELO rating after training.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-661


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added updated the changelog (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] I have updated the migration guide (if applicable)

### Other comments
