### PR TITLE
[change] Move console printing to StatsWriter class

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -21,6 +21,7 @@ from mlagents.trainers.stats import (
     CSVWriter,
     StatsReporter,
     GaugeWriter,
+    ConsoleWriter,
 )
 from mlagents_envs.environment import UnityEnvironment
 from mlagents.trainers.sampler_class import SamplerManager
@@ -270,9 +271,11 @@ def run_training(run_seed: int, options: RunOptions) -> None:
         )
         tb_writer = TensorboardWriter(summaries_dir)
         gauge_write = GaugeWriter()
+        console_writer = ConsoleWriter()
         StatsReporter.add_writer(tb_writer)
         StatsReporter.add_writer(csv_writer)
         StatsReporter.add_writer(gauge_write)
+        StatsReporter.add_writer(console_writer)
 
         if options.env_path is None:
             port = UnityEnvironment.DEFAULT_EDITOR_PORT

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -9,7 +9,6 @@ from mlagents import tf_utils
 
 from collections import deque
 
-from mlagents_envs.timers import set_gauge
 from mlagents.model_serialization import export_policy_model, SerializationSettings
 from mlagents.trainers.policy.tf_policy import TFPolicy
 from mlagents.trainers.stats import StatsReporter
@@ -193,33 +192,7 @@ class Trainer(abc.ABC):
         """
         Saves training statistics to Tensorboard.
         """
-        is_training = "Training." if self.should_still_train else "Not Training."
-        stats_summary = self.stats_reporter.get_stats_summaries(
-            "Environment/Cumulative Reward"
-        )
-        if stats_summary.num > 0:
-            logger.info(
-                "{}: {}: Step: {}. "
-                "Time Elapsed: {:0.3f} s "
-                "Mean "
-                "Reward: {:0.3f}"
-                ". Std of Reward: {:0.3f}. {}".format(
-                    self.run_id,
-                    self.brain_name,
-                    step,
-                    time.time() - self.training_start_time,
-                    stats_summary.mean,
-                    stats_summary.std,
-                    is_training,
-                )
-            )
-            set_gauge(f"{self.brain_name}.mean_reward", stats_summary.mean)
-        else:
-            logger.info(
-                " {}: {}: Step: {}. No episode was completed since last summary. {}".format(
-                    self.run_id, self.brain_name, step, is_training
-                )
-            )
+        self.stats_reporter.add_stat("Is Training", float(self.should_still_train))
         self.stats_reporter.write_stats(int(step))
 
     @abc.abstractmethod


### PR DESCRIPTION
### Proposed change(s)

Console printing was still handled in the Trainer class. This PR makes a new class (`ConsoleWriter`) that writes to the console; the Trainer uses this class through the `StatsReporter` interface as with everything else. 

TODO: Move ELO writing from the GhostTrainer into the ConsoleWriter as well. 

Output is slightly different than before.

Before:
```
2020-03-11 17:26:58 INFO [trainer.py:213] test: 3DBall: Step: 14400. Time Elapsed: 20.636 s Mean Reward: 2.200. Std of Reward: 0.000. Training.
2020-03-11 17:26:58 INFO [trainer.py:213] test: 3DBall: Step: 14436. Time Elapsed: 20.645 s Mean Reward: 1.200. Std of Reward: 0.000. Training.
```

After:
```
2020-03-11 16:51:58 INFO [stats.py:90] test_3DBall: Step: 6996. Time Elapsed: 13.717 s Mean Reward: 1.400. Std of Reward: 0.000. Training.
2020-03-11 16:51:58 INFO [stats.py:90] test_3DBall: Step: 7020. Time Elapsed: 13.744 s Mean Reward: 1.400. Std of Reward: 0.000. Training.
```
### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
