### PR TITLE
Messages will be consumed when the side channel registers

### DIFF
--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -506,7 +506,7 @@ namespace MLAgents
             }
 
             var numMessages = m_CachedMessages.Count;
-            for (int i = 0; i< numMessages; i++)
+            for (int i = 0; i < numMessages; i++)
             {
                 var cachedMessage = m_CachedMessages.Dequeue();
                 if (channelId == cachedMessage.ChannelId)

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -504,6 +504,19 @@ namespace MLAgents
                     "A side channel with type index {0} is already registered. You cannot register multiple " +
                     "side channels of the same id.", channelId));
             }
+
+            for (int i = 0; i< m_CachedMessages.Count; i++)
+            {
+                var cachedMessage = m_CachedMessages.Dequeue();
+                if (channelId == cachedMessage.ChannelId)
+                {
+                    sideChannel.OnMessageReceived(cachedMessage.Message);
+                }
+                else
+                {
+                    m_CachedMessages.Enqueue(cachedMessage);
+                }
+            }
             m_SideChannels.Add(channelId, sideChannel);
         }
 

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -505,7 +505,8 @@ namespace MLAgents
                     "side channels of the same id.", channelId));
             }
 
-            for (int i = 0; i< m_CachedMessages.Count; i++)
+            var numMessages = m_CachedMessages.Count;
+            for (int i = 0; i< numMessages; i++)
             {
                 var cachedMessage = m_CachedMessages.Dequeue();
                 if (channelId == cachedMessage.ChannelId)


### PR DESCRIPTION
### Proposed change(s)

Messages will be consumed when the side channel registers

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
