### PR TITLE
[change] public SensorComponent fields to properties, add custom editor

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The method `GetStepCount()` on the Agent class has been replaced with the property getter `StepCount`
  - `RayPerceptionSensorComponent` and related classes now display the debug gizmos whenever the Agent is selected (not just Play mode).
  - Most fields on `RayPerceptionSensorComponent` can now be changed while the editor is in Play mode. The exceptions to this are fields that affect the number of observations.
+ - Most fields on `CameraSensorComponent` and `RenderTextureSensorComponent` were changed to private and replaced by properties with the same name.
  - Unused static methods from the `Utilities` class (ShiftLeft, ReplaceRange, AddRangeNoAlloc, and GetSensorFloatObservationSize) were removed.
  - The `Agent` class is no longer abstract.
  - SensorBase was moved out of the package and into the Examples directory.

--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using UnityEditor;
+using MLAgents.Sensors;
+
+namespace MLAgents.Editor
+{
+    [CustomEditor(typeof(CameraSensorComponent))]
+    [CanEditMultipleObjects]
+    internal class CameraSensorComponentEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var so = serializedObject;
+            so.Update();
+
+            // Drawing the CameraSensorComponent
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.BeginDisabledGroup(Application.isPlaying);
+            {
+                EditorGUILayout.PropertyField(so.FindProperty("m_Camera"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Width"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Height"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
+            }
+
+            EditorGUI.EndDisabledGroup();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                //
+            }
+
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
@@ -16,24 +16,33 @@ namespace MLAgents.Editor
             // Drawing the CameraSensorComponent
             EditorGUI.BeginChangeCheck();
 
+            EditorGUILayout.PropertyField(so.FindProperty("m_Camera"), true);
             EditorGUI.BeginDisabledGroup(Application.isPlaying);
             {
-                EditorGUILayout.PropertyField(so.FindProperty("m_Camera"), true);
+                // These fields affect the sensor order or observation size,
+                // So can't be changed at runtime.
                 EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Width"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Height"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
-                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
             }
-
             EditorGUI.EndDisabledGroup();
+            EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                //
-            }
-
+            var requireSensorUpdate = EditorGUI.EndChangeCheck();
             so.ApplyModifiedProperties();
+
+            if (requireSensorUpdate)
+            {
+                UpdateSensor();
+            }
         }
+
+        void UpdateSensor()
+        {
+            var sensorComponent = serializedObject.targetObject as CameraSensorComponent;
+            sensorComponent?.UpdateSensor();
+        }
+
     }
 }

--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs.meta
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdda773c024894cf0ae47d1b1396c38d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
+++ b/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
@@ -17,12 +17,12 @@ namespace MLAgents.Editor
             EditorGUI.BeginChangeCheck();
             EditorGUI.indentLevel++;
 
-            EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
-
-            // Because the number of rays and the tags affect the observation shape,
-            // they are not editable during play mode.
+            // Don't allow certain fields to be modified during play mode.
+            // * SensorName affects the ordering of the Agent's observations
+            // * The number of tags and rays affects the size of the observations.
             EditorGUI.BeginDisabledGroup(Application.isPlaying);
             {
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_DetectableTags"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_RaysPerDirection"), true);
             }

--- a/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
+++ b/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
@@ -56,8 +56,8 @@ namespace MLAgents.Editor
                 m_RequireSensorUpdate = true;
             }
 
-            UpdateSensorIfDirty();
             so.ApplyModifiedProperties();
+            UpdateSensorIfDirty();
         }
 
 

--- a/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
@@ -20,17 +20,24 @@ namespace MLAgents.Editor
                 EditorGUILayout.PropertyField(so.FindProperty("m_RenderTexture"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
-                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
             }
-
             EditorGUI.EndDisabledGroup();
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                //
-            }
+            EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
 
+            var requireSensorUpdate = EditorGUI.EndChangeCheck();
             so.ApplyModifiedProperties();
+
+            if (requireSensorUpdate)
+            {
+                UpdateSensor();
+            }
+        }
+
+        void UpdateSensor()
+        {
+            var sensorComponent = serializedObject.targetObject as RenderTextureSensorComponent;
+            sensorComponent?.UpdateSensor();
         }
     }
 }

--- a/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using UnityEditor;
+using MLAgents.Sensors;
+namespace MLAgents.Editor
+{
+    [CustomEditor(typeof(RenderTextureSensorComponent))]
+    [CanEditMultipleObjects]
+    internal class RenderTextureSensorComponentEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var so = serializedObject;
+            so.Update();
+
+            // Drawing the RenderTextureComponent
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.BeginDisabledGroup(Application.isPlaying);
+            {
+                EditorGUILayout.PropertyField(so.FindProperty("m_RenderTexture"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
+            }
+
+            EditorGUI.EndDisabledGroup();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                //
+            }
+
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs.meta
+++ b/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dab309e01d2964f0792de3ef914ca6b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -45,9 +45,7 @@ namespace MLAgents.Policies
         /// <summary>
         /// The team ID for this behavior.
         /// </summary>
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("m_TeamID")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("m_TeamID")]
         public int TeamId;
 
         [FormerlySerializedAs("m_useChildSensors")]

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -16,6 +16,25 @@ namespace MLAgents.Sensors
         SensorCompressionType m_CompressionType;
 
         /// <summary>
+        /// The Camera used for rendering the sensor observations.
+        /// </summary>
+        public Camera camera
+        {
+            get { return m_Camera; }
+            set { m_Camera = value; }
+        }
+
+        /// <summary>
+        /// The compression type used by the sensor.
+        /// </summary>
+        public SensorCompressionType compressionType
+        {
+            get { return m_CompressionType;  }
+            set { m_CompressionType = value; }
+        }
+
+
+        /// <summary>
         /// Creates and returns the camera sensor.
         /// </summary>
         /// <param name="camera">Camera object to capture images from.</param>

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -9,9 +9,7 @@ namespace MLAgents.Sensors
     [AddComponentMenu("ML Agents/Camera Sensor", (int)MenuGroup.Sensors)]
     public class CameraSensorComponent : SensorComponent
     {
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("camera")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("camera")]
         Camera m_Camera;
 
         /// <summary>
@@ -23,9 +21,7 @@ namespace MLAgents.Sensors
             set { m_Camera = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("sensorName")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("sensorName")]
         string m_SensorName = "CameraSensor";
 
         /// <summary>
@@ -37,9 +33,7 @@ namespace MLAgents.Sensors
             internal set { m_SensorName = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("width")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("width")]
         int m_Width = 84;
 
         /// <summary>
@@ -51,9 +45,7 @@ namespace MLAgents.Sensors
             internal set { m_Width = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("height")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("height")]
         int m_Height = 84;
 
         /// <summary>
@@ -65,9 +57,7 @@ namespace MLAgents.Sensors
             internal set { m_Height = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("grayscale")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("grayscale")]
         public bool m_Grayscale;
 
         /// <summary>
@@ -79,9 +69,7 @@ namespace MLAgents.Sensors
             internal set { m_Grayscale = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("compression")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("compression")]
         SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Sensors
 {
@@ -8,35 +9,89 @@ namespace MLAgents.Sensors
     [AddComponentMenu("ML Agents/Camera Sensor", (int)MenuGroup.Sensors)]
     public class CameraSensorComponent : SensorComponent
     {
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("camera")]
+        Camera m_Camera;
+
         /// <summary>
         /// Camera object that provides the data to the sensor.
         /// </summary>
-        public new Camera camera;
+        public new Camera camera
+        {
+            get { return m_Camera;  }
+            set { m_Camera = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("sensorName")]
+        string m_SensorName = "CameraSensor";
 
         /// <summary>
         /// Name of the generated <see cref="CameraSensor"/> object.
         /// </summary>
-        public string sensorName = "CameraSensor";
+        public string sensorName
+        {
+            get { return m_SensorName;  }
+            internal set { m_SensorName = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("width")]
+        int m_Width = 84;
 
         /// <summary>
-        /// Width of the generated image.
+        /// Width of the generated observation.
         /// </summary>
-        public int width = 84;
+        public int width
+        {
+            get { return m_Width;  }
+            internal set { m_Width = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("height")]
+        int m_Height = 84;
 
         /// <summary>
-        /// Height of the generated image.
+        /// Height of the generated observation.
         /// </summary>
-        public int height = 84;
+        public int height
+        {
+            get { return m_Height;  }
+            internal set { m_Height = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("grayscale")]
+        public bool m_Grayscale;
 
         /// <summary>
         /// Whether to generate grayscale images or color.
         /// </summary>
-        public bool grayscale;
+        public bool grayscale
+        {
+            get { return m_Grayscale;  }
+            internal set { m_Grayscale = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("compression")]
+        SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>
         /// The compression type to use for the sensor.
         /// </summary>
-        public SensorCompressionType compression = SensorCompressionType.PNG;
+        public SensorCompressionType compression
+        {
+            get { return m_Compression;  }
+            set { m_Compression = value;  }
+        }
 
         /// <summary>
         /// Creates the <see cref="CameraSensor"/>
@@ -44,7 +99,7 @@ namespace MLAgents.Sensors
         /// <returns>The created <see cref="CameraSensor"/> object for this component.</returns>
         public override ISensor CreateSensor()
         {
-            return new CameraSensor(camera, width, height, grayscale, sensorName, compression);
+            return new CameraSensor(m_Camera, m_Width, m_Height, grayscale, m_SensorName, compression);
         }
 
         /// <summary>
@@ -53,7 +108,7 @@ namespace MLAgents.Sensors
         /// <returns>The observation shape of the associated <see cref="CameraSensor"/> object.</returns>
         public override int[] GetObservationShape()
         {
-            return CameraSensor.GenerateShape(width, height, grayscale);
+            return CameraSensor.GenerateShape(m_Width, m_Height, grayscale);
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -12,13 +12,15 @@ namespace MLAgents.Sensors
         [HideInInspector, SerializeField, FormerlySerializedAs("camera")]
         Camera m_Camera;
 
+        CameraSensor m_Sensor;
+
         /// <summary>
         /// Camera object that provides the data to the sensor.
         /// </summary>
         public new Camera camera
         {
             get { return m_Camera;  }
-            set { m_Camera = value;  }
+            set { m_Camera = value; UpdateSensor(); }
         }
 
         [HideInInspector, SerializeField, FormerlySerializedAs("sensorName")]
@@ -78,7 +80,7 @@ namespace MLAgents.Sensors
         public SensorCompressionType compression
         {
             get { return m_Compression;  }
-            set { m_Compression = value;  }
+            set { m_Compression = value; UpdateSensor(); }
         }
 
         /// <summary>
@@ -87,7 +89,8 @@ namespace MLAgents.Sensors
         /// <returns>The created <see cref="CameraSensor"/> object for this component.</returns>
         public override ISensor CreateSensor()
         {
-            return new CameraSensor(m_Camera, m_Width, m_Height, grayscale, m_SensorName, compression);
+            m_Sensor = new CameraSensor(m_Camera, m_Width, m_Height, grayscale, m_SensorName, compression);
+            return m_Sensor;
         }
 
         /// <summary>
@@ -97,6 +100,18 @@ namespace MLAgents.Sensors
         public override int[] GetObservationShape()
         {
             return CameraSensor.GenerateShape(m_Width, m_Height, grayscale);
+        }
+
+        /// <summary>
+        /// Update fields that are safe to change on the Sensor at runtime.
+        /// </summary>
+        internal void UpdateSensor()
+        {
+            if (m_Sensor != null)
+            {
+                m_Sensor.camera = m_Camera;
+                m_Sensor.compressionType = m_Compression;
+            }
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
@@ -9,9 +9,7 @@ namespace MLAgents.Sensors
     [AddComponentMenu("ML Agents/Ray Perception Sensor 3D", (int)MenuGroup.Sensors)]
     public class RayPerceptionSensorComponent3D : RayPerceptionSensorComponentBase
     {
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("startVerticalOffset")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("startVerticalOffset")]
         [Range(-10f, 10f)]
         [Tooltip("Ray start is offset up or down by this amount.")]
         float m_StartVerticalOffset;
@@ -25,9 +23,7 @@ namespace MLAgents.Sensors
             set { m_StartVerticalOffset = value; UpdateSensor(); }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("endVerticalOffset")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("endVerticalOffset")]
         [Range(-10f, 10f)]
         [Tooltip("Ray end is offset up or down by this amount.")]
         float m_EndVerticalOffset;

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -10,9 +10,7 @@ namespace MLAgents.Sensors
     /// </summary>
     public abstract class RayPerceptionSensorComponentBase : SensorComponent
     {
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("sensorName")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("sensorName")]
         string m_SensorName = "RayPerceptionSensor";
 
         /// <summary>
@@ -25,8 +23,7 @@ namespace MLAgents.Sensors
             internal set => m_SensorName = value;
         }
 
-        [SerializeField]
-        [FormerlySerializedAs("detectableTags")]
+        [SerializeField, FormerlySerializedAs("detectableTags")]
         [Tooltip("List of tags in the scene to compare against.")]
         List<string> m_DetectableTags;
 
@@ -40,9 +37,7 @@ namespace MLAgents.Sensors
             internal set => m_DetectableTags = value;
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("raysPerDirection")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("raysPerDirection")]
         [Range(0, 50)]
         [Tooltip("Number of rays to the left and right of center.")]
         int m_RaysPerDirection = 3;
@@ -57,9 +52,7 @@ namespace MLAgents.Sensors
             internal set => m_RaysPerDirection = value;
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("maxRayDegrees")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("maxRayDegrees")]
         [Range(0, 180)]
         [Tooltip("Cone size for rays. Using 90 degrees will cast rays to the left and right. " +
                  "Greater than 90 degrees will go backwards.")]
@@ -75,9 +68,7 @@ namespace MLAgents.Sensors
             set { m_MaxRayDegrees = value; UpdateSensor(); }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("sphereCastRadius")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("sphereCastRadius")]
         [Range(0f, 10f)]
         [Tooltip("Radius of sphere to cast. Set to zero for raycasts.")]
         float m_SphereCastRadius = 0.5f;
@@ -91,9 +82,7 @@ namespace MLAgents.Sensors
             set { m_SphereCastRadius = value; UpdateSensor(); }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("rayLength")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("rayLength")]
         [Range(1, 1000)]
         [Tooltip("Length of the rays to cast.")]
         float m_RayLength = 20f;
@@ -107,9 +96,7 @@ namespace MLAgents.Sensors
             set { m_RayLength = value; UpdateSensor(); }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("rayLayerMask")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("rayLayerMask")]
         [Tooltip("Controls which layers the rays can hit.")]
         LayerMask m_RayLayerMask = Physics.DefaultRaycastLayers;
 
@@ -122,9 +109,7 @@ namespace MLAgents.Sensors
             set { m_RayLayerMask = value; UpdateSensor();}
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("observationStacks")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("observationStacks")]
         [Range(1, 50)]
         [Tooltip("Whether to stack previous observations. Using 1 means no previous observations.")]
         int m_ObservationStacks = 1;

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -14,6 +14,16 @@ namespace MLAgents.Sensors
         SensorCompressionType m_CompressionType;
 
         /// <summary>
+        /// The compression type used by the sensor.
+        /// </summary>
+        public SensorCompressionType compressionType
+        {
+            get { return m_CompressionType;  }
+            set { m_CompressionType = value; }
+        }
+
+
+        /// <summary>
         /// Initializes the sensor.
         /// </summary>
         /// <param name="renderTexture">The <see cref="RenderTexture"/> instance to wrap.</param>

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -9,6 +9,8 @@ namespace MLAgents.Sensors
     [AddComponentMenu("ML Agents/Render Texture Sensor", (int)MenuGroup.Sensors)]
     public class RenderTextureSensorComponent : SensorComponent
     {
+        RenderTextureSensor m_Sensor;
+
         /// <summary>
         /// The <see cref="RenderTexture"/> instance that the associated
         /// <see cref="RenderTextureSensor"/> wraps.
@@ -55,13 +57,14 @@ namespace MLAgents.Sensors
         public SensorCompressionType compression
         {
             get { return m_Compression;  }
-            set { m_Compression = value;  }
+            set { m_Compression = value; UpdateSensor(); }
         }
 
         /// <inheritdoc/>
         public override ISensor CreateSensor()
         {
-            return new RenderTextureSensor(renderTexture, grayscale, sensorName, compression);
+            m_Sensor = new RenderTextureSensor(renderTexture, grayscale, sensorName, compression);
+            return m_Sensor;
         }
 
         /// <inheritdoc/>
@@ -71,6 +74,17 @@ namespace MLAgents.Sensors
             var height = renderTexture != null ? renderTexture.height : 0;
 
             return new[] { height, width, grayscale ? 1 : 3 };
+        }
+
+        /// <summary>
+        /// Update fields that are safe to change on the Sensor at runtime.
+        /// </summary>
+        internal void UpdateSensor()
+        {
+            if (m_Sensor != null)
+            {
+                m_Sensor.compressionType = m_Compression;
+            }
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -13,9 +13,7 @@ namespace MLAgents.Sensors
         /// The <see cref="RenderTexture"/> instance that the associated
         /// <see cref="RenderTextureSensor"/> wraps.
         /// </summary>
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("renderTexture")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("renderTexture")]
         RenderTexture m_RenderTexture;
 
         public RenderTexture renderTexture
@@ -24,9 +22,7 @@ namespace MLAgents.Sensors
             set { m_RenderTexture = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("sensorName")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("sensorName")]
         string m_SensorName = "RenderTextureSensor";
 
         /// <summary>
@@ -38,9 +34,7 @@ namespace MLAgents.Sensors
             internal set { m_SensorName = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("grayscale")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("grayscale")]
         public bool m_Grayscale;
 
         /// <summary>
@@ -52,9 +46,7 @@ namespace MLAgents.Sensors
             internal set { m_Grayscale = value;  }
         }
 
-        [HideInInspector]
-        [SerializeField]
-        [FormerlySerializedAs("compression")]
+        [HideInInspector, SerializeField, FormerlySerializedAs("compression")]
         SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Sensors
 {
@@ -12,22 +13,58 @@ namespace MLAgents.Sensors
         /// The <see cref="RenderTexture"/> instance that the associated
         /// <see cref="RenderTextureSensor"/> wraps.
         /// </summary>
-        public RenderTexture renderTexture;
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("renderTexture")]
+        RenderTexture m_RenderTexture;
+
+        public RenderTexture renderTexture
+        {
+            get { return m_RenderTexture;  }
+            set { m_RenderTexture = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("sensorName")]
+        string m_SensorName = "RenderTextureSensor";
 
         /// <summary>
-        /// Name of the sensor.
+        /// Name of the generated <see cref="RenderTextureSensor"/>.
         /// </summary>
-        public string sensorName = "RenderTextureSensor";
+        public string sensorName
+        {
+            get { return m_SensorName;  }
+            internal set { m_SensorName = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("grayscale")]
+        public bool m_Grayscale;
 
         /// <summary>
         /// Whether the RenderTexture observation should be converted to grayscale or not.
         /// </summary>
-        public bool grayscale;
+        public bool grayscale
+        {
+            get { return m_Grayscale;  }
+            internal set { m_Grayscale = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("compression")]
+        SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>
         /// Compression type for the render texture observation.
         /// </summary>
-        public SensorCompressionType compression = SensorCompressionType.PNG;
+        public SensorCompressionType compression
+        {
+            get { return m_Compression;  }
+            set { m_Compression = value;  }
+        }
 
         /// <inheritdoc/>
         public override ISensor CreateSensor()


### PR DESCRIPTION
### Proposed change(s)

For both CameraSensorComponent and RenderTextureSensorComponent:
* Move fields to private
* Add properties for the fields (public get, usually internal set)
* CustomEditors

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
