### PR TITLE
RenderTextureSensor+Component unit tests

### DIFF
--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using UnityEditor;
+using MLAgents.Sensors;
+
+namespace MLAgents.Editor
+{
+    [CustomEditor(typeof(CameraSensorComponent))]
+    [CanEditMultipleObjects]
+    internal class CameraSensorComponentEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var so = serializedObject;
+            so.Update();
+
+            // Drawing the CameraSensorComponent
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.BeginDisabledGroup(Application.isPlaying);
+            {
+                EditorGUILayout.PropertyField(so.FindProperty("m_Camera"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Width"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Height"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
+            }
+
+            EditorGUI.EndDisabledGroup();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                //
+            }
+
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
+++ b/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
@@ -17,12 +17,12 @@ namespace MLAgents.Editor
             EditorGUI.BeginChangeCheck();
             EditorGUI.indentLevel++;
 
-            EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
-
-            // Because the number of rays and the tags affect the observation shape,
-            // they are not editable during play mode.
+            // Don't allow certain fields to be modified during play mode.
+            // * SensorName affects the ordering of the Agent's observations
+            // * The number of tags and rays affects the size of the observations.
             EditorGUI.BeginDisabledGroup(Application.isPlaying);
             {
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_DetectableTags"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_RaysPerDirection"), true);
             }

--- a/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using UnityEditor;
+using MLAgents.Sensors;
+namespace MLAgents.Editor
+{
+    [CustomEditor(typeof(RenderTextureSensorComponent))]
+    [CanEditMultipleObjects]
+    internal class RenderTextureSensorComponentEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var so = serializedObject;
+            so.Update();
+
+            // Drawing the RenderTextureComponent
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.BeginDisabledGroup(Application.isPlaying);
+            {
+                EditorGUILayout.PropertyField(so.FindProperty("m_RenderTexture"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_Compression"), true);
+            }
+
+            EditorGUI.EndDisabledGroup();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                //
+            }
+
+            so.ApplyModifiedProperties();
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Sensors
 {
@@ -8,35 +9,89 @@ namespace MLAgents.Sensors
     [AddComponentMenu("ML Agents/Camera Sensor", (int)MenuGroup.Sensors)]
     public class CameraSensorComponent : SensorComponent
     {
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("camera")]
+        Camera m_Camera;
+
         /// <summary>
         /// Camera object that provides the data to the sensor.
         /// </summary>
-        public new Camera camera;
+        public new Camera camera
+        {
+            get { return m_Camera;  }
+            set { m_Camera = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("sensorName")]
+        string m_SensorName = "CameraSensor";
 
         /// <summary>
         /// Name of the generated <see cref="CameraSensor"/> object.
         /// </summary>
-        public string sensorName = "CameraSensor";
+        public string sensorName
+        {
+            get { return m_SensorName;  }
+            internal set { m_SensorName = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("width")]
+        int m_Width = 84;
 
         /// <summary>
-        /// Width of the generated image.
+        /// Width of the generated observation.
         /// </summary>
-        public int width = 84;
+        public int width
+        {
+            get { return m_Width;  }
+            internal set { m_Width = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("height")]
+        int m_Height = 84;
 
         /// <summary>
-        /// Height of the generated image.
+        /// Height of the generated observation.
         /// </summary>
-        public int height = 84;
+        public int height
+        {
+            get { return m_Height;  }
+            internal set { m_Height = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("grayscale")]
+        public bool m_Grayscale;
 
         /// <summary>
         /// Whether to generate grayscale images or color.
         /// </summary>
-        public bool grayscale;
+        public bool grayscale
+        {
+            get { return m_Grayscale;  }
+            internal set { m_Grayscale = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("compression")]
+        SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>
         /// The compression type to use for the sensor.
         /// </summary>
-        public SensorCompressionType compression = SensorCompressionType.PNG;
+        public SensorCompressionType compression
+        {
+            get { return m_Compression;  }
+            set { m_Compression = value;  }
+        }
 
         /// <summary>
         /// Creates the <see cref="CameraSensor"/>
@@ -44,7 +99,7 @@ namespace MLAgents.Sensors
         /// <returns>The created <see cref="CameraSensor"/> object for this component.</returns>
         public override ISensor CreateSensor()
         {
-            return new CameraSensor(camera, width, height, grayscale, sensorName, compression);
+            return new CameraSensor(m_Camera, m_Width, m_Height, grayscale, m_SensorName, compression);
         }
 
         /// <summary>
@@ -53,7 +108,7 @@ namespace MLAgents.Sensors
         /// <returns>The observation shape of the associated <see cref="CameraSensor"/> object.</returns>
         public override int[] GetObservationShape()
         {
-            return CameraSensor.GenerateShape(width, height, grayscale);
+            return CameraSensor.GenerateShape(m_Width, m_Height, grayscale);
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -52,7 +52,7 @@ namespace MLAgents.Sensors
                 var texture = ObservationToTexture(m_RenderTexture);
                 // TODO support more types here, e.g. JPG
                 var compressed = texture.EncodeToPNG();
-                UnityEngine.Object.Destroy(texture);
+                DestroyTexture(texture);
                 return compressed;
             }
         }
@@ -64,7 +64,7 @@ namespace MLAgents.Sensors
             {
                 var texture = ObservationToTexture(m_RenderTexture);
                 var numWritten = Utilities.TextureToTensorProxy(texture, adapter, m_Grayscale);
-                UnityEngine.Object.Destroy(texture);
+                DestroyTexture(texture);
                 return numWritten;
             }
         }
@@ -97,6 +97,20 @@ namespace MLAgents.Sensors
             texture2D.Apply();
             RenderTexture.active = prevActiveRt;
             return texture2D;
+        }
+
+        static void DestroyTexture(Texture2D texture)
+        {
+            if (Application.isEditor)
+            {
+                // Edit Mode tests complain if we use Destroy()
+                // TODO move to extension methods for UnityEngine.Object?
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+            else
+            {
+                UnityEngine.Object.Destroy(texture);
+            }
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Sensors
 {
@@ -12,22 +13,58 @@ namespace MLAgents.Sensors
         /// The <see cref="RenderTexture"/> instance that the associated
         /// <see cref="RenderTextureSensor"/> wraps.
         /// </summary>
-        public RenderTexture renderTexture;
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("renderTexture")]
+        RenderTexture m_RenderTexture;
+
+        public RenderTexture renderTexture
+        {
+            get { return m_RenderTexture;  }
+            set { m_RenderTexture = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("sensorName")]
+        string m_SensorName = "RenderTextureSensor";
 
         /// <summary>
-        /// Name of the sensor.
+        /// Name of the generated <see cref="RenderTextureSensor"/>.
         /// </summary>
-        public string sensorName = "RenderTextureSensor";
+        public string sensorName
+        {
+            get { return m_SensorName;  }
+            internal set { m_SensorName = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("grayscale")]
+        public bool m_Grayscale;
 
         /// <summary>
         /// Whether the RenderTexture observation should be converted to grayscale or not.
         /// </summary>
-        public bool grayscale;
+        public bool grayscale
+        {
+            get { return m_Grayscale;  }
+            internal set { m_Grayscale = value;  }
+        }
+
+        [HideInInspector]
+        [SerializeField]
+        [FormerlySerializedAs("compression")]
+        SensorCompressionType m_Compression = SensorCompressionType.PNG;
 
         /// <summary>
         /// Compression type for the render texture observation.
         /// </summary>
-        public SensorCompressionType compression = SensorCompressionType.PNG;
+        public SensorCompressionType compression
+        {
+            get { return m_Compression;  }
+            set { m_Compression = value;  }
+        }
 
         /// <inheritdoc/>
         public override ISensor CreateSensor()

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSenorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSenorTests.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using MLAgents.Sensors;
+
+namespace MLAgents.Tests
+{
+
+    [TestFixture]
+    public class RenderTextureSensorTest
+    {
+        [Test]
+        public void TestRenderTextureSensor()
+        {
+            foreach (var grayscale in new[] { true, false })
+            {
+                foreach (SensorCompressionType compression in Enum.GetValues(typeof(SensorCompressionType)))
+                {
+                    var width = 24;
+                    var height = 16;
+                    var texture = new RenderTexture(width, height, 0);
+                    var sensor = new RenderTextureSensor(texture, grayscale, "TestCameraSensor", compression);
+
+                    var writeAdapter = new WriteAdapter();
+                    var obs = sensor.GetObservationProto(writeAdapter);
+
+                    Assert.AreEqual((int) compression, (int) obs.CompressionType);
+                    var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
+                    Assert.AreEqual(expectedShape, obs.Shape);
+                }
+            }
+        }
+    }
+}

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSenorTests.cs.meta
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSenorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be9f7d8ce17d8407e92d46fbee2ab809
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
@@ -1,0 +1,42 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using MLAgents.Sensors;
+
+namespace MLAgents.Tests
+{
+
+    [TestFixture]
+    public class RenderTextureSensorComponentTest
+    {
+        [Test]
+        public void TestRenderTextureSensorComponent()
+        {
+            foreach (var grayscale in new[] { true, false })
+            {
+                foreach (SensorCompressionType compression in Enum.GetValues(typeof(SensorCompressionType)))
+                {
+                    var width = 24;
+                    var height = 16;
+                    var texture = new RenderTexture(width, height, 0);
+
+                    var agentGameObj = new GameObject("agent");
+
+                    var renderTexComponent = agentGameObj.AddComponent<RenderTextureSensorComponent>();
+                    renderTexComponent.renderTexture = texture;
+                    renderTexComponent.grayscale = grayscale;
+                    renderTexComponent.compression = compression;
+
+                    var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
+                    Assert.AreEqual(expectedShape, renderTexComponent.GetObservationShape());
+                    Assert.IsTrue(renderTexComponent.IsVisual());
+                    Assert.IsFalse(renderTexComponent.IsVector());
+
+                    var sensor = renderTexComponent.CreateSensor();
+                    Assert.AreEqual(expectedShape, sensor.GetObservationShape());
+                    Assert.AreEqual(typeof(RenderTextureSensor), sensor.GetType());
+                }
+            }
+        }
+    }
+}

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs.meta
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6be53c3cd01244f179a58c96560c54cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Proposed change(s)

Add unit tests for RenderTextureSensor and RenderTextureSensorComponent

(builds off of https://github.com/Unity-Technologies/ml-agents/pull/3564)