### PR TITLE
rename to RayPerceptionSensor.Perceive()

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - A tutorial on adding custom SideChannels was added (#3391)
  - The stepping logic for the Agent and the Academy has been simplified (#3448)
  - Update Barracuda to 0.6.0-preview
- - The interface for `RayPerceptionSensor.PerceiveStatic()` was changed to take an input class and write to an output class.
+ * The interface for `RayPerceptionSensor.PerceiveStatic()` was changed to take an input class and write to an output class, and the method was renamed to `Perceive()`.
  - The checkpoint file suffix was changed from `.cptk` to `.ckpt` (#3470)
  - The command-line argument used to determine the port that an environment will listen on was changed from `--port` to `--mlagents-port`.
  - `DemonstrationRecorder` can now record observations outside of the editor.

--- a/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensor/RayPerceptionSensor.cs
@@ -347,7 +347,7 @@ namespace MLAgents.Sensors
         /// </summary>
         /// <param name="input">Input defining the rays that will be cast.</param>
         /// <returns>Output struct containing the raycast results.</returns>
-        public static RayPerceptionOutput PerceiveStatic(RayPerceptionInput input)
+        public static RayPerceptionOutput Perceive(RayPerceptionInput input)
         {
             RayPerceptionOutput output = new RayPerceptionOutput();
             output.rayOutputs = new RayPerceptionOutput.RayOutput[input.angles.Count];

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -14,7 +14,7 @@ The versions can be found in
 * The `SetActionMask` method must now be called on the optional `ActionMasker` argument of the `CollectObservations` method. (We now consider an action mask as a type of observation)
 * The `Monitor` class has been moved to the Examples Project. (It was prone to errors during testing)
 * The `MLAgents.Sensor` namespace has been removed. All sensors now belong to the `MLAgents` namespace.
-* The interface for `RayPerceptionSensor.PerceiveStatic()` was changed to take an input class and write to an output class.
+* The interface for `RayPerceptionSensor.PerceiveStatic()` was changed to take an input class and write to an output class, and the method was renamed to `Perceive()`.
 * The `SetActionMask` method must now be called on the optional `ActionMasker` argument of the `CollectObservations` method. (We now consider an action mask as a type of observation)
 * The method `GetStepCount()` on the Agent class has been replaced with the property getter `StepCount`
 * The `--multi-gpu` option has been removed temporarily.
@@ -23,7 +23,8 @@ The versions can be found in
 * Add the `using MLAgents.Sensors;` in addition to `using MLAgents;` on top of your Agent's script.
 * Replace your Agent's implementation of `CollectObservations()` with `CollectObservations(VectorSensor sensor)`. In addition, replace all calls to `AddVectorObs()` with `sensor.AddObservation()` or `sensor.AddOneHotObservation()` on the `VectorSensor` passed as argument.
 * Replace your calls to `SetActionMask` on your Agent to `ActionMasker.SetActionMask` in `CollectObservations`
-* If you call `RayPerceptionSensor.PerceiveStatic()` manually, add your inputs to a `RayPerceptionInput`. To get the previous float array output, use `RayPerceptionOutput.ToFloatArray()`
+* If you call `RayPerceptionSensor.PerceiveStatic()` manually, add your inputs to a `RayPerceptionInput`. To get the previous float array output,
+ iterate through `RayPerceptionOutput.rayOutputs` and call `RayPerceptionOutput.RayOutput.ToFloatArray()`.
 * Re-import all of your `*.NN` files to work with the updated Barracuda package.
 * Replace all calls to `Agent.GetStepCount()` with `Agent.StepCount`
 


### PR DESCRIPTION
### Proposed change(s)

rename RayPerceptionSensor.PerceiveStatic() to RayPerceptionSensor.Perceive(). Also fix up some migration notes.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
