### PR TITLE
Stats SideChannel (for custom TensorBoard metrics)

### DIFF
--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
@@ -14,9 +14,12 @@ public class FoodCollectorSettings : MonoBehaviour
     public int totalScore;
     public Text scoreText;
 
+    StatsSideChannel m_statsSideChannel;
+
     public void Awake()
     {
         Academy.Instance.OnEnvironmentReset += EnvironmentReset;
+        m_statsSideChannel = Academy.Instance.GetSideChannel<StatsSideChannel>();
     }
 
     public void EnvironmentReset()
@@ -45,6 +48,13 @@ public class FoodCollectorSettings : MonoBehaviour
     public void Update()
     {
         scoreText.text = $"Score: {totalScore}";
-        Academy.Instance.GetSideChannel<StatsSideChannel>().AddStat("TotalScore", totalScore);
+
+        // Send stats via SideChannel so that they'll appear in TensorBoard.
+        // These values get averaged every summary_frequency steps, so we don't
+        // need to send every Update() call.
+        if ((Time.frameCount % 100)== 0)
+        {
+            m_statsSideChannel?.AddStat("TotalScore", totalScore);
+        }
     }
 }

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 using MLAgents;
+using MLAgents.SideChannels;
 
 public class FoodCollectorSettings : MonoBehaviour
 {
@@ -44,5 +45,6 @@ public class FoodCollectorSettings : MonoBehaviour
     public void Update()
     {
         scoreText.text = $"Score: {totalScore}";
+        Academy.Instance.GetSideChannel<StatsSideChannel>().AddStat("TotalScore", totalScore);
     }
 }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)
  - Raise the wall in CrawlerStatic scene to prevent Agent from falling off. (#3650)
- - Renamed 'Generalization' feature to 'Environment Parameter Randomization'.
+ - Added a feature to allow sending stats from C# environments to TensorBoard (and other python StatsWriters). To do this from your code, use `Academy.Instance.GetSideChannel<StatsSideChannel>().AddStat(key, value)` (#3660)
+- Renamed 'Generalization' feature to 'Environment Parameter Randomization'.
 
 ## [0.15.0-preview] - 2020-03-18
 ### Major Changes

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -237,22 +237,28 @@ namespace MLAgents
 
         /// <summary>
         /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
-        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
+        /// If there are multiple SideChannels of the same type registered, the returned instance is arbitrary.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         public T GetSideChannel<T>() where T: SideChannel
         {
-            return Communicator.GetSideChannel<T>();
+            return Communicator?.GetSideChannel<T>();
         }
 
         /// <summary>
-        /// Returns all SideChannels of Type T that are registered.
+        /// Returns all SideChannels of Type T that are registered. Use <see cref=GetSideChannel()> if possible, as
+        /// that does not make any memory allocations.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         public List<T> GetSideChannels<T>() where T: SideChannel
         {
+            if (Communicator == null)
+            {
+                // Make sure we return a non-null List.
+                return new List<T>();
+            }
             return Communicator.GetSideChannels<T>();
         }
 

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -247,8 +247,8 @@ namespace MLAgents
         }
 
         /// <summary>
-        /// Returns all SideChannels of Type T that are registered. Use <see cref=GetSideChannel()> if possible, as
-        /// that does not make any memory allocations.
+        /// Returns all SideChannels of Type T that are registered. Use <see cref="GetSideChannel{T}()"/> if possible,
+        /// as that does not make any memory allocations.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -236,6 +236,27 @@ namespace MLAgents
         }
 
         /// <summary>
+        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
+        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T GetSideChannel<T>() where T: SideChannel
+        {
+            return Communicator.GetSideChannel<T>();
+        }
+
+        /// <summary>
+        /// Returns all SideChannels of Type T that are registered.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public List<T> GetSideChannels<T>() where T: SideChannel
+        {
+            return Communicator.GetSideChannels<T>();
+        }
+
+        /// <summary>
         /// Disable stepping of the Academy during the FixedUpdate phase. If this is called, the Academy must be
         /// stepped manually by the user by calling Academy.EnvironmentStep().
         /// </summary>
@@ -334,6 +355,7 @@ namespace MLAgents
             {
                 Communicator.RegisterSideChannel(new EngineConfigurationChannel());
                 Communicator.RegisterSideChannel(floatProperties);
+                Communicator.RegisterSideChannel(new StatsSideChannel());
                 // We try to exchange the first message with Python. If this fails, it means
                 // no Python Process is ready to train the environment. In this case, the
                 //environment must use Inference.

--- a/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
@@ -167,5 +167,20 @@ namespace MLAgents
         /// </summary>
         /// <param name="sideChannel"> The side channel to be unregistered.</param>
         void UnregisterSideChannel(SideChannel sideChannel);
+
+        /// <summary>
+        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
+        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        T GetSideChannel<T>() where T : SideChannel;
+
+        /// <summary>
+        /// Returns all SideChannels of Type T that are registered.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        List<T> GetSideChannels<T>() where T : SideChannel;
     }
 }

--- a/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
@@ -170,14 +170,15 @@ namespace MLAgents
 
         /// <summary>
         /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
-        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
+        /// If there are multiple SideChannels of the same type registered, the returned instance is arbitrary.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         T GetSideChannel<T>() where T : SideChannel;
 
         /// <summary>
-        /// Returns all SideChannels of Type T that are registered.
+        /// Returns all SideChannels of Type T that are registered. Use <see cref="GetSideChannel{T}()"/> if possible,
+        /// as that does not make any memory allocations.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -538,6 +538,43 @@ namespace MLAgents
         }
 
         /// <summary>
+        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
+        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T GetSideChannel<T>() where T: SideChannel
+        {
+            foreach (var sc in m_SideChannels.Values)
+            {
+                if (sc.GetType() == typeof(T))
+                {
+                    return (T) sc;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns all SideChannels of Type T that are registered.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public List<T> GetSideChannels<T>() where T: SideChannel
+        {
+            var output = new List<T>();
+
+            foreach (var sc in m_SideChannels.Values)
+            {
+                if (sc.GetType() == typeof(T))
+                {
+                    output.Add((T) sc);
+                }
+            }
+            return output;
+        }
+
+        /// <summary>
         /// Grabs the messages that the registered side channels will send to Python at the current step
         /// into a singe byte array.
         /// </summary>

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -537,12 +537,7 @@ namespace MLAgents
             }
         }
 
-        /// <summary>
-        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
-        /// If there are multiple SideChannels of the same type registered, only the first found will be returned.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public T GetSideChannel<T>() where T: SideChannel
         {
             foreach (var sc in m_SideChannels.Values)
@@ -555,11 +550,7 @@ namespace MLAgents
             return null;
         }
 
-        /// <summary>
-        /// Returns all SideChannels of Type T that are registered.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public List<T> GetSideChannels<T>() where T: SideChannel
         {
             var output = new List<T>();

--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -13,7 +13,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Initializes the side channel.
         /// </summary>
-        public EngineConfigurationChannel()
+        internal EngineConfigurationChannel()
         {
             ChannelId = new Guid(k_EngineConfigId);
         }

--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -8,10 +8,11 @@ namespace MLAgents.SideChannels
     /// </summary>
     public class EngineConfigurationChannel : SideChannel
     {
-        private const string k_EngineConfigId = "e951342c-4f7e-11ea-b238-784f4387d1f7";
+        const string k_EngineConfigId = "e951342c-4f7e-11ea-b238-784f4387d1f7";
 
         /// <summary>
-        /// Initializes the side channel.
+        /// Initializes the side channel. The constructor is internal because only one instance is
+        /// supported at a time, and is created by the Academy.
         /// </summary>
         internal EngineConfigurationChannel()
         {

--- a/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
@@ -1,0 +1,41 @@
+using System;
+namespace MLAgents.SideChannels
+{
+    public class StatsSideChannel : SideChannel
+    {
+        const string k_StatsSideChannelDefaultId = "a1d8f7b7-cec8-50f9-b78b-d3e165a78520";
+
+        /// <summary>
+        /// Initializes the side channel with the provided channel ID.
+        /// </summary>
+        internal StatsSideChannel()
+        {
+            ChannelId = new Guid(k_StatsSideChannelDefaultId);
+        }
+
+        /// <summary>
+        /// Add a stat value for reporting. This will appear in the Tensorboard summary and trainer gauges.
+        /// You can nest stats in Tensorboard with "/".
+        /// Note that stats are only written to Tensorboard each summary_frequency steps; if a stat is
+        /// received multiple times, only the most recent version is used.
+        /// To avoid conflicts between multiple environments, only stats from worker index 0 are used.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        public void AddStat(string key, float value)
+        {
+            using (var msg = new OutgoingMessage())
+            {
+                msg.WriteString(key);
+                msg.WriteFloat32(value);
+                QueueMessageToSend(msg);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void OnMessageReceived(IncomingMessage msg)
+        {
+            throw new UnityAgentsException("StatsSideChannel should never receive messages.");
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
@@ -1,12 +1,39 @@
 using System;
 namespace MLAgents.SideChannels
 {
+    /// <summary>
+    /// Determines the behavior of how multiple stats within the same summary period are combined.
+    /// </summary>
+    public enum StatAggregationMethod
+    {
+        /// <summary>
+        /// Values within the summary period are averaged before reporting.
+        /// Note that values from the same C# environment in the same step may replace each other.
+        /// </summary>
+        Average = 0,
+
+        /// <summary>
+        /// Only the most recent value is reported.
+        /// To avoid conflicts between multiple environments, the ML Agents environment will only
+        /// keep stats from worker index 0.
+        /// </summary>
+        MostRecent = 1
+    }
+
+    /// <summary>
+    /// Add stats (key-value pairs) for reporting. The ML Agents environment will send these to a StatsReporter
+    /// instance, which means the values will appear in the Tensorboard summary, as well as trainer gauges.
+    /// Note that stats are only written every summary_frequency steps; See <see cref="StatAggregationMethod"/>
+    /// for options on how multiple values are handled.
+    /// </summary>
     public class StatsSideChannel : SideChannel
     {
         const string k_StatsSideChannelDefaultId = "a1d8f7b7-cec8-50f9-b78b-d3e165a78520";
 
         /// <summary>
         /// Initializes the side channel with the provided channel ID.
+        /// The constructor is internal because only one instance is
+        /// supported at a time, and is created by the Academy.
         /// </summary>
         internal StatsSideChannel()
         {
@@ -20,14 +47,18 @@ namespace MLAgents.SideChannels
         /// received multiple times, only the most recent version is used.
         /// To avoid conflicts between multiple environments, only stats from worker index 0 are used.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        public void AddStat(string key, float value)
+        /// <param name="key">The stat name.</param>
+        /// <param name="value">The stat value. You can nest stats in Tensorboard by using "/". </param>
+        /// <param name="aggregationMethod">How multiple values should be treated.</param>
+        public void AddStat(
+            string key, float value, StatAggregationMethod aggregationMethod = StatAggregationMethod.Average
+            )
         {
             using (var msg = new OutgoingMessage())
             {
                 msg.WriteString(key);
                 msg.WriteFloat32(value);
+                msg.WriteInt32((int)aggregationMethod);
                 QueueMessageToSend(msg);
             }
         }

--- a/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs.meta
+++ b/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83a07fdb9e8f04536908a51447dfe548
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -87,3 +87,10 @@ The ML-Agents training program saves the following statistics:
   taken between two observations.
 
 * `Losses/Cloning Loss` (BC) - The mean magnitude of the behavioral cloning loss. Corresponds to how well the model imitates the demonstration data.
+
+## Custom Metrics from C#
+To get custom metrics from a C# environment into Tensorboard, you can use the StatsSideChannel:
+```csharp
+var statsSideChannel = Academy.Instance.GetSideChannel<StatsSideChannel>();
+statsSideChannel.AddStat("MyMetric", 1.0);
+```

--- a/ml-agents-envs/mlagents_envs/side_channel/stats_side_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/stats_side_channel.py
@@ -1,22 +1,48 @@
 from mlagents_envs.side_channel import SideChannel, IncomingMessage
 import uuid
-from typing import Dict
+from typing import Dict, Tuple
+from enum import Enum
+
+
+# Determines the behavior of how multiple stats within the same summary period are combined.
+class StatsAggregationMethod(Enum):
+    # Values within the summary period are averaged before reporting.
+    AVERAGE = 0
+
+    # Only the most recent value is reported.
+    MOST_RECENT = 1
 
 
 class StatsSideChannel(SideChannel):
+    """
+    Side channel that receives (string, float) pairs from the environment, so that they can eventually
+    be passed to a StatsReporter.
+    """
+
     def __init__(self) -> None:
         # >>> uuid.uuid5(uuid.NAMESPACE_URL, "com.unity.ml-agents/StatsSideChannel")
         # UUID('a1d8f7b7-cec8-50f9-b78b-d3e165a78520')
         super().__init__(uuid.UUID("a1d8f7b7-cec8-50f9-b78b-d3e165a78520"))
 
-        self.stats: Dict[str, float] = {}
+        self.stats: Dict[str, Tuple[float, StatsAggregationMethod]] = {}
 
     def on_message_received(self, msg: IncomingMessage) -> None:
+        """
+        Receive the message from the environment, and save it for later retrieval.
+        :param msg:
+        :return:
+        """
         key = msg.read_string()
         val = msg.read_float32()
-        self.stats[key] = val
+        agg_type = StatsAggregationMethod(msg.read_int32())
 
-    def get_and_reset_stats(self) -> Dict[str, float]:
+        self.stats[key] = (val, agg_type)
+
+    def get_and_reset_stats(self) -> Dict[str, Tuple[float, StatsAggregationMethod]]:
+        """
+        Returns the current stats, and resets the internal storage of the stats.
+        :return:
+        """
         s = self.stats
         self.stats = {}
         return s

--- a/ml-agents-envs/mlagents_envs/side_channel/stats_side_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/stats_side_channel.py
@@ -1,0 +1,22 @@
+from mlagents_envs.side_channel import SideChannel, IncomingMessage
+import uuid
+from typing import Dict
+
+
+class StatsSideChannel(SideChannel):
+    def __init__(self) -> None:
+        # >>> uuid.uuid5(uuid.NAMESPACE_URL, "com.unity.ml-agents/StatsSideChannel")
+        # UUID('a1d8f7b7-cec8-50f9-b78b-d3e165a78520')
+        super().__init__(uuid.UUID("a1d8f7b7-cec8-50f9-b78b-d3e165a78520"))
+
+        self.stats: Dict[str, float] = {}
+
+    def on_message_received(self, msg: IncomingMessage) -> None:
+        key = msg.read_string()
+        val = msg.read_float32()
+        self.stats[key] = val
+
+    def get_and_reset_stats(self) -> Dict[str, float]:
+        s = self.stats
+        self.stats = {}
+        return s

--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -258,3 +258,8 @@ class AgentManager(AgentProcessor):
             self.behavior_id
         )
         self.publish_trajectory_queue(self.trajectory_queue)
+
+    def set_environment_stats(self, env_stats: Dict[str, float]) -> None:
+        for stat_name, val in env_stats.items():
+            # full_stat = f"Environment/{stat_name}"
+            self.stats_reporter.set_stat(stat_name, val)

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -17,6 +17,7 @@ class EnvironmentStep(NamedTuple):
     current_all_step_result: AllStepResult
     worker_id: int
     brain_name_to_action_info: Dict[AgentGroup, ActionInfo]
+    environment_stats: Dict[str, float]
 
     @property
     def name_behavior_ids(self) -> Iterable[AgentGroup]:
@@ -24,7 +25,7 @@ class EnvironmentStep(NamedTuple):
 
     @staticmethod
     def empty(worker_id: int) -> "EnvironmentStep":
-        return EnvironmentStep({}, worker_id, {})
+        return EnvironmentStep({}, worker_id, {}, {})
 
 
 class EnvManager(ABC):
@@ -108,4 +109,11 @@ class EnvManager(ABC):
                         name_behavior_id, ActionInfo.empty()
                     ),
                 )
+
+                # In order to prevent conflicts between multiple environments,
+                # only stats from the first environment are recorded.
+                if step_info.worker_id == 0:
+                    self.agent_managers[name_behavior_id].set_environment_stats(
+                        step_info.environment_stats
+                    )
         return len(step_infos)

--- a/ml-agents/mlagents/trainers/simple_env_manager.py
+++ b/ml-agents/mlagents/trainers/simple_env_manager.py
@@ -31,7 +31,9 @@ class SimpleEnvManager(EnvManager):
         self.env.step()
         all_step_result = self._generate_all_results()
 
-        step_info = EnvironmentStep(all_step_result, 0, self.previous_all_action_info)
+        step_info = EnvironmentStep(
+            all_step_result, 0, self.previous_all_action_info, {}
+        )
         self.previous_step = step_info
         return [step_info]
 
@@ -43,7 +45,7 @@ class SimpleEnvManager(EnvManager):
                 self.shared_float_properties.set_property(k, v)
         self.env.reset()
         all_step_result = self._generate_all_results()
-        self.previous_step = EnvironmentStep(all_step_result, 0, {})
+        self.previous_step = EnvironmentStep(all_step_result, 0, {}, {})
         return [self.previous_step]
 
     @property

--- a/ml-agents/mlagents/trainers/tests/test_agent_processor.py
+++ b/ml-agents/mlagents/trainers/tests/test_agent_processor.py
@@ -9,8 +9,9 @@ from mlagents.trainers.agent_processor import (
 )
 from mlagents.trainers.action_info import ActionInfo
 from mlagents.trainers.trajectory import Trajectory
-from mlagents.trainers.stats import StatsReporter
+from mlagents.trainers.stats import StatsReporter, StatsSummary
 from mlagents.trainers.brain_conversion_utils import get_global_agent_id
+from mlagents_envs.side_channel.stats_side_channel import StatsAggregationMethod
 
 
 def create_mock_brain():
@@ -229,3 +230,34 @@ def test_agent_manager_queue():
     queue_traj = queue.get_nowait()
     assert isinstance(queue_traj, Trajectory)
     assert queue.empty()
+
+
+def test_agent_manager_stats():
+    policy = mock.Mock()
+    stats_reporter = StatsReporter("FakeCategory")
+    writer = mock.Mock()
+    stats_reporter.add_writer(writer)
+    manager = AgentManager(policy, "MyBehavior", stats_reporter)
+
+    all_env_stats = [
+        {
+            "averaged": (1.0, StatsAggregationMethod.AVERAGE),
+            "most_recent": (2.0, StatsAggregationMethod.MOST_RECENT),
+        },
+        {
+            "averaged": (3.0, StatsAggregationMethod.AVERAGE),
+            "most_recent": (4.0, StatsAggregationMethod.MOST_RECENT),
+        },
+    ]
+    for env_stats in all_env_stats:
+        manager.record_environment_stats(env_stats, worker_id=0)
+
+    expected_stats = {
+        "averaged": StatsSummary(mean=2.0, std=mock.ANY, num=2),
+        "most_recent": StatsSummary(mean=4.0, std=0.0, num=1),
+    }
+    stats_reporter.write_stats(123)
+    writer.write_stats.assert_any_call("FakeCategory", expected_stats, 123)
+
+    # clean up our Mock from the global list
+    StatsReporter.writers.remove(writer)

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -12,6 +12,7 @@ from mlagents.trainers.subprocess_env_manager import (
 from mlagents.trainers.env_manager import EnvironmentStep
 from mlagents_envs.base_env import BaseEnv
 from mlagents_envs.side_channel.engine_configuration_channel import EngineConfig
+from mlagents_envs.side_channel.stats_side_channel import StatsAggregationMethod
 from mlagents.trainers.tests.simple_test_envs import Simple1DEnvironment
 from mlagents.trainers.stats import StatsReporter
 from mlagents.trainers.tests.test_simple_rl import (
@@ -147,7 +148,11 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         env_manager.set_agent_manager(brain_name, agent_manager_mock)
 
         step_info_dict = {brain_name: Mock()}
-        step_info = EnvironmentStep(step_info_dict, 0, action_info_dict, {})
+        env_stats = {
+            "averaged": (1.0, StatsAggregationMethod.AVERAGE),
+            "most_recent": (2.0, StatsAggregationMethod.MOST_RECENT),
+        }
+        step_info = EnvironmentStep(step_info_dict, 0, action_info_dict, env_stats)
         step_mock.return_value = [step_info]
         env_manager.advance()
 

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -102,8 +102,8 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         )
         manager.step_queue = Mock()
         manager.step_queue.get_nowait.side_effect = [
-            EnvironmentResponse("step", 0, StepResponse(0, None)),
-            EnvironmentResponse("step", 1, StepResponse(1, None)),
+            EnvironmentResponse("step", 0, StepResponse(0, None, {})),
+            EnvironmentResponse("step", 1, StepResponse(1, None, {})),
             EmptyQueue(),
         ]
         step_mock = Mock()
@@ -147,7 +147,7 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         env_manager.set_agent_manager(brain_name, agent_manager_mock)
 
         step_info_dict = {brain_name: Mock()}
-        step_info = EnvironmentStep(step_info_dict, 0, action_info_dict)
+        step_info = EnvironmentStep(step_info_dict, 0, action_info_dict, {})
         step_mock.return_value = [step_info]
         env_manager.advance()
 


### PR DESCRIPTION
### Proposed change(s)

Add a SideChannel that can be used to sent stats from C# to python, and later add those to TensorBoard.
Also adds methods to the Academy to find an instance (or instances) of specific SideChannel subclass (inspired by [MonoBehaviour.GetComponent(s)](https://docs.unity3d.com/ScriptReference/Component.GetComponent.html))

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-675
https://forum.unity.com/threads/custom-graphs-in-tensorboard.843865/
https://github.com/Unity-Technologies/ml-agents/issues/2984
https://github.com/Unity-Technologies/ml-agents/pull/3594/files

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
Sample graph of the number of time the 3DBallAgent drops the ball
![image](https://user-images.githubusercontent.com/6877802/77122671-80648300-69fb-11ea-9dd2-ddac6a8d5d80.png)
