### PR TITLE
Don't make the test a MonoBehavior

### DIFF
--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -7,7 +7,7 @@ using MLAgents.CommunicatorObjects;
 namespace MLAgents.Tests
 {
     [TestFixture]
-    public class DemonstrationTests : MonoBehaviour
+    public class DemonstrationTests
     {
         const string k_DemoDirectory = "Assets/Demonstrations/";
         const string k_ExtensionType = ".demo";


### PR DESCRIPTION
### Proposed change(s)

Fixes this warning during test:
```
You are trying to create a MonoBehaviour using the 'new' keyword.  This is not allowed.  MonoBehaviours can only be added using AddComponent(). Alternatively, your script can inherit from ScriptableObject or no base class at all
UnityEngine.MonoBehaviour:.ctor()
MLAgents.Tests.DemonstrationTests:.ctor()
UnityEngine.TestTools.NUnitExtensions.ConstructDelegator:Delegate(Type, Object[])
NUnit.Framework.Internal.Reflect:Construct(Type, Object[])
NUnit.Framework.Internal.TypeWrapper:Construct(Object[])
NUnit.Framework.Internal.Commands.OneTimeSetUpCommand:Execute(ITestExecutionContext)
UnityEditor.EditorApplication:Internal_CallUpdateFunctions()
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
