### PR TITLE
Fix demo icon path

### DIFF
--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -13,7 +13,7 @@ namespace MLAgents
     [ScriptedImporter(1, new[] {"demo"})]
     internal class DemonstrationImporter : ScriptedImporter
     {
-        const string k_IconPath = "Assets/ML-Agents/Resources/DemoIcon.png";
+        const string k_IconPath = "Packages/com.unity.ml-agents/Editor/Icons/DemoIcon.png";
 
         public override void OnImportAsset(AssetImportContext ctx)
         {


### PR DESCRIPTION
### Proposed change(s)

Fixes the path used by the Demonstration importer. I started with the approach here https://github.cds.internal.unity3d.com/unity/UnityInferenceEngine/blob/35aecad2a99dcb2b6d6a98988ed3a58f6de1a491/UnityProject/Assets/Barracuda/Plugins/Editor/BarracudaEditor/NNModelImporter.cs#L34-L46 to get the right path, then went back to the hard-coded path.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added updated the changelog (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the migration guide (if applicable)

### Other comments
![image](https://user-images.githubusercontent.com/6877802/75209359-ce56d580-5732-11ea-8df9-f06683c404ae.png)
