### PR TITLE
Simplified initial reset logic.

### DIFF
--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -124,9 +124,6 @@ namespace MLAgents
         bool m_Initialized;
         List<ModelRunner> m_ModelRunners = new List<ModelRunner>();
 
-        // Flag used to keep track of the first time the Academy is reset.
-        bool m_FirstAcademyReset;
-
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure
         // that all the agents performs their steps in a consistent order (i.e. no
@@ -437,7 +434,6 @@ namespace MLAgents
         {
             EnvironmentReset();
             AgentForceReset?.Invoke();
-            m_FirstAcademyReset = true;
         }
 
         /// <summary>
@@ -446,11 +442,6 @@ namespace MLAgents
         /// </summary>
         public void EnvironmentStep()
         {
-            if (!m_FirstAcademyReset)
-            {
-                ForcedFullReset();
-            }
-
             AgentSetStatus?.Invoke(m_StepCount);
 
             m_StepCount += 1;

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -430,7 +430,6 @@ namespace MLAgents
         /// </summary>
         void ForcedFullReset()
         {
-            Debug.Log("Forced Full reset");
             EnvironmentReset();
             AgentForceReset?.Invoke();
         }

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -334,6 +334,10 @@ namespace MLAgents
                 // We try to exchange the first message with Python. If this fails, it means
                 // no Python Process is ready to train the environment. In this case, the
                 //environment must use Inference.
+
+                Communicator.QuitCommandReceived += OnQuitCommandReceived;
+                Communicator.ResetCommandReceived += OnResetCommand;
+
                 try
                 {
                     var unityRlInitParameters = Communicator.Initialize(
@@ -352,12 +356,6 @@ namespace MLAgents
                         "Will perform inference instead."
                     );
                     Communicator = null;
-                }
-
-                if (Communicator != null)
-                {
-                    Communicator.QuitCommandReceived += OnQuitCommandReceived;
-                    Communicator.ResetCommandReceived += OnResetCommand;
                 }
             }
 
@@ -432,6 +430,7 @@ namespace MLAgents
         /// </summary>
         void ForcedFullReset()
         {
+            Debug.Log("Forced Full reset");
             EnvironmentReset();
             AgentForceReset?.Invoke();
         }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -283,6 +283,7 @@ namespace MLAgents
             ResetData();
             Initialize();
             InitializeSensors();
+            OnEpisodeBegin();
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -267,17 +267,10 @@ namespace MLAgents.Tests
         {
             var aca = Academy.Instance;
 
-            var numberReset = 0;
             for (var i = 0; i < 10; i++)
             {
-                Assert.AreEqual(numberReset, aca.EpisodeCount);
                 Assert.AreEqual(i, aca.StepCount);
 
-                // The reset happens at the beginning of the first step
-                if (i == 0)
-                {
-                    numberReset += 1;
-                }
                 Academy.Instance.EnvironmentStep();
             }
         }
@@ -313,7 +306,8 @@ namespace MLAgents.Tests
 
             agent1.LazyInitialize();
 
-            var numberAgent1Reset = 0;
+            var numberAgent1Reset = 1; // agent1 resets when initialized
+            var numberAgent2Reset = 0;
             var numberAgent2Initialization = 0;
             var requestDecision = 0;
             var requestAction = 0;
@@ -321,23 +315,19 @@ namespace MLAgents.Tests
             {
                 Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
                 // Agent2 is never reset since initialized after academy
-                Assert.AreEqual(0, agent2.agentResetCalls);
+                Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
                 Assert.AreEqual(1, agent1.initializeAgentCalls);
                 Assert.AreEqual(numberAgent2Initialization, agent2.initializeAgentCalls);
                 Assert.AreEqual(i, agent1.agentActionCalls);
                 Assert.AreEqual(requestAction, agent2.agentActionCalls);
                 Assert.AreEqual((i + 1) / 2, agent1.collectObservationsCalls);
                 Assert.AreEqual(requestDecision, agent2.collectObservationsCalls);
-                // Agent 1 resets at the first step
-                if (i == 0)
-                {
-                    numberAgent1Reset += 1;
-                }
                 //Agent 2 is only initialized at step 2
                 if (i == 2)
                 {
                     agent2.LazyInitialize();
                     numberAgent2Initialization += 1;
+                    numberAgent2Reset += 1;
                 }
 
                 // We are testing request decision and request actions when called
@@ -382,13 +372,7 @@ namespace MLAgents.Tests
             for (var i = 0; i < 50; i++)
             {
                 Assert.AreEqual(stepsSinceReset, aca.StepCount);
-                Assert.AreEqual(numberReset, aca.EpisodeCount);
                 Assert.AreEqual(i, aca.TotalStepCount);
-                // Academy resets at the first step
-                if (i == 0)
-                {
-                    numberReset += 1;
-                }
 
                 stepsSinceReset += 1;
                 aca.EnvironmentStep();
@@ -413,14 +397,12 @@ namespace MLAgents.Tests
             agent2.LazyInitialize();
 
             var numberAgent1Reset = 0;
-            var numberAgent2Reset = 0;
-            var numberAcaReset = 0;
+            var numberAgent2Reset = 1; // Agent2's Episode started
             var acaStepsSinceReset = 0;
             var agent2StepSinceReset = 0;
-            for (var i = 0; i < 5000; i++)
+            for (var i = 0; i < 500; i++)
             {
                 Assert.AreEqual(acaStepsSinceReset, aca.StepCount);
-                Assert.AreEqual(numberAcaReset, aca.EpisodeCount);
 
                 Assert.AreEqual(i, aca.TotalStepCount);
 
@@ -428,16 +410,11 @@ namespace MLAgents.Tests
                 Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
                 Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
 
-                // Agent 2  and academy reset at the first step
-                if (i == 0)
-                {
-                    numberAcaReset += 1;
-                    numberAgent2Reset += 1;
-                }
                 //Agent 1 is only initialized at step 2
                 if (i == 2)
                 {
                     agent1.LazyInitialize();
+                    numberAgent1Reset += 1;
                 }
                 // Set agent 1 to done every 11 steps to test behavior
                 if (i % 11 == 5)

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -335,7 +335,7 @@ class UnityEnvironment(BaseEnv):
         if not self._loaded:
             raise UnityEnvironmentException("No Unity environment is loaded.")
         # fill the blanks for missing actions
-        for group_name in self._env_specs:
+        for group_name in self._env_state:
             if group_name not in self._env_actions:
                 n_agents = 0
                 if group_name in self._env_state:

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -162,7 +162,6 @@ class UnityEnvironment(BaseEnv):
         self._env_state: Dict[str, BatchedStepResult] = {}
         self._env_specs: Dict[str, AgentGroupSpec] = {}
         self._env_actions: Dict[str, np.ndarray] = {}
-        self._is_first_message = True
         self._update_group_specs(aca_output)
 
     @staticmethod
@@ -327,15 +326,12 @@ class UnityEnvironment(BaseEnv):
             self._update_group_specs(outputs)
             rl_output = outputs.rl_output
             self._update_state(rl_output)
-            self._is_first_message = False
             self._env_actions.clear()
         else:
             raise UnityEnvironmentException("No Unity environment is loaded.")
 
     @timed
     def step(self) -> None:
-        if self._is_first_message:
-            return self.reset()
         if not self._loaded:
             raise UnityEnvironmentException("No Unity environment is loaded.")
         # fill the blanks for missing actions

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -205,6 +205,8 @@ class TrainerController(object):
         global_step = 0
         last_brain_behavior_ids: Set[str] = set()
         try:
+            # Initial reset
+            self._reset_env(env_manager)
             while self._not_done_training():
                 external_brain_behavior_ids = set(env_manager.external_brains.keys())
                 new_behavior_ids = external_brain_behavior_ids - last_brain_behavior_ids

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -205,8 +205,6 @@ class TrainerController(object):
         global_step = 0
         last_brain_behavior_ids: Set[str] = set()
         try:
-            # Initial reset
-            self._reset_env(env_manager)
             while self._not_done_training():
                 external_brain_behavior_ids = set(env_manager.external_brains.keys())
                 new_behavior_ids = external_brain_behavior_ids - last_brain_behavior_ids


### PR DESCRIPTION
### Proposed change(s)

Agents will call `OnEpisodeBegin()` when initializing.
The first python command need not be `env.reset()`.
The Academy does not ForceReset when initializing.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

#3058 
[MLA-743](https://jira.unity3d.com/browse/MLA-743)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
