### PR TITLE
[bug-fix] Fix stats reporting for reward signals in SAC

### DIFF
--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -56,7 +56,6 @@ class TFPolicy(Policy):
 
         self.use_recurrent = trainer_parameters["use_recurrent"]
         self.memory_dict: Dict[str, np.ndarray] = {}
-        self.reward_signals: Dict[str, "RewardSignal"] = {}
         self.num_branches = len(self.brain.vector_action_space_size)
         self.previous_action_dict: Dict[str, np.array] = {}
         self.normalize = trainer_parameters.get("normalize", False)

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -190,8 +190,6 @@ class SACTrainer(RLTrainer):
         )
 
         if trajectory.done_reached:
-            for key, val in self.collected_rewards.items():
-                print(key, val[agent_id])
             self._update_end_episode_stats(agent_id, self.optimizer)
 
     def _is_ready_update(self) -> bool:

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -156,7 +156,7 @@ class SACTrainer(RLTrainer):
         self.collected_rewards["environment"][agent_id] += np.sum(
             agent_buffer_trajectory["environment_rewards"]
         )
-        for name, reward_signal in self.policy.reward_signals.items():
+        for name, reward_signal in self.optimizer.reward_signals.items():
             evaluate_result = reward_signal.evaluate_batch(
                 agent_buffer_trajectory
             ).scaled_reward
@@ -190,6 +190,8 @@ class SACTrainer(RLTrainer):
         )
 
         if trajectory.done_reached:
+            for key, val in self.collected_rewards.items():
+                print(key, val[agent_id])
             self._update_end_episode_stats(agent_id, self.optimizer)
 
     def _is_ready_update(self) -> bool:
@@ -223,9 +225,6 @@ class SACTrainer(RLTrainer):
             reparameterize=True,
             create_tf_graph=False,
         )
-        for _reward_signal in policy.reward_signals.keys():
-            self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
-
         # Load the replay buffer if load
         if self.load and self.checkpoint_replay_buffer:
             try:

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -221,6 +221,10 @@ def test_process_trajectory(dummy_config):
         for agent in reward.values():
             assert agent == 0
     assert trainer.stats_reporter.get_stats_summaries("Policy/Extrinsic Reward").num > 0
+    # Assert we're not just using the default values
+    assert (
+        trainer.stats_reporter.get_stats_summaries("Policy/Extrinsic Reward").mean > 0
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Proposed change(s)

When the Optimizer was split from the Policy, SAC was still using the Policy's reward signals to write the reward values to Tensorboard. This meant that the Policy's reward stats (e.g. Extrinsic Reward, GAIL Reward) was always 0. 

This PR fixes the bug and removes the unnecessary reward_signals dict in Policy. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
