### PR TITLE
check for __init__.py files in python directories.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,9 @@ repos:
         language: script
         entry: utils/validate_versions.py
         files: ".*/__init__.py"
+    -   id: validate-init-py
+        name: validate __init__.py files
+        language: script
+        entry: utils/validate_inits.py
+        types: [python]
+

--- a/utils/validate_inits.py
+++ b/utils/validate_inits.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import os
+import glob
+from setuptools import find_packages, PEP420PackageFinder
+
+
+class NonTrivialPEP420PackageFinder(PEP420PackageFinder):
+    """
+    The PEP420PackageFinder (used by find_namespace_packages) thinks everything
+    looks like a package, even if there are no python files in it. This is a
+    little stricter and only considers directories with python files in it.
+    """
+
+    @staticmethod
+    def _looks_like_package(path):
+        glob_path = os.path.join(path, "*.py")
+        return any(glob.iglob(glob_path))
+
+
+def validate_packages(root_dir):
+    """
+    Makes sure that all python files are discoverable by find_packages(), which
+    is what we use in setup.py. We could potentially use
+    find_namespace_packages instead, but depending on PEP420 has been flaky
+    in the past (particularly with regards to mypy).
+    """
+    exclude = ["*.tests", "*.tests.*", "tests.*", "tests"]
+    found_packages = find_packages(root_dir, exclude=exclude)
+    found_ns_packages = NonTrivialPEP420PackageFinder.find(root_dir, exclude=exclude)
+    assert found_packages, f"Couldn't find anything in directory {root_dir}"
+    if set(found_packages) != set(found_ns_packages):
+        raise RuntimeError(
+            "The following packages are not discoverable using found_packages():\n"
+            f"{set(found_ns_packages) - set(found_packages)}\n"
+            "Make sure you have an __init__.py file in the directories."
+        )
+    else:
+        print(f"__init__.py files for {root_dir} are OK.")
+
+
+def main():
+    for root_dir in ["ml-agents", "ml-agents-envs", "gym-unity"]:
+        validate_packages(root_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
### Proposed change(s)

In 0.14.0, we almost shipped a broken package because of a missing `__init__.py` file. This would have missed the ghost trainer files: https://github.com/Unity-Technologies/ml-agents/blob/master/ml-agents/setup.py#L53 and needed https://github.com/Unity-Technologies/ml-agents/pull/3382 to fix it. 

This adds a pre-commit check for this (in the utils directory since it's a bit "meta").

We _could_ also use find_namespace_packages in setup.py, but I'd prefer to not depend on namespace packages since they've been flaky with our tooling in the past (see MLA-426)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-611 (this test)
https://jira.unity3d.com/browse/MLA-426 (removing namespace package)
https://github.com/Unity-Technologies/ml-agents/pull/3382

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) - add new test

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
