### PR TITLE
Remove vis_encode_type from list of required

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)
  - Raise the wall in CrawlerStatic scene to prevent Agent from falling off. (#3650)
  - Renamed 'Generalization' feature to 'Environment Parameter Randomization'.
+ - Fixed an issue where specifying `vis_encode_type` was required only for SAC. (#3677)
 
 ## [0.15.0-preview] - 2020-03-18
 ### Major Changes

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -73,7 +73,6 @@ class SACTrainer(RLTrainer):
             "memory_size",
             "model_path",
             "reward_signals",
-            "vis_encode_type",
         ]
 
         self._check_param_keys()


### PR DESCRIPTION
### Proposed change(s)

As described here: https://github.com/Unity-Technologies/ml-agents/issues/3675, our docs say vis_encode_type is optional for both PPO and SAC but it is required for SAC, even though internally it will default to `simple`. This PR removes it from the list of required hyperparams. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

MLA-790
https://github.com/Unity-Technologies/ml-agents/issues/3675

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)