### PR TITLE
cancel old CI

### DIFF
--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -11,3 +11,5 @@ pack:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
+  triggers:
+    cancel_old_ci: true

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -43,6 +43,7 @@ test_{{ platform.name }}_{{ editor.version }}:
   dependencies:
     - .yamato/com.unity.ml-agents-pack.yml#pack
   triggers:
+    cancel_old_ci: true
     changes:
       only:
         - "com.unity.ml-agents/**"

--- a/.yamato/protobuf-generation-test.yml
+++ b/.yamato/protobuf-generation-test.yml
@@ -27,6 +27,7 @@ test_mac_protobuf_generation:
       echo "Apply the patch with the command 'git apply proto.patch'";                                  \
       git diff -- :/ ":(exclude,top)$CS_PROTO_PATH/*.meta" > artifacts/proto.patch; exit $GIT_ERR; }
   triggers:
+    cancel_old_ci: true
     changes:
       only:
         - "protobuf-definitions/**"

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -15,6 +15,7 @@ test_mac_standalone_{{ editor.version }}:
     - pip install pyyaml
     - python -u -m ml-agents.tests.yamato.standalone_build_tests
   triggers:
+    cancel_old_ci: true
     changes:
       only:
         - "com.unity.ml-agents/**"

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -15,6 +15,7 @@ test_mac_training_int_{{ editor.version }}:
     - pip install pyyaml
     - python -u -m ml-agents.tests.yamato.training_int_tests
   triggers:
+    cancel_old_ci: true
     changes:
       only:
         - "com.unity.ml-agents/**"

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -135,7 +135,7 @@ namespace MLAgents.Policies
             get { return m_BehaviorName + "?team=" + TeamId; }
         }
 
-        internal IPolicy GeneratePolicy(Func<float[]> heuristic )
+        internal IPolicy GeneratePolicy(Func<float[]> heuristic)
         {
             switch (m_BehaviorType)
             {

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -135,7 +135,7 @@ namespace MLAgents.Policies
             get { return m_BehaviorName + "?team=" + TeamId; }
         }
 
-        internal IPolicy GeneratePolicy(Func<float[]> heuristic)
+        internal IPolicy GeneratePolicy(Func<float[]> heuristic )
         {
             switch (m_BehaviorType)
             {


### PR DESCRIPTION
### Proposed change(s)

Configure our yamato jobs to cancel currently running jobs when new commits are pushed.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Announcement on #devs-yamato https://unity.slack.com/archives/C998PJJDD/p1584541233176700


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
