### PR TITLE
[bug-fix] Increase 3dballhard steps

### DIFF
--- a/config/gail_config.yaml
+++ b/config/gail_config.yaml
@@ -7,7 +7,7 @@ default:
     hidden_units: 128
     lambd: 0.95
     learning_rate: 3.0e-4
-    max_steps: 5.0e4
+    max_steps: 5.0e5
     memory_size: 256
     normalize: false
     num_epoch: 3

--- a/config/trainer_config.yaml
+++ b/config/trainer_config.yaml
@@ -120,7 +120,7 @@ VisualPyramids:
     buffer_size: 12000
     summary_freq: 12000
     time_horizon: 1000
-    max_steps: 5.0e5
+    max_steps: 5.0e6
     beta: 0.001
     reward_signals:
         extrinsic:


### PR DESCRIPTION
### Proposed change(s)

Increase 3dballhard max_steps to 5e6, which is what it needs to train properly.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)
