### PR TITLE
Renaming AgentInfo.actionMasks to AgentInfo.DiscreteActionMasks

### DIFF
--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs.meta
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 553b05a1b59a94260b3e545f13190389
+guid: cf19888920fa24df7ad75a52ede51cf3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Unused static methods from the `Utilities` class (ShiftLeft, ReplaceRange, AddRangeNoAlloc, and GetSensorFloatObservationSize) were removed.
  - The `Agent` class is no longer abstract.
  - SensorBase was moved out of the package and into the Examples directory.
+ - `AgentInfo.actionMasks` has been renamed to `AgentInfo.discreteActionMasks`.
 
 
 ## [0.14.1-preview] - 2020-02-25

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -23,7 +23,7 @@ namespace MLAgents
         /// For discrete control, specifies the actions that the agent cannot take. Is true if
         /// the action is masked.
         /// </summary>
-        public bool[] actionMasks;
+        public bool[] discreteActionMasks;
 
         /// <summary>
         /// Current agent reward.
@@ -564,7 +564,7 @@ namespace MLAgents
                     CollectDiscreteActionMasks(m_ActionMasker);
                 }
             }
-            m_Info.actionMasks = m_ActionMasker.GetMask();
+            m_Info.discreteActionMasks = m_ActionMasker.GetMask();
 
             m_Info.reward = m_Reward;
             m_Info.done = false;

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -51,9 +51,9 @@ namespace MLAgents
                 Id = ai.episodeId,
             };
 
-            if (ai.actionMasks != null)
+            if (ai.discreteActionMasks != null)
             {
-                agentInfoProto.ActionMask.AddRange(ai.actionMasks);
+                agentInfoProto.ActionMask.AddRange(ai.discreteActionMasks);
             }
 
             return agentInfoProto;

--- a/com.unity.ml-agents/Runtime/Inference/GeneratorImpl.cs
+++ b/com.unity.ml-agents/Runtime/Inference/GeneratorImpl.cs
@@ -306,7 +306,7 @@ namespace MLAgents.Inference
             foreach (var infoSensorPair in infos)
             {
                 var agentInfo = infoSensorPair.agentInfo;
-                var maskList = agentInfo.actionMasks;
+                var maskList = agentInfo.discreteActionMasks;
                 for (var j = 0; j < maskSize; j++)
                 {
                     var isUnmasked = (maskList != null && maskList[j]) ? 0.0f : 1.0f;

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -65,7 +65,7 @@ namespace MLAgents.Tests
             var agentInfo = new AgentInfo
             {
                 reward = 1f,
-                actionMasks = new[] { false, true },
+                discreteActionMasks = new[] { false, true },
                 done = true,
                 episodeId = 5,
                 maxStepReached = true,

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
@@ -44,13 +44,13 @@ namespace MLAgents.Tests
             var infoA = new AgentInfo
             {
                 storedVectorActions = new[] { 1f, 2f },
-                actionMasks = null
+                discreteActionMasks = null
             };
 
             var infoB = new AgentInfo
             {
                 storedVectorActions = new[] { 3f, 4f },
-                actionMasks = new[] { true, false, false, false, false },
+                discreteActionMasks = new[] { true, false, false, false, false },
             };
 
 

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -20,6 +20,7 @@ The versions can be found in
 * The `SetMask` method must now be called on the `DiscreteActionMasker` argument of the `CollectDiscreteActionMasks` method.
 * The method `GetStepCount()` on the Agent class has been replaced with the property getter `StepCount`
 * The `--multi-gpu` option has been removed temporarily.
+* `AgentInfo.actionMasks` has been renamed to `AgentInfo.discreteActionMasks`.
 
 ### Steps to Migrate
 * Add the `using MLAgents.Sensors;` in addition to `using MLAgents;` on top of your Agent's script.


### PR DESCRIPTION
### Proposed change(s)

Renaming AgentInfo.actionMasks to AgentInfo.DiscreteActionMasks

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://docs.google.com/document/d/1pfSmIIIlo-Far35o-8sYadLjMo3YmHMi4s4qW0z5I-w/edit?ts=5e5758d1

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
