### PR TITLE
[tests] Add additional unit tests

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_barracuda_converter.py
+++ b/ml-agents/mlagents/trainers/tests/test_barracuda_converter.py
@@ -1,7 +1,12 @@
 import os
 import tempfile
+import pytest
+import yaml
 
 import mlagents.trainers.tensorflow_to_barracuda as tf2bc
+from mlagents.trainers.tests.test_nn_policy import create_policy_mock
+from mlagents.tf_utils import tf
+from mlagents.model_serialization import SerializationSettings, export_policy_model
 
 
 def test_barracuda_converter():
@@ -24,3 +29,58 @@ def test_barracuda_converter():
 
     # cleanup
     os.remove(tmpfile)
+
+
+@pytest.fixture
+def dummy_config():
+    return yaml.safe_load(
+        """
+        trainer: ppo
+        batch_size: 32
+        beta: 5.0e-3
+        buffer_size: 512
+        epsilon: 0.2
+        hidden_units: 128
+        lambd: 0.95
+        learning_rate: 3.0e-4
+        max_steps: 5.0e4
+        normalize: true
+        num_epoch: 5
+        num_layers: 2
+        time_horizon: 64
+        sequence_length: 64
+        summary_freq: 1000
+        use_recurrent: false
+        normalize: true
+        memory_size: 8
+        curiosity_strength: 0.0
+        curiosity_enc_size: 1
+        summary_path: test
+        model_path: test
+        reward_signals:
+          extrinsic:
+            strength: 1.0
+            gamma: 0.99
+        """
+    )
+
+
+@pytest.mark.parametrize("discrete", [True, False], ids=["discrete", "continuous"])
+@pytest.mark.parametrize("visual", [True, False], ids=["visual", "vector"])
+@pytest.mark.parametrize("rnn", [True, False], ids=["rnn", "no_rnn"])
+def test_policy_conversion(dummy_config, tmpdir, rnn, visual, discrete):
+    tf.reset_default_graph()
+    dummy_config["summary_path"] = str(tmpdir)
+    dummy_config["model_path"] = os.path.join(tmpdir, "test")
+    policy = create_policy_mock(
+        dummy_config, use_rnn=rnn, use_discrete=discrete, use_visual=visual
+    )
+    policy.save_model(1000)
+    settings = SerializationSettings(
+        policy.model_path, os.path.join(tmpdir, policy.brain.brain_name)
+    )
+    export_policy_model(settings, policy.graph, policy.sess)
+
+    # These checks taken from test_barracuda_converter
+    assert os.path.isfile(os.path.join(tmpdir, "test.nn"))
+    assert os.path.getsize(os.path.join(tmpdir, "test.nn")) > 100

--- a/ml-agents/mlagents/trainers/tests/test_nn_policy.py
+++ b/ml-agents/mlagents/trainers/tests/test_nn_policy.py
@@ -64,8 +64,6 @@ def create_policy_mock(dummy_config, use_rnn, use_discrete, use_visual):
     )
 
     trainer_parameters = dummy_config
-    model_path = "testmodel"
-    trainer_parameters["model_path"] = model_path
     trainer_parameters["keep_checkpoints"] = 3
     trainer_parameters["use_recurrent"] = use_rnn
     policy = NNPolicy(0, mock_brain, trainer_parameters, False, False)

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -27,7 +27,7 @@ def dummy_config():
         learning_rate: 3.0e-4
         max_steps: 1024
         memory_size: 10
-        normalize: false
+        normalize: true
         num_update: 1
         train_interval: 1
         num_layers: 1

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, MagicMock
 import unittest
 import pytest
 from queue import Empty as EmptyQueue
+import multiprocessing as mp
 
 from mlagents.trainers.subprocess_env_manager import (
     SubprocessEnvManager,
@@ -20,6 +21,8 @@ from mlagents.trainers.tests.test_simple_rl import (
     generate_config,
     DebugWriter,
 )
+
+mp.set_start_method("spawn")  # Prevent breakage in CircleCI
 
 
 def mock_env_factory(worker_id):


### PR DESCRIPTION
### Proposed change(s)

Adds a variety of unit tests to the Python code where we were missing, namely:

- Barracuda export for all NNPolicy configurations
- Error checking for trainer_util
- Using the Normalizer for SAC
- end-to-end test of subprocess env manager

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other - additional unit tests

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
