### PR TITLE
[change] Reduce max_steps for PushBlock and Bouncer

### DIFF
--- a/config/sac_trainer_config.yaml
+++ b/config/sac_trainer_config.yaml
@@ -40,7 +40,7 @@ Bouncer:
     summary_freq: 20000
 
 PushBlock:
-    max_steps: 1.5e7
+    max_steps: 2e6
     init_entcoef: 0.05
     hidden_units: 256
     summary_freq: 60000

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -37,7 +37,7 @@ Bouncer:
     hidden_units: 64
 
 PushBlock:
-    max_steps: 1.5e7
+    max_steps: 2.0e6
     batch_size: 128
     buffer_size: 2048
     beta: 1.0e-2

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -32,7 +32,7 @@ FoodCollector:
 
 Bouncer:
     normalize: true
-    max_steps: 7.0e6
+    max_steps: 4.0e6
     num_layers: 2
     hidden_units: 64
 


### PR DESCRIPTION
### Proposed change(s)

PushBlock and Bouncer were running for far more than needed. This PR reduces the max_steps so that cloud runs don't take too long. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
