### PR TITLE
Make the agent begin episode at initialization

### DIFF
--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -125,7 +125,7 @@ namespace MLAgents
         List<ModelRunner> m_ModelRunners = new List<ModelRunner>();
 
         // Flag used to keep track of the first time the Academy is reset.
-        internal bool HadFirstReset;
+        bool HadFirstReset;
 
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -125,7 +125,7 @@ namespace MLAgents
         List<ModelRunner> m_ModelRunners = new List<ModelRunner>();
 
         // Flag used to keep track of the first time the Academy is reset.
-        bool HadFirstReset;
+        bool m_HadFirstReset;
 
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure
@@ -437,7 +437,7 @@ namespace MLAgents
         {
             EnvironmentReset();
             AgentForceReset?.Invoke();
-            HadFirstReset = true;
+            m_HadFirstReset = true;
         }
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace MLAgents
         /// </summary>
         public void EnvironmentStep()
         {
-            if (!HadFirstReset)
+            if (!m_HadFirstReset)
             {
                 ForcedFullReset();
             }

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -125,7 +125,7 @@ namespace MLAgents
         List<ModelRunner> m_ModelRunners = new List<ModelRunner>();
 
         // Flag used to keep track of the first time the Academy is reset.
-        bool m_FirstAcademyReset;
+        internal bool FirstAcademyReset;
 
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure
@@ -437,7 +437,7 @@ namespace MLAgents
         {
             EnvironmentReset();
             AgentForceReset?.Invoke();
-            m_FirstAcademyReset = true;
+            FirstAcademyReset = true;
         }
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace MLAgents
         /// </summary>
         public void EnvironmentStep()
         {
-            if (!m_FirstAcademyReset)
+            if (!FirstAcademyReset)
             {
                 ForcedFullReset();
             }

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -125,7 +125,7 @@ namespace MLAgents
         List<ModelRunner> m_ModelRunners = new List<ModelRunner>();
 
         // Flag used to keep track of the first time the Academy is reset.
-        internal bool FirstAcademyReset;
+        internal bool HadFirstReset;
 
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure
@@ -437,7 +437,7 @@ namespace MLAgents
         {
             EnvironmentReset();
             AgentForceReset?.Invoke();
-            FirstAcademyReset = true;
+            HadFirstReset = true;
         }
 
         /// <summary>
@@ -446,7 +446,7 @@ namespace MLAgents
         /// </summary>
         public void EnvironmentStep()
         {
-            if (!FirstAcademyReset)
+            if (!HadFirstReset)
             {
                 ForcedFullReset();
             }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -264,7 +264,7 @@ namespace MLAgents
             // forced to reset through the <see cref="AgentForceReset"/> event.
             // To avoid the Agent resetting twice, the Agents will not begin their
             // episode when initializing until after the Academy had its first reset.
-            if (Academy.Instance.HadFirstReset)
+            if (Academy.Instance.TotalStepCount != 0)
             {
                 OnEpisodeBegin();
             }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -259,7 +259,12 @@ namespace MLAgents
             ResetData();
             Initialize();
             InitializeSensors();
-            if (Academy.Instance.FirstAcademyReset)
+
+            // The first time the Academy resets, all Agents in the scene will be
+            // forced to reset through the <see cref="AgentForceReset"/> event.
+            // To avoid the Agent resetting twice, the Agents will not begin their
+            // episode when initializing until after the Academy had its first reset.
+            if (Academy.Instance.HadFirstReset)
             {
                 OnEpisodeBegin();
             }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -259,6 +259,10 @@ namespace MLAgents
             ResetData();
             Initialize();
             InitializeSensors();
+            if (Academy.Instance.FirstAcademyReset)
+            {
+                OnEpisodeBegin();
+            }
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -337,7 +337,10 @@ namespace MLAgents.Tests
                 //Agent 2 is only initialized at step 2
                 if (i == 2)
                 {
+                    // Since Agent2 is initialized after the Academy has stepped, its OnEpisodeBegin should be called now.
+                    Assert.AreEqual(0, agent2.agentResetCalls);
                     agent2.LazyInitialize();
+                    Assert.AreEqual(1, agent2.agentResetCalls);
                     numberAgent2Initialization += 1;
                     numberAgent2Reset += 1;
                 }

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -314,6 +314,7 @@ namespace MLAgents.Tests
             agent1.LazyInitialize();
 
             var numberAgent1Reset = 0;
+            var numberAgent2Reset = 0;
             var numberAgent2Initialization = 0;
             var requestDecision = 0;
             var requestAction = 0;
@@ -321,7 +322,7 @@ namespace MLAgents.Tests
             {
                 Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
                 // Agent2 is never reset since initialized after academy
-                Assert.AreEqual(0, agent2.agentResetCalls);
+                Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
                 Assert.AreEqual(1, agent1.initializeAgentCalls);
                 Assert.AreEqual(numberAgent2Initialization, agent2.initializeAgentCalls);
                 Assert.AreEqual(i, agent1.agentActionCalls);
@@ -338,6 +339,7 @@ namespace MLAgents.Tests
                 {
                     agent2.LazyInitialize();
                     numberAgent2Initialization += 1;
+                    numberAgent2Reset += 1;
                 }
 
                 // We are testing request decision and request actions when called
@@ -438,6 +440,7 @@ namespace MLAgents.Tests
                 if (i == 2)
                 {
                     agent1.LazyInitialize();
+                    numberAgent1Reset += 1;
                 }
                 // Set agent 1 to done every 11 steps to test behavior
                 if (i % 11 == 5)

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -321,7 +321,6 @@ namespace MLAgents.Tests
             for (var i = 0; i < 50; i++)
             {
                 Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
-                // Agent2 is never reset since initialized after academy
                 Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
                 Assert.AreEqual(1, agent1.initializeAgentCalls);
                 Assert.AreEqual(numberAgent2Initialization, agent2.initializeAgentCalls);

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -43,10 +43,10 @@ namespace MLAgents.Tests
 
         public int initializeAgentCalls;
         public int collectObservationsCalls;
-        public int collectObservationsCallsSinceLastReset;
+        public int collectObservationsCallsForEpisode;
         public int agentActionCalls;
-        public int agentActionCallsSinceLastReset;
-        public int agentResetCalls;
+        public int agentActionCallsForEpisode;
+        public int agentOnEpisodeBeginCalls;
         public int heuristicCalls;
         public TestSensor sensor1;
         public TestSensor sensor2;
@@ -67,22 +67,22 @@ namespace MLAgents.Tests
         public override void CollectObservations(VectorSensor sensor)
         {
             collectObservationsCalls += 1;
-            collectObservationsCallsSinceLastReset += 1;
+            collectObservationsCallsForEpisode += 1;
             sensor.AddObservation(0f);
         }
 
         public override void OnActionReceived(float[] vectorAction)
         {
             agentActionCalls += 1;
-            agentActionCallsSinceLastReset += 1;
+            agentActionCallsForEpisode += 1;
             AddReward(0.1f);
         }
 
         public override void OnEpisodeBegin()
         {
-            agentResetCalls += 1;
-            collectObservationsCallsSinceLastReset = 0;
-            agentActionCallsSinceLastReset = 0;
+            agentOnEpisodeBeginCalls += 1;
+            collectObservationsCallsForEpisode = 0;
+            agentActionCallsForEpisode = 0;
         }
 
         public override float[] Heuristic()
@@ -224,8 +224,8 @@ namespace MLAgents.Tests
             agentGo2.AddComponent<TestAgent>();
             var agent2 = agentGo2.GetComponent<TestAgent>();
 
-            Assert.AreEqual(0, agent1.agentResetCalls);
-            Assert.AreEqual(0, agent2.agentResetCalls);
+            Assert.AreEqual(0, agent1.agentOnEpisodeBeginCalls);
+            Assert.AreEqual(0, agent2.agentOnEpisodeBeginCalls);
             Assert.AreEqual(0, agent1.initializeAgentCalls);
             Assert.AreEqual(0, agent2.initializeAgentCalls);
             Assert.AreEqual(0, agent1.agentActionCalls);
@@ -237,8 +237,8 @@ namespace MLAgents.Tests
 
             // agent1 was not enabled when the academy started
             // The agents have been initialized
-            Assert.AreEqual(0, agent1.agentResetCalls);
-            Assert.AreEqual(0, agent2.agentResetCalls);
+            Assert.AreEqual(0, agent1.agentOnEpisodeBeginCalls);
+            Assert.AreEqual(0, agent2.agentOnEpisodeBeginCalls);
             Assert.AreEqual(1, agent1.initializeAgentCalls);
             Assert.AreEqual(1, agent2.initializeAgentCalls);
             Assert.AreEqual(0, agent1.agentActionCalls);
@@ -313,35 +313,35 @@ namespace MLAgents.Tests
 
             agent1.LazyInitialize();
 
-            var numberAgent1Reset = 0;
-            var numberAgent2Reset = 0;
+            var numberAgent1Episodes = 0;
+            var numberAgent2Episodes = 0;
             var numberAgent2Initialization = 0;
             var requestDecision = 0;
             var requestAction = 0;
             for (var i = 0; i < 50; i++)
             {
-                Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
-                Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
+                Assert.AreEqual(numberAgent1Episodes, agent1.agentOnEpisodeBeginCalls);
+                Assert.AreEqual(numberAgent2Episodes, agent2.agentOnEpisodeBeginCalls);
                 Assert.AreEqual(1, agent1.initializeAgentCalls);
                 Assert.AreEqual(numberAgent2Initialization, agent2.initializeAgentCalls);
                 Assert.AreEqual(i, agent1.agentActionCalls);
                 Assert.AreEqual(requestAction, agent2.agentActionCalls);
                 Assert.AreEqual((i + 1) / 2, agent1.collectObservationsCalls);
                 Assert.AreEqual(requestDecision, agent2.collectObservationsCalls);
-                // Agent 1 resets at the first step
+                // Agent 1 starts a new episode at the first step
                 if (i == 0)
                 {
-                    numberAgent1Reset += 1;
+                    numberAgent1Episodes += 1;
                 }
                 //Agent 2 is only initialized at step 2
                 if (i == 2)
                 {
                     // Since Agent2 is initialized after the Academy has stepped, its OnEpisodeBegin should be called now.
-                    Assert.AreEqual(0, agent2.agentResetCalls);
+                    Assert.AreEqual(0, agent2.agentOnEpisodeBeginCalls);
                     agent2.LazyInitialize();
-                    Assert.AreEqual(1, agent2.agentResetCalls);
+                    Assert.AreEqual(1, agent2.agentOnEpisodeBeginCalls);
                     numberAgent2Initialization += 1;
-                    numberAgent2Reset += 1;
+                    numberAgent2Episodes += 1;
                 }
 
                 // We are testing request decision and request actions when called
@@ -416,46 +416,51 @@ namespace MLAgents.Tests
 
             agent2.LazyInitialize();
 
-            var numberAgent1Reset = 0;
-            var numberAgent2Reset = 0;
+            var numberAgent1Episodes = 0;
+            var numberAgent2Episodes = 0;
             var numberAcaReset = 0;
             var acaStepsSinceReset = 0;
-            var agent2StepSinceReset = 0;
+            var agent2StepForEpisode = 0;
             for (var i = 0; i < 5000; i++)
             {
                 Assert.AreEqual(acaStepsSinceReset, aca.StepCount);
                 Assert.AreEqual(numberAcaReset, aca.EpisodeCount);
 
                 Assert.AreEqual(i, aca.TotalStepCount);
+                Assert.AreEqual(numberAgent2Episodes, agent2.agentOnEpisodeBeginCalls);
+                Assert.AreEqual(agent2StepForEpisode, agent2.StepCount);
 
-                Assert.AreEqual(agent2StepSinceReset, agent2.StepCount);
-                Assert.AreEqual(numberAgent1Reset, agent1.agentResetCalls);
-                Assert.AreEqual(numberAgent2Reset, agent2.agentResetCalls);
-
-                // Agent 2  and academy reset at the first step
+                // Agent 2 and academy reset at the first step
                 if (i == 0)
                 {
+                    Assert.AreEqual(numberAgent2Episodes, agent2.agentOnEpisodeBeginCalls);
                     numberAcaReset += 1;
-                    numberAgent2Reset += 1;
+                    numberAgent2Episodes += 1;
                 }
                 //Agent 1 is only initialized at step 2
                 if (i == 2)
                 {
+                    Assert.AreEqual(numberAgent1Episodes, agent1.agentOnEpisodeBeginCalls);
                     agent1.LazyInitialize();
-                    numberAgent1Reset += 1;
+                    numberAgent1Episodes += 1;
+                    Assert.AreEqual(numberAgent1Episodes, agent1.agentOnEpisodeBeginCalls);
                 }
                 // Set agent 1 to done every 11 steps to test behavior
                 if (i % 11 == 5)
                 {
+                    Assert.AreEqual(numberAgent1Episodes, agent1.agentOnEpisodeBeginCalls);
                     agent1.EndEpisode();
-                    numberAgent1Reset += 1;
+                    numberAgent1Episodes += 1;
+                    Assert.AreEqual(numberAgent1Episodes, agent1.agentOnEpisodeBeginCalls);
                 }
-                // Resetting agent 2 regularly
+                // Ending the episode for agent 2 regularly
                 if (i % 13 == 3)
                 {
+                    Assert.AreEqual(numberAgent2Episodes, agent2.agentOnEpisodeBeginCalls);
                     agent2.EndEpisode();
-                    numberAgent2Reset += 1;
-                    agent2StepSinceReset = 0;
+                    numberAgent2Episodes += 1;
+                    agent2StepForEpisode = 0;
+                    Assert.AreEqual(numberAgent2Episodes, agent2.agentOnEpisodeBeginCalls);
                 }
                 // Request a decision for agent 2 regularly
                 if (i % 3 == 2)
@@ -469,7 +474,7 @@ namespace MLAgents.Tests
                 }
 
                 acaStepsSinceReset += 1;
-                agent2StepSinceReset += 1;
+                agent2StepForEpisode += 1;
                 aca.EnvironmentStep();
             }
         }
@@ -509,17 +514,17 @@ namespace MLAgents.Tests
             agent1.LazyInitialize();
             agent2.SetPolicy(new TestPolicy());
 
-            var expectedAgent1ActionSinceReset = 0;
+            var expectedAgent1ActionForEpisode = 0;
 
             for (var i = 0; i < 50; i++)
             {
-                expectedAgent1ActionSinceReset += 1;
-                if (expectedAgent1ActionSinceReset == agent1.maxStep || i == 0)
+                expectedAgent1ActionForEpisode += 1;
+                if (expectedAgent1ActionForEpisode == agent1.maxStep || i == 0)
                 {
-                    expectedAgent1ActionSinceReset = 0;
+                    expectedAgent1ActionForEpisode = 0;
                 }
                 agent2.RequestAction();
-                Assert.LessOrEqual(Mathf.Abs(expectedAgent1ActionSinceReset * 10.1f - agent1.GetCumulativeReward()), 0.05f);
+                Assert.LessOrEqual(Mathf.Abs(expectedAgent1ActionForEpisode * 10.1f - agent1.GetCumulativeReward()), 0.05f);
                 Assert.LessOrEqual(Mathf.Abs(i * 0.1f - agent2.GetCumulativeReward()), 0.05f);
 
                 agent1.AddReward(10f);
@@ -544,41 +549,41 @@ namespace MLAgents.Tests
             agent1.LazyInitialize();
 
             var expectedAgentStepCount = 0;
-            var expectedResets = 0;
+            var expectedEpisodes = 0;
             var expectedAgentAction = 0;
-            var expectedAgentActionSinceReset = 0;
+            var expectedAgentActionForEpisode = 0;
             var expectedCollectObsCalls = 0;
-            var expectedCollectObsCallsSinceReset = 0;
+            var expectedCollectObsCallsForEpisode = 0;
 
             for (var i = 0; i < 15; i++)
             {
                 // Agent should observe and act on each Academy step
                 expectedAgentAction += 1;
-                expectedAgentActionSinceReset += 1;
+                expectedAgentActionForEpisode += 1;
                 expectedCollectObsCalls += 1;
-                expectedCollectObsCallsSinceReset += 1;
+                expectedCollectObsCallsForEpisode += 1;
                 expectedAgentStepCount += 1;
 
                 // If the next step will put the agent at maxSteps, we expect it to reset
                 if (agent1.StepCount == maxStep - 1 || (i == 0))
                 {
-                    expectedResets += 1;
+                    expectedEpisodes += 1;
                 }
 
                 if (agent1.StepCount == maxStep - 1)
                 {
-                    expectedAgentActionSinceReset = 0;
-                    expectedCollectObsCallsSinceReset = 0;
+                    expectedAgentActionForEpisode = 0;
+                    expectedCollectObsCallsForEpisode = 0;
                     expectedAgentStepCount = 0;
                 }
                 aca.EnvironmentStep();
 
                 Assert.AreEqual(expectedAgentStepCount, agent1.StepCount);
-                Assert.AreEqual(expectedResets, agent1.agentResetCalls);
+                Assert.AreEqual(expectedEpisodes, agent1.agentOnEpisodeBeginCalls);
                 Assert.AreEqual(expectedAgentAction, agent1.agentActionCalls);
-                Assert.AreEqual(expectedAgentActionSinceReset, agent1.agentActionCallsSinceLastReset);
+                Assert.AreEqual(expectedAgentActionForEpisode, agent1.agentActionCallsForEpisode);
                 Assert.AreEqual(expectedCollectObsCalls, agent1.collectObservationsCalls);
-                Assert.AreEqual(expectedCollectObsCallsSinceReset, agent1.collectObservationsCallsSinceLastReset);
+                Assert.AreEqual(expectedCollectObsCallsForEpisode, agent1.collectObservationsCallsForEpisode);
             }
         }
 


### PR DESCRIPTION
### Proposed change(s)

OnEpisodeBegin during initiialization
No double OnEpisodeBegin

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

[MLA-743](https://jira.unity3d.com/browse/MLA-743)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
