### PR TITLE
enable code coverage in Yamato

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -27,7 +27,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents
+    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
   artifacts:
     logs:
       paths:

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -1,7 +1,11 @@
 test_editors:
   - version: 2018.4
+    # 2018.4 doesn't support code-coverage
+    coverageOptions:
   - version: 2019.3
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
   - version: 2020.1
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
 test_platforms:
   - name: win
     type: Unity::VM
@@ -27,7 +31,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
   artifacts:
     logs:
       paths:

--- a/DevProject/Packages/manifest.json
+++ b/DevProject/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.3.5",
+    "com.unity.coding": "0.1.0-preview.13",
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.1.4",
@@ -12,10 +13,10 @@
     "com.unity.package-manager-doctools": "1.1.1-preview.3",
     "com.unity.package-validation-suite": "0.7.15-preview",
     "com.unity.purchasing": "2.0.6",
-    "com.unity.test-framework": "1.1.9",
+    "com.unity.test-framework": "1.1.11",
     "com.unity.testtools.codecoverage": "0.2.2-preview",
     "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.2.10",
+    "com.unity.timeline": "1.2.12",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.legacyinputhelpers": "1.3.8",
     "com.unity.modules.ai": "1.0.0",
@@ -48,8 +49,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-    "com.unity.coding" : "0.1.0-preview.13"
+    "com.unity.modules.xr": "1.0.0"
   },
   "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
   "testables": [

--- a/DevProject/ProjectSettings/ProjectVersion.txt
+++ b/DevProject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f6
-m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)
+m_EditorVersion: 2019.3.3f1
+m_EditorVersionWithRevision: 2019.3.3f1 (7ceaae5f7503)


### PR DESCRIPTION
### Proposed change(s)

Currently this only runs the checks; as far as I can tell, there's no option to set a min percentage and fail if it goes below that (waiting for a [slack response](https://unity.slack.com/archives/C18KJF78T/p1584120758017700))

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://confluence.unity3d.com/pages/viewpage.action?spaceKey=PAK&title=Setting+up+your+package+CI#SettingupyourpackageCI-AddCodeCoverageSupportAddCodeCoverageSupport


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
