### PR TITLE
[bug-fix] Fix metacurriculum test

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
@@ -102,7 +102,7 @@ TRAINER_CONFIG = """
         hidden_units: 128
         lambd: 0.95
         learning_rate: 5.0e-3
-        max_steps: 300
+        max_steps: 100
         memory_size: 256
         normalize: false
         num_epoch: 3
@@ -123,4 +123,4 @@ def test_simple_metacurriculum(curriculum_brain_name):
     env = Simple1DEnvironment(use_discrete=False)
     curriculum_config = json.loads(dummy_curriculum_json_str)
     mc = MetaCurriculum({curriculum_brain_name: curriculum_config})
-    _check_environment_trains(env, TRAINER_CONFIG, mc, -100.0)
+    _check_environment_trains(env, TRAINER_CONFIG, mc, None)

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -263,9 +263,12 @@ def _check_environment_trains(
         # Begin training
         tc.start_learning(env_manager)
         print(tc._get_measure_vals())
-        for mean_reward in tc._get_measure_vals().values():
-            assert not math.isnan(mean_reward)
-            assert mean_reward > success_threshold
+        if (
+            success_threshold is not None
+        ):  # For tests where we are just checking setup and not reward
+            for mean_reward in tc._get_measure_vals().values():
+                assert not math.isnan(mean_reward)
+                assert mean_reward > success_threshold
 
 
 @pytest.mark.parametrize("use_discrete", [True, False])


### PR DESCRIPTION
### Proposed change(s)

The metacurriculum test uses simple RL to check for runtime errors. However it runs for a very short number of steps and occasionally won't finish the episode, returning NaN for the reward. This PR adds a flag to Simple RL that turns off the reward check. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)