### PR TITLE
Add timestamps to logs

### DIFF
--- a/ml-agents-envs/mlagents_envs/communicator.py
+++ b/ml-agents-envs/mlagents_envs/communicator.py
@@ -1,10 +1,6 @@
-import logging
 from typing import Optional
-
 from mlagents_envs.communicator_objects.unity_output_pb2 import UnityOutputProto
 from mlagents_envs.communicator_objects.unity_input_pb2 import UnityInputProto
-
-logger = logging.getLogger("mlagents_envs")
 
 
 class Communicator(object):

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -46,7 +46,7 @@ from sys import platform
 import signal
 import struct
 
-logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger("mlagents_envs")
 
 

--- a/ml-agents-envs/mlagents_envs/exception.py
+++ b/ml-agents-envs/mlagents_envs/exception.py
@@ -1,8 +1,3 @@
-import logging
-
-logger = logging.getLogger("mlagents_envs")
-
-
 class UnityException(Exception):
     """
     Any error related to ml-agents environment.

--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -1,4 +1,3 @@
-import logging
 import grpc
 from typing import Optional
 
@@ -15,8 +14,6 @@ from mlagents_envs.communicator_objects.unity_message_pb2 import UnityMessagePro
 from mlagents_envs.communicator_objects.unity_input_pb2 import UnityInputProto
 from mlagents_envs.communicator_objects.unity_output_pb2 import UnityOutputProto
 from .exception import UnityTimeOutException, UnityWorkerInUseException
-
-logger = logging.getLogger("mlagents_envs")
 
 
 class UnityToExternalServicerImplementation(UnityToExternalProtoServicer):

--- a/ml-agents-envs/mlagents_envs/rpc_utils.py
+++ b/ml-agents-envs/mlagents_envs/rpc_utils.py
@@ -7,13 +7,10 @@ from mlagents_envs.communicator_objects.observation_pb2 import (
     NONE as COMPRESSION_NONE,
 )
 from mlagents_envs.communicator_objects.brain_parameters_pb2 import BrainParametersProto
-import logging
 import numpy as np
 import io
 from typing import cast, List, Tuple, Union, Collection, Optional, Iterable
 from PIL import Image
-
-logger = logging.getLogger("mlagents_envs")
 
 
 def agent_group_spec_from_proto(

--- a/ml-agents/mlagents/logging_util.py
+++ b/ml-agents/mlagents/logging_util.py
@@ -1,0 +1,17 @@
+import logging
+
+
+def create_logger(name):
+    log_level = logging.INFO
+    log_format = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
+    logging.basicConfig(level=log_level, format=log_format, datefmt="%Y-%m-%d %H:%M:%S")
+    logger = logging.getLogger(name=name)
+    return logger
+
+
+# TODO
+"""
+1. change mlagents.trainers to mlagents_trainers
+2. logger should be in lowercase in all files
+3. if logger is not used in a file then it should be deleted
+"""

--- a/ml-agents/mlagents/logging_util.py
+++ b/ml-agents/mlagents/logging_util.py
@@ -1,8 +1,7 @@
 import logging
 
 
-def create_logger(name):
-    log_level = logging.INFO
+def create_logger(name, log_level=logging.INFO):
     date_format = "%Y-%m-%d %H:%M:%S"
     log_format = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
 

--- a/ml-agents/mlagents/logging_util.py
+++ b/ml-agents/mlagents/logging_util.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def create_logger(name, log_level=logging.INFO):
+def create_logger(name, log_level):
     date_format = "%Y-%m-%d %H:%M:%S"
     log_format = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
 

--- a/ml-agents/mlagents/logging_util.py
+++ b/ml-agents/mlagents/logging_util.py
@@ -3,15 +3,9 @@ import logging
 
 def create_logger(name):
     log_level = logging.INFO
+    date_format = "%Y-%m-%d %H:%M:%S"
     log_format = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
-    logging.basicConfig(level=log_level, format=log_format, datefmt="%Y-%m-%d %H:%M:%S")
+
+    logging.basicConfig(level=log_level, format=log_format, datefmt=date_format)
     logger = logging.getLogger(name=name)
     return logger
-
-
-# TODO
-"""
-1. change mlagents.trainers to mlagents_trainers
-2. logger should be in lowercase in all files
-3. if logger is not used in a file then it should be deleted
-"""

--- a/ml-agents/mlagents/trainers/brain.py
+++ b/ml-agents/mlagents/trainers/brain.py
@@ -1,10 +1,6 @@
-import logging
-
 from mlagents_envs.communicator_objects.agent_info_pb2 import AgentInfoProto
 from mlagents_envs.communicator_objects.brain_parameters_pb2 import BrainParametersProto
 from typing import List, NamedTuple
-
-logger = logging.getLogger("mlagents.trainers")
 
 
 class CameraResolution(NamedTuple):

--- a/ml-agents/mlagents/trainers/components/reward_signals/gail/signal.py
+++ b/ml-agents/mlagents/trainers/components/reward_signals/gail/signal.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List
-import logging
 import numpy as np
 from mlagents.tf_utils import tf
 
@@ -7,8 +6,6 @@ from mlagents.trainers.components.reward_signals import RewardSignal, RewardSign
 from mlagents.trainers.policy.tf_policy import TFPolicy
 from .model import GAILModel
 from mlagents.trainers.demo_loader import demo_to_buffer
-
-LOGGER = logging.getLogger("mlagents.trainers")
 
 
 class GAILRewardSignal(RewardSignal):

--- a/ml-agents/mlagents/trainers/components/reward_signals/reward_signal_factory.py
+++ b/ml-agents/mlagents/trainers/components/reward_signals/reward_signal_factory.py
@@ -1,6 +1,4 @@
-import logging
 from typing import Any, Dict, Type
-
 from mlagents.trainers.exception import UnityTrainerException
 from mlagents.trainers.components.reward_signals import RewardSignal
 from mlagents.trainers.components.reward_signals.extrinsic.signal import (
@@ -11,8 +9,6 @@ from mlagents.trainers.components.reward_signals.curiosity.signal import (
     CuriosityRewardSignal,
 )
 from mlagents.trainers.policy.tf_policy import TFPolicy
-
-logger = logging.getLogger("mlagents.trainers")
 
 
 NAME_TO_CLASS: Dict[str, Type[RewardSignal]] = {

--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import List, Tuple
 import numpy as np
@@ -20,9 +19,6 @@ from mlagents_envs.communicator_objects.demonstration_meta_pb2 import (
 )
 from mlagents_envs.timers import timed, hierarchical_timer
 from google.protobuf.internal.decoder import _DecodeVarint32  # type: ignore
-
-
-logger = logging.getLogger("mlagents.trainers")
 
 
 @timed

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -1,7 +1,6 @@
 # # Unity ML-Agents Toolkit
 # ## ML-Agent Learning (Ghost Trainer)
 
-# import logging
 from typing import Deque, Dict, List, Any, cast
 
 import numpy as np
@@ -15,7 +14,7 @@ from mlagents.trainers.trainer import Trainer
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.agent_processor import AgentManagerQueue
 
-LOGGER = logging.getLogger("mlagents.trainers")
+logger = logging.getLogger("mlagents.trainers")
 
 
 class GhostTrainer(Trainer):
@@ -93,7 +92,7 @@ class GhostTrainer(Trainer):
         Saves training statistics to Tensorboard.
         """
         opponents = np.array(self.policy_elos, dtype=np.float32)
-        LOGGER.info(
+        logger.info(
             " Learning brain {} ELO: {:0.3f}\n"
             "Mean Opponent ELO: {:0.3f}"
             " Std Opponent ELO: {:0.3f}".format(
@@ -234,7 +233,7 @@ class GhostTrainer(Trainer):
                 x = "current"
                 self.policy_elos[-1] = self.current_elo
             self.current_opponent = -1 if x == "current" else x
-            LOGGER.debug(
+            logger.debug(
                 "Step {}: Swapping snapshot {} to id {} with {} learning".format(
                     self.get_step, x, name_behavior_id, self.learning_behavior_name
                 )

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -451,16 +451,14 @@ def run_cli(options: RunOptions) -> None:
     except Exception:
         print("\n\n\tUnity Technologies\n")
     print(get_version_string())
-    trainer_logger = create_logger("mlagents.trainers")
-    env_logger = create_logger("mlagents_envs")
+    trainer_logger = create_logger("mlagents.trainers", log_level=logging.INFO)
+    env_logger = create_logger("mlagents_envs", log_level=logging.INFO)
 
     if options.debug:
         trainer_logger.setLevel("DEBUG")
         env_logger.setLevel("DEBUG")
     else:
-        trainer_logger.setLevel("INFO")
-        env_logger.setLevel("INFO")
-        # disable noisy warnings from tensorflow.
+        # disable noisy warnings from tensorflow
         tf_utils.set_warnings_enabled(False)
 
     trainer_logger.debug("Configuration for this run:")

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -451,15 +451,15 @@ def run_cli(options: RunOptions) -> None:
     except Exception:
         print("\n\n\tUnity Technologies\n")
     print(get_version_string())
-    trainer_logger = create_logger("mlagents.trainers", log_level=logging.INFO)
-    env_logger = create_logger("mlagents_envs", log_level=logging.INFO)
 
     if options.debug:
-        trainer_logger.setLevel("DEBUG")
-        env_logger.setLevel("DEBUG")
+        log_level = logging.DEBUG
     else:
+        log_level = logging.INFO
         # disable noisy warnings from tensorflow
         tf_utils.set_warnings_enabled(False)
+
+    trainer_logger = create_logger("mlagents.trainers", log_level)
 
     trainer_logger.debug("Configuration for this run:")
     trainer_logger.debug(json.dumps(options._asdict(), indent=4))

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -30,6 +30,7 @@ from mlagents.trainers.subprocess_env_manager import SubprocessEnvManager
 from mlagents_envs.side_channel.side_channel import SideChannel
 from mlagents_envs.side_channel.engine_configuration_channel import EngineConfig
 from mlagents_envs.exception import UnityEnvironmentException
+from mlagents.logging_util import create_logger
 
 
 def _create_parser():
@@ -450,8 +451,8 @@ def run_cli(options: RunOptions) -> None:
     except Exception:
         print("\n\n\tUnity Technologies\n")
     print(get_version_string())
-    trainer_logger = logging.getLogger("mlagents.trainers")
-    env_logger = logging.getLogger("mlagents_envs")
+    trainer_logger = create_logger("mlagents.trainers")
+    env_logger = create_logger("mlagents_envs")
 
     if options.debug:
         trainer_logger.setLevel("DEBUG")

--- a/ml-agents/mlagents/trainers/models.py
+++ b/ml-agents/mlagents/trainers/models.py
@@ -1,4 +1,3 @@
-import logging
 from enum import Enum
 from typing import Callable, Dict, List, Tuple, NamedTuple
 
@@ -7,8 +6,6 @@ from mlagents.tf_utils import tf
 
 from mlagents.trainers.exception import UnityTrainerException
 from mlagents.trainers.brain import CameraResolution
-
-logger = logging.getLogger("mlagents.trainers")
 
 ActivationFunction = Callable[[tf.Tensor], tf.Tensor]
 EncoderFunction = Callable[

--- a/ml-agents/mlagents/trainers/policy/nn_policy.py
+++ b/ml-agents/mlagents/trainers/policy/nn_policy.py
@@ -1,8 +1,5 @@
-import logging
 from typing import Any, Dict, Optional, List
-
 from mlagents.tf_utils import tf
-
 from mlagents_envs.timers import timed
 from mlagents_envs.base_env import BatchedStepResult
 from mlagents.trainers.brain import BrainParameters
@@ -13,8 +10,6 @@ from mlagents.trainers.distributions import (
     GaussianDistribution,
     MultiCategoricalDistribution,
 )
-
-logger = logging.getLogger("mlagents.trainers")
 
 EPSILON = 1e-6  # Small value to avoid divide by zero
 

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -1,12 +1,9 @@
 import logging
 from typing import Any, Dict, List, Optional
-
 import abc
 import numpy as np
-
 from mlagents.tf_utils import tf
 from mlagents import tf_utils
-
 from mlagents_envs.exception import UnityException
 from mlagents.trainers.policy import Policy
 from mlagents.trainers.action_info import ActionInfo

--- a/ml-agents/mlagents/trainers/ppo/optimizer.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer.py
@@ -1,6 +1,4 @@
-import logging
 from typing import Optional, Any, Dict
-
 import numpy as np
 from mlagents.tf_utils import tf
 from mlagents_envs.timers import timed
@@ -8,9 +6,6 @@ from mlagents.trainers.models import ModelUtils, EncoderType, LearningRateSchedu
 from mlagents.trainers.policy.tf_policy import TFPolicy
 from mlagents.trainers.optimizer.tf_optimizer import TFOptimizer
 from mlagents.trainers.buffer import AgentBuffer
-
-
-logger = logging.getLogger("mlagents.trainers")
 
 
 class PPOOptimizer(TFOptimizer):

--- a/ml-agents/mlagents/trainers/sac/network.py
+++ b/ml-agents/mlagents/trainers/sac/network.py
@@ -1,8 +1,5 @@
-import logging
 from typing import Dict, Optional
-
 from mlagents.tf_utils import tf
-
 from mlagents.trainers.models import ModelUtils, EncoderType
 
 LOG_STD_MAX = 2
@@ -10,9 +7,6 @@ LOG_STD_MIN = -20
 EPSILON = 1e-6  # Small value to avoid divide by zero
 DISCRETE_TARGET_ENTROPY_SCALE = 0.2  # Roughly equal to e-greedy 0.05
 CONTINUOUS_TARGET_ENTROPY_SCALE = 1.0  # TODO: Make these an optional hyperparam.
-
-LOGGER = logging.getLogger("mlagents.trainers")
-
 POLICY_SCOPE = ""
 TARGET_SCOPE = "target_network"
 

--- a/ml-agents/mlagents/trainers/sac/optimizer.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer.py
@@ -13,7 +13,7 @@ from mlagents_envs.timers import timed
 
 EPSILON = 1e-6  # Small value to avoid divide by zero
 
-LOGGER = logging.getLogger("mlagents.trainers")
+logger = logging.getLogger("mlagents.trainers")
 
 POLICY_SCOPE = ""
 TARGET_SCOPE = "target_network"
@@ -477,15 +477,15 @@ class SACOptimizer(TFOptimizer):
                 self.target_network.value_vars, self.policy_network.value_vars
             )
         ]
-        LOGGER.debug("value_vars")
+        logger.debug("value_vars")
         self.print_all_vars(self.policy_network.value_vars)
-        LOGGER.debug("targvalue_vars")
+        logger.debug("targvalue_vars")
         self.print_all_vars(self.target_network.value_vars)
-        LOGGER.debug("critic_vars")
+        logger.debug("critic_vars")
         self.print_all_vars(self.policy_network.critic_vars)
-        LOGGER.debug("q_vars")
+        logger.debug("q_vars")
         self.print_all_vars(self.policy_network.q_vars)
-        LOGGER.debug("policy_vars")
+        logger.debug("policy_vars")
         policy_vars = self.policy.get_trainable_variables()
         self.print_all_vars(policy_vars)
 
@@ -513,7 +513,7 @@ class SACOptimizer(TFOptimizer):
 
     def print_all_vars(self, variables):
         for _var in variables:
-            LOGGER.debug(_var)
+            logger.debug(_var)
 
     @timed
     def update(self, batch: AgentBuffer, num_sequences: int) -> Dict[str, float]:

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -1,5 +1,4 @@
 # # Unity ML-Agents Toolkit
-import logging
 from typing import Dict
 from collections import defaultdict
 
@@ -8,8 +7,6 @@ from mlagents.trainers.buffer import AgentBuffer
 from mlagents.trainers.trainer import Trainer
 from mlagents.trainers.exception import UnityTrainerException
 from mlagents.trainers.components.reward_signals import RewardSignalResult
-
-LOGGER = logging.getLogger("mlagents.trainers")
 
 RewardSignalResults = Dict[str, RewardSignalResult]
 

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -199,7 +199,7 @@ class Trainer(abc.ABC):
         )
         if stats_summary.num > 0:
             LOGGER.info(
-                " {}: {}: Step: {}. "
+                "{}: {}: Step: {}. "
                 "Time Elapsed: {:0.3f} s "
                 "Mean "
                 "Reward: {:0.3f}"

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -20,7 +20,7 @@ from mlagents.trainers.policy import Policy
 from mlagents.trainers.exception import UnityTrainerException
 from mlagents_envs.timers import hierarchical_timer
 
-LOGGER = logging.getLogger("mlagents.trainers")
+logger = logging.getLogger("mlagents.trainers")
 
 
 class Trainer(abc.ABC):
@@ -84,7 +84,7 @@ class Trainer(abc.ABC):
                 s = sess.run(s_op)
                 self.stats_reporter.write_text(s, self.get_step)
         except Exception:
-            LOGGER.info("Could not write text summary for Tensorboard.")
+            logger.info("Could not write text summary for Tensorboard.")
             pass
 
     def _dict_to_str(self, param_dict: Dict[str, Any], num_tabs: int) -> str:
@@ -198,7 +198,7 @@ class Trainer(abc.ABC):
             "Environment/Cumulative Reward"
         )
         if stats_summary.num > 0:
-            LOGGER.info(
+            logger.info(
                 "{}: {}: Step: {}. "
                 "Time Elapsed: {:0.3f} s "
                 "Mean "
@@ -215,7 +215,7 @@ class Trainer(abc.ABC):
             )
             set_gauge(f"{self.brain_name}.mean_reward", stats_summary.mean)
         else:
-            LOGGER.info(
+            logger.info(
                 " {}: {}: Step: {}. No episode was completed since last summary. {}".format(
                     self.run_id, self.brain_name, step, is_training
                 )


### PR DESCRIPTION
### Proposed change(s)

1. Modified the current logger to include timestamps.
1. `basicConfig` should be used exactly once. It was used in `environment.py` and `learn.py`. code has been refactored. it is called only in `logging_util.py` now.

Some code cleanup
1. Removed "import logging" statements and loggers from files which do not use them.
1. Minor formatting changes:
   - removed blank lines
   - some uppercase to lowercase conversion to maintain consistency

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-614

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
Here's a sample of the new log format

```2020-03-03 23:56:51.882456: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2020-03-03 23:56:51.897480: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x7faa22c166b0 executing computations on platform Host. Devices:
2020-03-03 23:56:51.897496: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): Host, Default Version
2020-03-03 23:57:04 INFO [trainer.py:213] 3dball-no-logging3: 3DBall: Step: 12000. Time Elapsed: 12.269 s Mean Reward: 1.198. Std of Reward: 0.741. Training.
2020-03-03 23:57:17 INFO [trainer.py:213] 3dball-no-logging3: 3DBall: Step: 24000. Time Elapsed: 25.191 s Mean Reward: 1.405. Std of Reward: 0.935. Training.
2020-03-03 23:57:29 INFO [trainer.py:213] 3dball-no-logging3: 3DBall: Step: 36000. Time Elapsed: 37.932 s Mean Reward: 1.851. Std of Reward: 1.286. Training.
