### PR TITLE
[bug-fix] Re-record GridWorld Demo

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer.py
@@ -537,7 +537,7 @@ class SACOptimizer(TFOptimizer):
         return update_stats
 
     def update_reward_signals(
-        self, reward_signal_minibatches: Mapping[str, AgentBuffer], num_sequences: int
+        self, reward_signal_minibatches: Mapping[str, Dict], num_sequences: int
     ) -> Dict[str, float]:
         """
         Only update the reward signals.
@@ -567,7 +567,7 @@ class SACOptimizer(TFOptimizer):
         feed_dict: Dict[tf.Tensor, Any],
         update_dict: Dict[str, tf.Tensor],
         stats_needed: Dict[str, str],
-        reward_signal_minibatches: Mapping[str, AgentBuffer],
+        reward_signal_minibatches: Mapping[str, Dict],
         num_sequences: int,
     ) -> None:
         """

--- a/ml-agents/mlagents/trainers/sac/optimizer.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer.py
@@ -537,7 +537,7 @@ class SACOptimizer(TFOptimizer):
         return update_stats
 
     def update_reward_signals(
-        self, reward_signal_minibatches: Mapping[str, Dict], num_sequences: int
+        self, reward_signal_minibatches: Mapping[str, AgentBuffer], num_sequences: int
     ) -> Dict[str, float]:
         """
         Only update the reward signals.
@@ -567,7 +567,7 @@ class SACOptimizer(TFOptimizer):
         feed_dict: Dict[tf.Tensor, Any],
         update_dict: Dict[str, tf.Tensor],
         stats_needed: Dict[str, str],
-        reward_signal_minibatches: Mapping[str, Dict],
+        reward_signal_minibatches: Mapping[str, AgentBuffer],
         num_sequences: int,
     ) -> None:
         """


### PR DESCRIPTION
### Proposed change(s)

At some point the GridWorld environment was switched to 84x64 visual obs from 84x84, so the demo files no longer work. This PR updates the demo file. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Need to throw a better error when mismatched: (MLA-745)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
