### PR TITLE
add DoneReason enum to Agent

### DIFF
--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -87,8 +87,6 @@ namespace MLAgentsExamples
             {
                 if (m_NumSteps > m_MaxEpisodes * m_Agent.maxStep)
                 {
-                    // Stop recording so that we don't write partial rewards to the timer info.
-                    TimerStack.Instance.Recording = false;
                     Application.Quit(0);
                 }
             }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -257,6 +257,27 @@ namespace MLAgents
             InitializeSensors();
         }
 
+        /// <summary>
+        /// Reason that the Agent is being considered "done"
+        /// </summary>
+        enum DoneReason
+        {
+            /// <summary>
+            /// The <see cref="Done"/> method was called.
+            /// </summary>
+            DoneCalled,
+
+            /// <summary>
+            /// The max steps for the Agent were reached.
+            /// </summary>
+            MaxStepReached,
+
+            /// <summary>
+            /// The Agent was disabled
+            /// </summary>
+            Disabled,
+        }
+
         void OnDisable()
         {
             DemonstrationWriters.Clear();
@@ -271,16 +292,16 @@ namespace MLAgents
                 Academy.Instance.AgentAct -= AgentStep;
                 Academy.Instance.AgentForceReset -= _AgentReset;
             }
-            NotifyAgentDone();
+            NotifyAgentDone(DoneReason.Disabled);
             m_Brain?.Dispose();
             m_Initialized = false;
         }
 
-        void NotifyAgentDone(bool maxStepReached = false)
+        void NotifyAgentDone(DoneReason doneReason)
         {
             m_Info.reward = m_Reward;
             m_Info.done = true;
-            m_Info.maxStepReached = maxStepReached;
+            m_Info.maxStepReached = doneReason == DoneReason.MaxStepReached;
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately
             m_Brain?.RequestDecision(m_Info, sensors);
@@ -291,7 +312,12 @@ namespace MLAgents
                 demoWriter.Record(m_Info, sensors);
             }
 
-            UpdateRewardStats();
+            if (doneReason != DoneReason.Disabled)
+            {
+                // We don't want to udpate the reward stats when the Agent is disabled, because this will make
+                // the rewards look lower than they actually are during shutdown.
+                UpdateRewardStats();
+            }
 
             // The Agent is done, so we give it a new episode Id
             m_EpisodeId = EpisodeIdCounter.GetEpisodeId();
@@ -381,7 +407,7 @@ namespace MLAgents
         /// </summary>
         public void Done()
         {
-            NotifyAgentDone();
+            NotifyAgentDone(DoneReason.DoneCalled);
             _AgentReset();
         }
 
@@ -730,7 +756,7 @@ namespace MLAgents
 
             if ((m_StepCount >= maxStep) && (maxStep > 0))
             {
-                NotifyAgentDone(true);
+                NotifyAgentDone(DoneReason.MaxStepReached);
                 _AgentReset();
             }
         }

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -285,7 +285,7 @@ namespace MLAgents
     /// This implements the Singleton pattern (solution 4) as described in
     /// https://csharpindepth.com/articles/singleton
     /// </remarks>
-    public class TimerStack : IDisposable
+    internal class TimerStack : IDisposable
     {
         static readonly TimerStack k_Instance = new TimerStack();
 

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -152,16 +152,12 @@ namespace MLAgents
         /// <summary>
         /// Stop timing a block of code, and increment internal counts.
         /// </summary>
-        public void End(bool isRecording)
+        public void End()
         {
-            if (isRecording)
-            {
-                var elapsed = DateTime.Now.Ticks - m_TickStart;
-                m_TotalTicks += elapsed;
-                m_TickStart = 0;
-                m_NumCalls++;
-            }
-            // Note that samplers are always updated regardless of recording state, to ensure matching start and ends.
+            var elapsed = DateTime.Now.Ticks - m_TickStart;
+            m_TotalTicks += elapsed;
+            m_TickStart = 0;
+            m_NumCalls++;
             m_Sampler?.End();
         }
 
@@ -291,8 +287,6 @@ namespace MLAgents
 
         Stack<TimerNode> m_Stack;
         TimerNode m_RootNode;
-        // Whether or not new timers and gauges can be added.
-        bool m_Recording = true;
 
         // Explicit static constructor to tell C# compiler
         // not to mark type as beforefieldinit
@@ -330,26 +324,12 @@ namespace MLAgents
         }
 
         /// <summary>
-        /// Whether or not new timers and gauges can be added.
-        /// </summary>
-        public bool Recording
-        {
-            get { return m_Recording; }
-            set { m_Recording = value; }
-        }
-
-        /// <summary>
         /// Updates the referenced gauge in the root node with the provided value.
         /// </summary>
         /// <param name="name">The name of the Gauge to modify.</param>
         /// <param name="value">The value to update the Gauge with.</param>
         public void SetGauge(string name, float value)
         {
-            if (!Recording)
-            {
-                return;
-            }
-
             if (!float.IsNaN(value))
             {
                 GaugeNode gauge;
@@ -375,7 +355,7 @@ namespace MLAgents
         void Pop()
         {
             var node = m_Stack.Pop();
-            node.End(Recording);
+            node.End();
         }
 
         /// <summary>


### PR DESCRIPTION
### Proposed change(s)

In order to accurately track inference rewards, we need to make sure that we don't record incomplete results when an Agent is disabled (namely at shutdown). Previously, we were stopping updates of the timers. This changes Agent.NotifyAgentDone to take an enum for the shutdown reason, so that we can exclude timers when coming from OnDisable.

This allows us to mark TimerStack internal.

No new public API.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
