### PR TITLE
Revamped the definition of ActionSize in the BrainParameters

### DIFF
--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -15,6 +15,7 @@ namespace MLAgents.Editor
         const float k_LineHeight = 17f;
         const int k_VecObsNumLine = 3;
         const string k_ActionSizePropName = "vectorActionSize";
+        const string k_ActionBranchesPropName = "discreteActionBranches";
         const string k_ActionTypePropName = "vectorActionSpaceType";
         const string k_ActionDescriptionPropName = "vectorActionDescriptions";
         const string k_VecObsPropName = "vectorObservationSize";
@@ -124,12 +125,9 @@ namespace MLAgents.Editor
         static void DrawContinuousVectorAction(Rect position, SerializedProperty property)
         {
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
-            vecActionSize.arraySize = 1;
-            var continuousActionSize =
-                vecActionSize.GetArrayElementAtIndex(0);
             EditorGUI.PropertyField(
                 position,
-                continuousActionSize,
+                vecActionSize,
                 new GUIContent("Space Size", "Length of continuous action vector."));
         }
 
@@ -142,17 +140,19 @@ namespace MLAgents.Editor
         static void DrawDiscreteVectorAction(Rect position, SerializedProperty property)
         {
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
-            vecActionSize.arraySize = EditorGUI.IntField(
-                position, "Branches Size", vecActionSize.arraySize);
+            var vecBranches = property.FindPropertyRelative(k_ActionBranchesPropName);
+            vecActionSize.intValue = EditorGUI.IntField(
+                position, "Branches Size", vecActionSize.intValue);
+            vecBranches.arraySize = vecActionSize.intValue;
             position.y += k_LineHeight;
             position.x += 20;
             position.width -= 20;
             for (var branchIndex = 0;
-                 branchIndex < vecActionSize.arraySize;
+                 branchIndex < vecBranches.arraySize;
                  branchIndex++)
             {
                 var branchActionSize =
-                    vecActionSize.GetArrayElementAtIndex(branchIndex);
+                    vecBranches.GetArrayElementAtIndex(branchIndex);
 
                 EditorGUI.PropertyField(
                     position,
@@ -169,10 +169,10 @@ namespace MLAgents.Editor
         /// <returns>The height of the drawer of the Vector Action.</returns>
         static float GetHeightDrawVectorAction(SerializedProperty property)
         {
-            var actionSize = 2 + property.FindPropertyRelative(k_ActionSizePropName).arraySize;
-            if (property.FindPropertyRelative(k_ActionTypePropName).enumValueIndex == 0)
+            var actionSize = 3 ;
+            if (property.FindPropertyRelative(k_ActionTypePropName).enumValueIndex == 0) // IE : Discrete
             {
-                actionSize += 1;
+                actionSize += property.FindPropertyRelative(k_ActionBranchesPropName).arraySize;
             }
             return actionSize * k_LineHeight;
         }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -442,16 +442,8 @@ namespace MLAgents
             // should stay the previous action before the Done(), so that it is properly recorded.
             if (m_Action.vectorActions == null)
             {
-                if (param.vectorActionSpaceType == SpaceType.Continuous)
-                {
-                    m_Action.vectorActions = new float[param.vectorActionSize[0]];
-                    m_Info.storedVectorActions = new float[param.vectorActionSize[0]];
-                }
-                else
-                {
-                    m_Action.vectorActions = new float[param.vectorActionSize.Length];
-                    m_Info.storedVectorActions = new float[param.vectorActionSize.Length];
-                }
+                m_Action.vectorActions = new float[param.vectorActionSize];
+                m_Info.storedVectorActions = new float[param.vectorActionSize];
             }
         }
 
@@ -479,11 +471,7 @@ namespace MLAgents
         {
             Debug.LogWarning("Heuristic method called but not implemented. Return placeholder actions.");
             var param = m_PolicyFactory.brainParameters;
-            var actionSize = param.vectorActionSpaceType == SpaceType.Continuous ?
-                param.vectorActionSize[0] :
-                param.vectorActionSize.Length;
-
-            return new float[actionSize];
+            return new float[param.vectorActionSize];
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -122,12 +122,22 @@ namespace MLAgents
         /// <returns>A BrainParameters struct.</returns>
         public static BrainParameters ToBrainParameters(this BrainParametersProto bpp)
         {
+            var actionSizeArray = bpp.VectorActionSize.ToArray();
+
             var bp = new BrainParameters
             {
-                vectorActionSize = bpp.VectorActionSize.ToArray(),
                 vectorActionDescriptions = bpp.VectorActionDescriptions.ToArray(),
                 vectorActionSpaceType = (SpaceType)bpp.VectorActionSpaceType
             };
+            if (bp.vectorActionSpaceType == SpaceType.Continuous)
+            {
+                bp.vectorActionSize = actionSizeArray[0];
+            }
+            else
+            {
+                bp.vectorActionSize = actionSizeArray.Length;
+                bp.discreteActionBranches = actionSizeArray;
+            }
             return bp;
         }
 

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -68,9 +68,13 @@ namespace MLAgents
         /// <param name="isTraining">Whether or not the Brain is training.</param>
         public static BrainParametersProto ToProto(this BrainParameters bp, string name, bool isTraining)
         {
+            int[] actionSize = bp.discreteActionBranches;
+            if (bp.vectorActionSpaceType == SpaceType.Continuous){
+                actionSize = new int[] { bp.vectorActionSize };
+            }
             var brainParametersProto = new BrainParametersProto
             {
-                VectorActionSize = { bp.vectorActionSize },
+                VectorActionSize = {actionSize},
                 VectorActionSpaceType =
                     (SpaceTypeProto)bp.vectorActionSpaceType,
                 BrainName = name,

--- a/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
+++ b/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
@@ -38,11 +38,11 @@ namespace MLAgents
         public void SetMask(int branch, IEnumerable<int> actionIndices)
         {
             // If the branch does not exist, raise an error
-            if (branch >= m_BrainParameters.vectorActionSize.Length)
+            if (branch >= m_BrainParameters.vectorActionSize)
                 throw new UnityAgentsException(
                     "Invalid Action Masking : Branch " + branch + " does not exist.");
 
-            var totalNumberActions = m_BrainParameters.vectorActionSize.Sum();
+            var totalNumberActions = m_BrainParameters.discreteActionBranches.Sum();
 
             // By default, the masks are null. If we want to specify a new mask, we initialize
             // the actionMasks with trues.
@@ -55,13 +55,13 @@ namespace MLAgents
             // indices for each branch.
             if (m_StartingActionIndices == null)
             {
-                m_StartingActionIndices = Utilities.CumSum(m_BrainParameters.vectorActionSize);
+                m_StartingActionIndices = Utilities.CumSum(m_BrainParameters.discreteActionBranches);
             }
 
             // Perform the masking
             foreach (var actionIndex in actionIndices)
             {
-                if (actionIndex >= m_BrainParameters.vectorActionSize[branch])
+                if (actionIndex >= m_BrainParameters.discreteActionBranches[branch])
                 {
                     throw new UnityAgentsException(
                         "Invalid Action Masking: Action Mask is too large for specified branch.");
@@ -96,7 +96,7 @@ namespace MLAgents
                     "Invalid Action Masking : Can only set action mask for Discrete Control.");
             }
 
-            var numBranches = m_BrainParameters.vectorActionSize.Length;
+            var numBranches = m_BrainParameters.vectorActionSize;
             for (var branchIndex = 0; branchIndex < numBranches; branchIndex++)
             {
                 if (AreAllActionsMasked(branchIndex))

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -523,7 +523,7 @@ namespace MLAgents.Inference
         static string CheckPreviousActionShape(
             BrainParameters brainParameters, TensorProxy tensorProxy, SensorComponent[] sensorComponents)
         {
-            var numberActionsBp = brainParameters.vectorActionSize.Length;
+            var numberActionsBp = brainParameters.vectorActionSize;
             var numberActionsT = tensorProxy.shape[tensorProxy.shape.Length - 1];
             if (numberActionsBp != numberActionsT)
             {
@@ -624,7 +624,7 @@ namespace MLAgents.Inference
         static string CheckDiscreteActionOutputShape(
             BrainParameters brainParameters, TensorShape shape, int modelActionSize)
         {
-            var bpActionSize = brainParameters.vectorActionSize.Sum();
+            var bpActionSize = brainParameters.discreteActionBranches.Sum();
             if (modelActionSize != bpActionSize)
             {
                 return "Action Size of the model does not match. The BrainParameters expect " +
@@ -649,7 +649,7 @@ namespace MLAgents.Inference
         static string CheckContinuousActionOutputShape(
             BrainParameters brainParameters, TensorShape shape, int modelActionSize)
         {
-            var bpActionSize = brainParameters.vectorActionSize[0];
+            var bpActionSize = brainParameters.vectorActionSize;
             if (modelActionSize != bpActionSize)
             {
                 return "Action Size of the model does not match. The BrainParameters expect " +

--- a/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
@@ -58,7 +58,7 @@ namespace MLAgents.Inference
             else
             {
                 m_Dict[TensorNames.ActionOutput] =
-                    new DiscreteActionOutputApplier(bp.vectorActionSize, seed, allocator);
+                    new DiscreteActionOutputApplier(bp.discreteActionBranches, seed, allocator);
             }
             m_Dict[TensorNames.RecurrentOutput] = new MemoryOutputApplier(memories);
 

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -39,10 +39,14 @@ namespace MLAgents.Policies
         [Range(1, 50)] public int numStackedVectorObservations = 1;
 
         /// <summary>
-        /// If continuous : The length of the float vector that represents the action.
-        /// If discrete : The number of possible values the action can take.
+        /// The length of the float vector that represents the action.
         /// </summary>
-        public int[] vectorActionSize = new[] {1};
+        public int vectorActionSize = 1;
+
+        /// <summary>
+        /// For discrete only: The number of possible options per action branches
+        /// </summary>
+        public int[] discreteActionBranches = new[] {1};
 
         /// <summary>
         /// The list of strings describing what the actions correspond to.
@@ -64,7 +68,8 @@ namespace MLAgents.Policies
             {
                 vectorObservationSize = vectorObservationSize,
                 numStackedVectorObservations = numStackedVectorObservations,
-                vectorActionSize = (int[])vectorActionSize.Clone(),
+                vectorActionSize = vectorActionSize,
+                discreteActionBranches = (int[])discreteActionBranches?.Clone(),
                 vectorActionDescriptions = (string[])vectorActionDescriptions.Clone(),
                 vectorActionSpaceType = vectorActionSpaceType
             };

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -46,7 +46,8 @@ namespace MLAgents.Tests
             bp.brainParameters.vectorObservationSize = 3;
             bp.brainParameters.numStackedVectorObservations = 2;
             bp.brainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bp.brainParameters.vectorActionSize = new[] { 2, 2 };
+            bp.brainParameters.vectorActionSize = 2;
+            bp.brainParameters.discreteActionBranches = new[] { 2, 2 };
             bp.brainParameters.vectorActionSpaceType = SpaceType.Discrete;
 
             var agent = gameobj.AddComponent<TestAgent>();
@@ -103,7 +104,8 @@ namespace MLAgents.Tests
             bpA.brainParameters.vectorObservationSize = 3;
             bpA.brainParameters.numStackedVectorObservations = 1;
             bpA.brainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bpA.brainParameters.vectorActionSize = new[] { 2, 2 };
+            bpA.brainParameters.vectorActionSize = 2;
+            bpA.brainParameters.discreteActionBranches = new[] { 2, 2 };
             bpA.brainParameters.vectorActionSpaceType = SpaceType.Discrete;
 
             agentGo1.AddComponent<ObservationAgent>();

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
@@ -18,7 +18,7 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters();
             bp.vectorActionSpaceType = SpaceType.Continuous;
-            bp.vectorActionSize = new[] {4};
+            bp.vectorActionSize = 4;
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(0, new[] {0});
             Assert.Catch<UnityAgentsException>(() => masker.GetMask());
@@ -39,7 +39,8 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters();
             bp.vectorActionSpaceType = SpaceType.Discrete;
-            bp.vectorActionSize = new[] {4, 5, 6};
+            bp.vectorActionSize = 3;
+            bp.discreteActionBranches = new[] {4, 5, 6};
             var masker = new DiscreteActionMasker(bp);
             var mask = masker.GetMask();
             Assert.IsNull(mask);
@@ -59,7 +60,8 @@ namespace MLAgents.Tests
             var bp = new BrainParameters
             {
                 vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                vectorActionSize = 3,
+                discreteActionBranches = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(1, new[] {1, 2, 3});
@@ -79,7 +81,8 @@ namespace MLAgents.Tests
             var bp = new BrainParameters
             {
                 vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                vectorActionSize = 3,
+                discreteActionBranches = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(1, new[] {1, 2, 3});
@@ -97,7 +100,8 @@ namespace MLAgents.Tests
             var bp = new BrainParameters
             {
                 vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                vectorActionSize = 3,
+                discreteActionBranches = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
 
@@ -120,7 +124,8 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters();
             bp.vectorActionSpaceType = SpaceType.Discrete;
-            bp.vectorActionSize = new[] {4, 5, 6};
+            bp.vectorActionSize = 3;
+            bp.discreteActionBranches = new[] { 4, 5, 6 };
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(0, new[] {0, 1});
             masker.SetMask(0, new[] {3});

--- a/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
@@ -23,7 +23,7 @@ namespace MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.vectorObservationSize = 8;
-            validBrainParameters.vectorActionSize = new int[] { 2 };
+            validBrainParameters.vectorActionSize = 2;
             validBrainParameters.numStackedVectorObservations = 1;
             validBrainParameters.vectorActionSpaceType = SpaceType.Continuous;
             return validBrainParameters;
@@ -33,7 +33,8 @@ namespace MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.vectorObservationSize = 0;
-            validBrainParameters.vectorActionSize = new int[] { 2, 3 };
+            validBrainParameters.vectorActionSize = 2;
+            validBrainParameters.discreteActionBranches = new int[] { 2, 3 };
             validBrainParameters.numStackedVectorObservations = 1;
             validBrainParameters.vectorActionSpaceType = SpaceType.Discrete;
             return validBrainParameters;
@@ -94,7 +95,7 @@ namespace MLAgents.Tests
             Assert.IsNotNull(modelRunner.GetAction(1));
             Assert.IsNotNull(modelRunner.GetAction(2));
             Assert.IsNull(modelRunner.GetAction(3));
-            Assert.AreEqual(brainParameters.vectorActionSize.Count(), modelRunner.GetAction(1).Count());
+            Assert.AreEqual(brainParameters.vectorActionSize, modelRunner.GetAction(1).Count());
             modelRunner.Dispose();
         }
     }

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -84,7 +84,7 @@ namespace MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.vectorObservationSize = 8;
-            validBrainParameters.vectorActionSize = new int[] { 2 };
+            validBrainParameters.vectorActionSize = 2;
             validBrainParameters.numStackedVectorObservations = 1;
             validBrainParameters.vectorActionSpaceType = SpaceType.Continuous;
             return validBrainParameters;
@@ -94,7 +94,8 @@ namespace MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.vectorObservationSize = 0;
-            validBrainParameters.vectorActionSize = new int[] { 2, 3 };
+            validBrainParameters.discreteActionBranches = new int[] { 2, 3 };
+            validBrainParameters.vectorActionSize = 2;
             validBrainParameters.numStackedVectorObservations = 1;
             validBrainParameters.vectorActionSpaceType = SpaceType.Discrete;
             return validBrainParameters;
@@ -223,7 +224,7 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(continuous2vis8vec2actionModel);
 
             var brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.vectorActionSize = new int[] { 3 }; // Invalid action
+            brainParameters.vectorActionSize = 3; // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 });
             Assert.Greater(errors.Count(), 0);
 
@@ -239,7 +240,7 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(discrete1vis0vec_2_3action_recurrModel);
 
             var brainParameters = GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters();
-            brainParameters.vectorActionSize = new int[] { 3, 3 }; // Invalid action
+            brainParameters.discreteActionBranches = new int[] { 3, 3 }; // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 });
             Assert.Greater(errors.Count(), 0);
 


### PR DESCRIPTION


### Proposed change(s)

 - ActionSize of BrainParameters is now an int (corresponds to the size of the action array)
 - Added a DiscreteActionBranches that is an int[] just for the discrete case

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
This will be breaking when upgrading the repo as I have not figured out how to convert an old BrainParameter to a new one
The scenes are currently broken