### PR TITLE
disable compile warning

### DIFF
--- a/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
@@ -30,7 +30,14 @@ namespace MLAgents
         InferenceDevice m_InferenceDevice;
         [HideInInspector]
         [SerializeField]
+
+        // Disable warning /com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs(34,22):
+        //   warning CS0649: Field 'BehaviorParameters.m_BehaviorType' is never assigned to,
+        //   and will always have its default value
+        // This field is set in the custom editor.
+        #pragma warning disable 0649
         BehaviorType m_BehaviorType;
+        #pragma warning restore 0649
         [HideInInspector]
         [SerializeField]
         string m_BehaviorName = "My Behavior";

--- a/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs
@@ -31,7 +31,7 @@ namespace MLAgents
         [HideInInspector]
         [SerializeField]
 
-        // Disable warning /com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs(34,22):
+        // Disable warning /com.unity.ml-agents/Runtime/Policy/BehaviorParameters.cs(...):
         //   warning CS0649: Field 'BehaviorParameters.m_BehaviorType' is never assigned to,
         //   and will always have its default value
         // This field is set in the custom editor.


### PR DESCRIPTION
### Proposed change(s)

Disable that one annoying compiler warning. We set that field in the custom editor.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
