### PR TITLE
Fix editor port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ COPY ml-agents /ml-agents
 WORKDIR /ml-agents
 RUN pip install -e .
 
-# port 5005 is the port used in in Editor training.
-EXPOSE 5005
+# port 5004 is the port used in in Editor training.
+EXPOSE 5004
 
 ENTRYPOINT ["mlagents-learn"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,9 @@ COPY ml-agents /ml-agents
 WORKDIR /ml-agents
 RUN pip install -e .
 
-# port 5004 is the port used in in Editor training.
-EXPOSE 5004
+# Port 5004 is the port used in in Editor training.
+# Environments will start from port 5005, 
+# so allow enough ports for several environments.
+EXPOSE 5004-5050
 
 ENTRYPOINT ["mlagents-learn"]


### PR DESCRIPTION
### Proposed change(s)
I noticed this while searching for hardcoded ports in https://github.com/Unity-Technologies/ml-agents/pull/3673.

5004 has been the editor port for a while now.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
