### PR TITLE
Replace Agent.GetStepCount with Agent.StepCount`

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
@@ -30,7 +30,7 @@ public class HallwayAgent : Agent
     {
         if (useVectorObs)
         {
-            sensor.AddObservation(GetStepCount() / (float)maxStep);
+            sensor.AddObservation(StepCount / (float)maxStep);
         }
     }
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The stepping logic for the Agent and the Academy has been simplified (#3448)
  - Update Barracuda to 0.6.0-preview
  - The checkpoint file suffix was changed from `.cptk` to `.ckpt` (#3470)
+ - The method `GetStepCount()` on the Agent class has been replaced with the property getter `StepCount`
 
 ### Bugfixes
 - Fixed an issue which caused self-play training sessions to consume a lot of memory. (#3451)

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -314,15 +314,14 @@ namespace MLAgents
             m_Brain = m_PolicyFactory.GeneratePolicy(Heuristic);
         }
 
-        /// <summary>
         /// Returns the current step counter (within the current episode).
         /// </summary>
         /// <returns>
-        /// Current episode number.
+        /// Current step count.
         /// </returns>
-        public int GetStepCount()
+        public int StepCount
         {
-            return m_StepCount;
+            get { return m_StepCount; }
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -406,7 +406,7 @@ namespace MLAgents.Tests
 
                 Assert.AreEqual(i, aca.TotalStepCount);
 
-                Assert.AreEqual(agent2StepSinceReset, agent2.GetStepCount());
+                Assert.AreEqual(agent2StepSinceReset, agent2.StepCount);
                 Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
                 Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
 
@@ -536,12 +536,12 @@ namespace MLAgents.Tests
                 expectedAgentStepCount += 1;
 
                 // If the next step will put the agent at maxSteps, we expect it to reset
-                if (agent1.GetStepCount() == maxStep - 1 || (i == 0))
+                if (agent1.StepCount == maxStep - 1 || (i == 0))
                 {
                     expectedResets +=1;
                 }
 
-                if (agent1.GetStepCount() == maxStep - 1)
+                if (agent1.StepCount == maxStep - 1)
                 {
                     expectedAgentActionSinceReset = 0;
                     expectedCollectObsCallsSinceReset = 0;
@@ -549,7 +549,7 @@ namespace MLAgents.Tests
                 }
                 aca.EnvironmentStep();
 
-                Assert.AreEqual(expectedAgentStepCount, agent1.GetStepCount());
+                Assert.AreEqual(expectedAgentStepCount, agent1.StepCount);
                 Assert.AreEqual(expectedResets, agent1.agentResetCalls);
                 Assert.AreEqual(expectedAgentAction, agent1.agentActionCalls);
                 Assert.AreEqual(expectedAgentActionSinceReset, agent1.agentActionCallsSinceLastReset);

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -14,11 +14,13 @@ The versions can be found in
 * The `Monitor` class has been moved to the Examples Project. (It was prone to errors during testing)
 * The `MLAgents.Sensor` namespace has been removed. All sensors now belong to the `MLAgents` namespace.
 * The `SetActionMask` method must now be called on the optional `ActionMasker` argument of the `CollectObservations` method. (We now consider an action mask as a type of observation)
+* The method `GetStepCount()` on the Agent class has been replaced with the property getter `StepCount`
 
 ### Steps to Migrate
 * Replace your Agent's implementation of `CollectObservations()` with `CollectObservations(VectorSensor sensor)`. In addition, replace all calls to `AddVectorObs()` with `sensor.AddObservation()` or `sensor.AddOneHotObservation()` on the `VectorSensor` passed as argument.
 * Replace your calls to `SetActionMask` on your Agent to `ActionMasker.SetActionMask` in `CollectObservations`
 * Re-import all of your `*.NN` files to work with the updated Barracuda package.
+* Replace all calls to `Agent.GetStepCount()` with `Agent.StepCount`
 
 ## Migrating from 0.13 to 0.14
 


### PR DESCRIPTION
### Proposed change(s)

Replace the method GetStepCount on the Agent with StepCount property accessor for parity with the Academy.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
None


### Types of change(s)

- ~[ ] Bug fix~
- ~[ ] New feature~
- [x] Code refactor
- [x] Breaking change
- [x] Documentation update
- ~[ ] Other (please describe)~

### Checklist
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added updated the changelog (if applicable)
- ~[ ] I have added necessary documentation (if applicable)~
- [x] I have updated the migration guide (if applicable)

### Other comments
