### PR TITLE
[change] Clean up trainer interface, clean up GhostTrainer stats

### DIFF
--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -144,10 +144,6 @@ class AgentProcessor:
                     self.experience_buffers[global_id] = []
                     if curr_agent_step.done:
                         self.stats_reporter.add_stat(
-                            "Environment/Cumulative Reward",
-                            self.episode_rewards.get(global_id, 0),
-                        )
-                        self.stats_reporter.add_stat(
                             "Environment/Episode Length",
                             self.episode_steps.get(global_id, 0),
                         )

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -93,9 +93,6 @@ class PPOTrainer(RLTrainer):
         super()._process_trajectory(trajectory)
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 
-        # Add to episode_steps
-        self.episode_steps[agent_id] += len(trajectory.steps)
-
         agent_buffer_trajectory = trajectory.to_agentbuffer()
         # Update the normalization
         if self.is_training:
@@ -109,7 +106,7 @@ class PPOTrainer(RLTrainer):
         )
         for name, v in value_estimates.items():
             agent_buffer_trajectory["{}_value_estimates".format(name)].extend(v)
-            self.stats_reporter.add_stat(
+            self._stats_reporter.add_stat(
                 self.optimizer.reward_signals[name].value_name, np.mean(v)
             )
 
@@ -214,12 +211,12 @@ class PPOTrainer(RLTrainer):
                     batch_update_stats[stat_name].append(value)
 
         for stat, stat_list in batch_update_stats.items():
-            self.stats_reporter.add_stat(stat, np.mean(stat_list))
+            self._stats_reporter.add_stat(stat, np.mean(stat_list))
 
         if self.optimizer.bc_module:
             update_stats = self.optimizer.bc_module.update()
             for stat, val in update_stats.items():
-                self.stats_reporter.add_stat(stat, val)
+                self._stats_reporter.add_stat(stat, val)
         self._clear_update_buffer()
 
     def create_policy(self, brain_parameters: BrainParameters) -> TFPolicy:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -220,7 +220,7 @@ class PPOTrainer(RLTrainer):
             update_stats = self.optimizer.bc_module.update()
             for stat, val in update_stats.items():
                 self.stats_reporter.add_stat(stat, val)
-        self.clear_update_buffer()
+        self._clear_update_buffer()
 
     def create_policy(self, brain_parameters: BrainParameters) -> TFPolicy:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -157,9 +157,6 @@ class SACTrainer(RLTrainer):
         last_step = trajectory.steps[-1]
         agent_id = trajectory.agent_id  # All the agents should have the same ID
 
-        # Add to episode_steps
-        self.episode_steps[agent_id] += len(trajectory.steps)
-
         agent_buffer_trajectory = trajectory.to_agentbuffer()
 
         # Update the normalization
@@ -182,7 +179,7 @@ class SACTrainer(RLTrainer):
             agent_buffer_trajectory, trajectory.next_obs, trajectory.done_reached
         )
         for name, v in value_estimates.items():
-            self.stats_reporter.add_stat(
+            self._stats_reporter.add_stat(
                 self.optimizer.reward_signals[name].value_name, np.mean(v)
             )
 
@@ -298,12 +295,12 @@ class SACTrainer(RLTrainer):
             )
 
         for stat, stat_list in batch_update_stats.items():
-            self.stats_reporter.add_stat(stat, np.mean(stat_list))
+            self._stats_reporter.add_stat(stat, np.mean(stat_list))
 
         if self.optimizer.bc_module:
             update_stats = self.optimizer.bc_module.update()
             for stat, val in update_stats.items():
-                self.stats_reporter.add_stat(stat, val)
+                self._stats_reporter.add_stat(stat, val)
 
     def update_reward_signals(self) -> None:
         """
@@ -338,7 +335,7 @@ class SACTrainer(RLTrainer):
             for stat_name, value in update_stats.items():
                 batch_update_stats[stat_name].append(value)
         for stat, stat_list in batch_update_stats.items():
-            self.stats_reporter.add_stat(stat, np.mean(stat_list))
+            self._stats_reporter.add_stat(stat, np.mean(stat_list))
 
     def add_policy(self, name_behavior_id: str, policy: TFPolicy) -> None:
         """

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -26,6 +26,8 @@ class StatsSummary(NamedTuple):
 
 class StatsPropertyType(Enum):
     HYPERPARAMETERS = "hyperparameters"
+    SELF_PLAY = "selfplay"
+    SELF_PLAY_TEAM = "selfplayteam"
 
 
 class StatsWriter(abc.ABC):
@@ -77,6 +79,9 @@ class GaugeWriter(StatsWriter):
 class ConsoleWriter(StatsWriter):
     def __init__(self):
         self.training_start_time = time.time()
+        # If self-play, we want to print ELO instead of reward
+        self.self_play = False
+        self.self_play_team = -1
 
     def write_stats(
         self, category: str, values: Dict[str, StatsSummary], step: int
@@ -86,6 +91,7 @@ class ConsoleWriter(StatsWriter):
             stats_summary = stats_summary = values["Is Training"]
             if stats_summary.mean > 0.0:
                 is_training = "Training."
+
         if "Environment/Cumulative Reward" in values:
             stats_summary = values["Environment/Cumulative Reward"]
             logger.info(
@@ -102,6 +108,21 @@ class ConsoleWriter(StatsWriter):
                     is_training,
                 )
             )
+            if self.self_play and "Self-play/ELO" in values:
+                elo_stats = values["Self-play/ELO"]
+                mean_opponent_elo = values["Self-play/Mean Opponent ELO"]
+                std_opponent_elo = values["Self-play/Std Opponent ELO"]
+                logger.info(
+                    "{} Team {}: ELO: {:0.3f}. "
+                    "Mean Opponent ELO: {:0.3f}. "
+                    "Std Opponent ELO: {:0.3f}. ".format(
+                        category,
+                        self.self_play_team,
+                        elo_stats.mean,
+                        mean_opponent_elo.mean,
+                        std_opponent_elo.mean,
+                    )
+                )
         else:
             logger.info(
                 "{}: Step: {}. No episode was completed since last summary. {}".format(
@@ -118,6 +139,12 @@ class ConsoleWriter(StatsWriter):
                     category, self._dict_to_str(value, 0)
                 )
             )
+        elif property_type == StatsPropertyType.SELF_PLAY:
+            assert isinstance(value, bool)
+            self.self_play = value
+        elif property_type == StatsPropertyType.SELF_PLAY_TEAM:
+            assert isinstance(value, int)
+            self.self_play_team = value
 
     def _dict_to_str(self, param_dict: Dict[str, Any], num_tabs: int) -> str:
         """

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -79,7 +79,7 @@ class GaugeWriter(StatsWriter):
 class ConsoleWriter(StatsWriter):
     def __init__(self):
         self.training_start_time = time.time()
-        # If self-play, we want to print ELO instead of reward
+        # If self-play, we want to print ELO as well as reward
         self.self_play = False
         self.self_play_team = -1
 

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -4,6 +4,7 @@ from mlagents.trainers import learn
 from mlagents.trainers.trainer_controller import TrainerController
 from mlagents.trainers.learn import parse_command_line
 from mlagents_envs.exception import UnityEnvironmentException
+from mlagents.trainers.stats import StatsReporter
 
 
 def basic_options(extra_args=None):
@@ -49,6 +50,7 @@ def test_run_training(
                 sampler_manager_mock.return_value,
                 None,
             )
+    StatsReporter.writers.clear()  # make sure there aren't any writers as added by learn.py
 
 
 @patch("mlagents.trainers.learn.SamplerManager")
@@ -74,6 +76,7 @@ def test_docker_target_path(
             mock_init.assert_called_once()
             assert mock_init.call_args[0][1] == "/dockertarget/models/ppo"
             assert mock_init.call_args[0][2] == "/dockertarget/summaries"
+    StatsReporter.writers.clear()  # make sure there aren't any writers as added by learn.py
 
 
 def test_bad_env_path():

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -74,12 +74,12 @@ def test_rl_trainer():
 def test_clear_update_buffer():
     trainer = create_rl_trainer()
     trainer.update_buffer = construct_fake_buffer(0)
-    trainer.clear_update_buffer()
+    trainer._clear_update_buffer()
     for _, arr in trainer.update_buffer.items():
         assert len(arr) == 0
 
 
-@mock.patch("mlagents.trainers.trainer.rl_trainer.RLTrainer.clear_update_buffer")
+@mock.patch("mlagents.trainers.trainer.rl_trainer.RLTrainer._clear_update_buffer")
 def test_advance(mocked_clear_update_buffer):
     trainer = create_rl_trainer()
     trajectory_queue = AgentManagerQueue("testbrain")

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -60,12 +60,9 @@ def create_rl_trainer():
 def test_rl_trainer():
     trainer = create_rl_trainer()
     agent_id = "0"
-    trainer.episode_steps[agent_id] = 3
     trainer.collected_rewards["extrinsic"] = {agent_id: 3}
     # Test end episode
     trainer.end_episode()
-    for agent_id in trainer.episode_steps:
-        assert trainer.episode_steps[agent_id] == 0
     for rewards in trainer.collected_rewards.values():
         for agent_id in rewards:
             assert rewards[agent_id] == 0

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -186,3 +186,30 @@ class ConsoleWriterTest(unittest.TestCase):
 
         self.assertIn("Hyperparameters for behavior name", cm.output[2])
         self.assertIn("example:\t1.0", cm.output[2])
+
+    def test_selfplay_console_writer(self):
+        with self.assertLogs("mlagents.trainers", level="INFO") as cm:
+            category = "category1"
+            console_writer = ConsoleWriter()
+            console_writer.add_property(category, StatsPropertyType.SELF_PLAY, True)
+            console_writer.add_property(category, StatsPropertyType.SELF_PLAY_TEAM, 1)
+            statssummary1 = StatsSummary(mean=1.0, std=1.0, num=1)
+            console_writer.write_stats(
+                category,
+                {
+                    "Environment/Cumulative Reward": statssummary1,
+                    "Is Training": statssummary1,
+                    "Self-play/ELO": statssummary1,
+                    "Self-play/Mean Opponent ELO": statssummary1,
+                    "Self-play/Std Opponent ELO": statssummary1,
+                },
+                10,
+            )
+
+        self.assertIn(
+            "Mean Reward: 1.000. Std of Reward: 1.000. Training.", cm.output[0]
+        )
+        self.assertIn(
+            "category1 Team 1: ELO: 1.000. Mean Opponent ELO: 1.000. Std Opponent ELO: 1.000.",
+            cm.output[1],
+        )

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -11,6 +11,7 @@ from mlagents.trainers.components.reward_signals import RewardSignalResult
 from mlagents_envs.timers import hierarchical_timer
 from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.trajectory import Trajectory
+from mlagents.trainers.stats import StatsPropertyType
 
 RewardSignalResults = Dict[str, RewardSignalResult]
 
@@ -37,6 +38,9 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
             "environment": defaultdict(lambda: 0)
         }
         self.update_buffer: AgentBuffer = AgentBuffer()
+        self._stats_reporter.add_property(
+            StatsPropertyType.HYPERPARAMETERS, self.trainer_parameters
+        )
 
     def end_episode(self) -> None:
         """

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -54,6 +54,9 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
     def _update_end_episode_stats(self, agent_id: str, optimizer: TFOptimizer) -> None:
         for name, rewards in self.collected_rewards.items():
             if name == "environment":
+                self.stats_reporter.add_stat(
+                    "Environment/Cumulative Reward", rewards.get(agent_id, 0)
+                )
                 self.cumulative_returns_since_policy_update.append(
                     rewards.get(agent_id, 0)
                 )

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -7,7 +7,7 @@ from collections import deque
 
 from mlagents.model_serialization import export_policy_model, SerializationSettings
 from mlagents.trainers.policy.tf_policy import TFPolicy
-from mlagents.trainers.stats import StatsReporter, StatsPropertyType
+from mlagents.trainers.stats import StatsReporter
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.brain import BrainParameters
@@ -49,9 +49,6 @@ class Trainer(abc.ABC):
         self.step: int = 0
         self.summary_freq = self.trainer_parameters["summary_freq"]
         self.next_summary_step = self.summary_freq
-        self._stats_reporter.add_property(
-            StatsPropertyType.HYPERPARAMETERS, self.trainer_parameters
-        )
 
     @property
     def stats_reporter(self):

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -1,7 +1,6 @@
 # # Unity ML-Agents Toolkit
 import logging
 from typing import Dict, List, Deque, Any
-import time
 import abc
 
 from collections import deque
@@ -42,19 +41,24 @@ class Trainer(abc.ABC):
         self.run_id = run_id
         self.trainer_parameters = trainer_parameters
         self.summary_path = trainer_parameters["summary_path"]
-        self.stats_reporter = StatsReporter(self.summary_path)
-        self.cumulative_returns_since_policy_update: List[float] = []
+        self._stats_reporter = StatsReporter(self.summary_path)
         self.is_training = training
         self._reward_buffer: Deque[float] = deque(maxlen=reward_buff_cap)
         self.policy_queues: List[AgentManagerQueue[Policy]] = []
         self.trajectory_queues: List[AgentManagerQueue[Trajectory]] = []
         self.step: int = 0
-        self.training_start_time = time.time()
         self.summary_freq = self.trainer_parameters["summary_freq"]
         self.next_summary_step = self.summary_freq
-        self.stats_reporter.add_property(
+        self._stats_reporter.add_property(
             StatsPropertyType.HYPERPARAMETERS, self.trainer_parameters
         )
+
+    @property
+    def stats_reporter(self):
+        """
+        Returns the stats reporter associated with this Trainer.
+        """
+        return self._stats_reporter
 
     def _check_param_keys(self):
         for k in self.param_keys:
@@ -106,23 +110,6 @@ class Trainer(abc.ABC):
         """
         return self._reward_buffer
 
-    def _increment_step(self, n_steps: int, name_behavior_id: str) -> None:
-        """
-        Increment the step count of the trainer
-        :param n_steps: number of steps to increment the step count by
-        """
-        self.step += n_steps
-        self.next_summary_step = self._get_next_summary_step()
-        p = self.get_policy(name_behavior_id)
-        if p:
-            p.increment_step(n_steps)
-
-    def _get_next_summary_step(self) -> int:
-        """
-        Get the next step count that should result in a summary write.
-        """
-        return self.step + (self.summary_freq - self.step % self.summary_freq)
-
     def save_model(self, name_behavior_id: str) -> None:
         """
         Saves the model
@@ -136,31 +123,6 @@ class Trainer(abc.ABC):
         policy = self.get_policy(name_behavior_id)
         settings = SerializationSettings(policy.model_path, policy.brain.brain_name)
         export_policy_model(settings, policy.graph, policy.sess)
-
-    def _write_summary(self, step: int) -> None:
-        """
-        Saves training statistics to Tensorboard.
-        """
-        self.stats_reporter.add_stat("Is Training", float(self.should_still_train))
-        self.stats_reporter.write_stats(int(step))
-
-    @abc.abstractmethod
-    def _process_trajectory(self, trajectory: Trajectory) -> None:
-        """
-        Takes a trajectory and processes it, putting it into the update buffer.
-        :param trajectory: The Trajectory tuple containing the steps to be processed.
-        """
-        self._maybe_write_summary(self.get_step + len(trajectory.steps))
-        self._increment_step(len(trajectory.steps), trajectory.behavior_id)
-
-    def _maybe_write_summary(self, step_after_process: int) -> None:
-        """
-        If processing the trajectory will make the step exceed the next summary write,
-        write the summary. This logic ensures summaries are written on the update step and not in between.
-        :param step_after_process: the step count after processing the next trajectory.
-        """
-        if step_after_process >= self.next_summary_step and self.get_step != 0:
-            self._write_summary(self.next_summary_step)
 
     @abc.abstractmethod
     def end_episode(self):


### PR DESCRIPTION
### Proposed change(s)

This PR moves most private methods out of the Trainer class and into RLTrainer, making it more of an interface. This also removed some methods in the Ghost Trainer. As part of this change, it was necessary to move the console printing out of the Ghost Trainer and into the ConsoleWriter. @andrewcoh I need to make sure that I'm writing the stats in the right place, and that the ELO reported where it is won't cause issues.

Also moved reward reporting from the AgentProcessor to the Trainer, so that the GhostTrainer's cumulative reward is (correctly) only one of the learning teams. This doesn't affect single-team training.

There is some special casing and property passing in the ConsoleWriter that is a bit hacky - open to ideas on how to solve that. 

Also fixes a bug where hyperparameters were printed twice for ghost trainer. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
