### PR TITLE
[change] Change warning language when adversarial scene is used without self-play

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -233,7 +233,7 @@ class PPOTrainer(RLTrainer):
         """
         if self.policy:
             logger.warning(
-                "Your scene contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
+                "Your environment contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
                     train adversarial games.".format(
                     self.__class__.__name__
                 )

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -233,7 +233,8 @@ class PPOTrainer(RLTrainer):
         """
         if self.policy:
             logger.warning(
-                "add_policy has been called twice. {} is not a multi-agent trainer".format(
+                "Your scene contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
+                    train adversarial games.".format(
                     self.__class__.__name__
                 )
             )

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -336,7 +336,7 @@ class SACTrainer(RLTrainer):
         """
         if self.policy:
             logger.warning(
-                "Your scene contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
+                "Your environment contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
                     train adversarial games.".format(
                     self.__class__.__name__
                 )

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -336,7 +336,8 @@ class SACTrainer(RLTrainer):
         """
         if self.policy:
             logger.warning(
-                "add_policy has been called twice. {} is not a multi-agent trainer".format(
+                "Your scene contains multiple teams, but {} doesn't support adversarial games. Enable self-play to \
+                    train adversarial games.".format(
                     self.__class__.__name__
                 )
             )


### PR DESCRIPTION
### Proposed change(s)

The original warning when a normal trainer is used with a self-play environment is confusing and implies that the normal trainers don't support multi-agent (they do, just not versus games). This PR updates the warning. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-732

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
