### PR TITLE
[MLA-762] Better logging when no model + inference only

### DIFF
--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -106,7 +106,8 @@ namespace MLAgents.Editor
             if (brainParameters != null)
             {
                 var failedChecks = Inference.BarracudaModelParamLoader.CheckModel(
-                    barracudaModel, brainParameters, sensorComponents);
+                    barracudaModel, brainParameters, sensorComponents, behaviorParameters.behaviorType
+                );
                 foreach (var check in failedChecks)
                 {
                     if (check != null)

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -127,14 +127,22 @@ namespace MLAgents.Inference
         /// </param>
         /// <param name="sensorComponents">Attached sensor components</param>
         /// <returns>The list the error messages of the checks that failed</returns>
-        public static IEnumerable<string> CheckModel(Model model, BrainParameters brainParameters, SensorComponent[] sensorComponents)
+        public static IEnumerable<string> CheckModel(Model model, BrainParameters brainParameters,
+            SensorComponent[] sensorComponents, BehaviorType behaviorType = BehaviorType.Default)
         {
             List<string> failedModelChecks = new List<string>();
             if (model == null)
             {
-                failedModelChecks.Add(
-                    "There is no model for this Brain, cannot run inference. " +
-                    "(But can still train)");
+                var errorMsg = "There is no model for this Brain; cannot run inference. ";
+                if (behaviorType == BehaviorType.InferenceOnly)
+                {
+                    errorMsg += "Either assign a model, or change to a different Behavior Type.";
+                }
+                else
+                {
+                    errorMsg += "(But can still train)";
+                }
+                failedModelChecks.Add(errorMsg);
                 return failedModelChecks;
             }
 

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -142,7 +142,17 @@ namespace MLAgents.Policies
                 case BehaviorType.HeuristicOnly:
                     return new HeuristicPolicy(heuristic);
                 case BehaviorType.InferenceOnly:
+                {
+                    if (m_Model == null)
+                    {
+                        var behaviorType = BehaviorType.InferenceOnly.ToString();
+                        throw new UnityAgentsException(
+                            $"Can't use Behavior Type {behaviorType} without a model. " +
+                            "Either assign a model, or change to a different Behavior Type."
+                        );
+                    }
                     return new BarracudaPolicy(m_BrainParameters, m_Model, m_InferenceDevice);
+                }
                 case BehaviorType.Default:
                     if (Academy.Instance.IsCommunicatorOn)
                     {

--- a/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UnityEngine;
+using MLAgents;
+using MLAgents.Policies;
+
+namespace MLAgents.Tests
+{
+    [TestFixture]
+    public class BehaviorParameterTests
+    {
+        static float[] DummyHeuristic()
+        {
+            return null;
+        }
+
+        [Test]
+        public void TestNoModelInferenceOnlyThrows()
+        {
+            var gameObj = new GameObject();
+            var bp = gameObj.AddComponent<BehaviorParameters>();
+            bp.behaviorType = BehaviorType.InferenceOnly;
+
+            Assert.Throws<UnityAgentsException>(() =>
+            {
+                bp.GeneratePolicy(DummyHeuristic);
+            });
+        }
+    }
+}

--- a/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs.meta
+++ b/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 877266b9e1bfe4330a68ab5f2da1836b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -102,6 +102,8 @@ namespace MLAgentsExamples
             var agent = gameObject.AddComponent<PublicApiAgent>();
             // Make sure we can set the behavior type correctly after the agent is added
             behaviorParams.behaviorType = BehaviorType.InferenceOnly;
+            // Can't actually create an Agent with InferenceOnly and no model, so change back
+            behaviorParams.behaviorType = BehaviorType.Default;
 
             // TODO -  not internal yet
             // var decisionRequester = gameObject.AddComponent<DecisionRequester>();


### PR DESCRIPTION
### Proposed change(s)
If the BehaviorParameters don't have a model specific, and the BehaviorType is set to InferenceOnly, it will eventually cause an NullReferenceException during simulation.

This combination doesn't make any sense, but we can at least surface the error better (and sooner). This PR throws an exception in BehaviorParameters.GeneratePolicy, and also customizes the Inspector warning.

![image](https://user-images.githubusercontent.com/6877802/76476407-28a49700-63bf-11ea-9a4d-3fb72a6e0c02.png)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
First spotted in https://forum.unity.com/threads/cant-create-new-brain-model.844153/


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
