### PR TITLE
make a few things in RayPerceptionSensorComponent public

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -142,6 +142,14 @@ namespace MLAgents.Sensors
         RayPerceptionSensor m_RaySensor;
 
         /// <summary>
+        /// Get the RayPerceptionSensor that was created.
+        /// </summary>
+        public RayPerceptionSensor raySensor
+        {
+            get => m_RaySensor;
+        }
+
+        /// <summary>
         /// Returns the <see cref="RayPerceptionCastType"/> for the associated raycast sensor.
         /// </summary>
         /// <returns></returns>
@@ -223,7 +231,11 @@ namespace MLAgents.Sensors
             return new[] { obsSize * stacks };
         }
 
-        RayPerceptionInput GetRayPerceptionInput()
+        /// <summary>
+        /// Get the RayPerceptionInput that is used by the <see cref="RayPerceptionSensor"/>.
+        /// </summary>
+        /// <returns></returns>
+        public RayPerceptionInput GetRayPerceptionInput()
         {
             var rayAngles = GetRayAngles(raysPerDirection, maxRayDegrees);
 


### PR DESCRIPTION
### Proposed change(s)
Give a public get property for the sensor, and also make `GetRayPerceptionInput()` public (the latter is probably more useful).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Request from https://github.com/Unity-Technologies/ml-agents/issues/3536.


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
