### PR TITLE
sanitize gauge names

### DIFF
--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -71,7 +71,10 @@ class GaugeWriter(StatsWriter):
         self, category: str, values: Dict[str, StatsSummary], step: int
     ) -> None:
         for val, stats_summary in values.items():
-            set_gauge(f"{category}.{val}.mean", float(stats_summary.mean))
+            set_gauge(
+                GaugeWriter.sanitize_string(f"{category}.{val}.mean"),
+                float(stats_summary.mean),
+            )
 
 
 class ConsoleWriter(StatsWriter):


### PR DESCRIPTION
### Proposed change(s)

```
before:

    "ppo_3DBall.Environment/Cumulative Reward.mean": {
        "value": 1.1560150697211127,
        "min": 1.1560150697211127,
        "max": 1.1560150697211127,
        "count": 1
    },

after:

    "ppo_3DBall.Environment.CumulativeReward.mean": {
        "value": 1.1631579269704067,
        "min": 1.1631579269704067,
        "max": 1.1631579269704067,
        "count": 1
    },
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
