### PR TITLE
Raise exceptions from environment subprocesses

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The way that UnityEnvironment decides the port was changed. If no port is specified, the behavior will depend on the `file_name` parameter. If it is `None`, 5004 (the editor port) will be used; otherwise 5005 (the base environment port) will be used.
  - Fixed an issue where switching models using `SetModel()` during training would use an excessive amount of memory. (#3664)
  - Environment subprocesses now close immediately on timeout or wrong API version. (#3679)
+ - Fixed an issue where exceptions from environments provided a returncode of 0. (#3680)
 
 ## [0.15.0-preview] - 2020-03-18
 ### Major Changes

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, NamedTuple, List, Any, Optional, Callable, Set, Tuple
 import cloudpickle
+import enum
 
 from mlagents_envs.environment import UnityEnvironment
 from mlagents_envs.exception import (
@@ -37,13 +38,22 @@ from mlagents.trainers.brain_conversion_utils import group_spec_to_brain_paramet
 logger = logging.getLogger("mlagents.trainers")
 
 
-class EnvironmentCommand(NamedTuple):
-    name: str
+class EnvironmentCommand(enum.Enum):
+    STEP = 1
+    EXTERNAL_BRAINS = 2
+    GET_PROPERTIES = 3
+    RESET = 4
+    CLOSE = 5
+    ENV_EXITED = 6
+
+
+class EnvironmentRequest(NamedTuple):
+    cmd: EnvironmentCommand
     payload: Any = None
 
 
 class EnvironmentResponse(NamedTuple):
-    name: str
+    cmd: EnvironmentCommand
     worker_id: int
     payload: Any
 
@@ -63,17 +73,17 @@ class UnityEnvWorker:
         self.previous_all_action_info: Dict[str, ActionInfo] = {}
         self.waiting = False
 
-    def send(self, name: str, payload: Any = None) -> None:
+    def send(self, cmd: EnvironmentCommand, payload: Any = None) -> None:
         try:
-            cmd = EnvironmentCommand(name, payload)
-            self.conn.send(cmd)
+            req = EnvironmentRequest(cmd, payload)
+            self.conn.send(req)
         except (BrokenPipeError, EOFError):
             raise UnityCommunicationException("UnityEnvironment worker: send failed.")
 
     def recv(self) -> EnvironmentResponse:
         try:
             response: EnvironmentResponse = self.conn.recv()
-            if response.name == "env_close":
+            if response.cmd == EnvironmentCommand.ENV_EXITED:
                 env_exception: Exception = response.payload
                 raise env_exception
             return response
@@ -82,7 +92,7 @@ class UnityEnvWorker:
 
     def close(self):
         try:
-            self.conn.send(EnvironmentCommand("close"))
+            self.conn.send(EnvironmentRequest(EnvironmentCommand.CLOSE))
         except (BrokenPipeError, EOFError):
             logger.debug(
                 f"UnityEnvWorker {self.worker_id} got exception trying to close."
@@ -108,7 +118,7 @@ def worker(
     stats_channel = StatsSideChannel()
     env: BaseEnv = None
 
-    def _send_response(cmd_name, payload):
+    def _send_response(cmd_name: EnvironmentCommand, payload: Any) -> None:
         parent_conn.send(EnvironmentResponse(cmd_name, worker_id, payload))
 
     def _generate_all_results() -> AllStepResult:
@@ -131,9 +141,9 @@ def worker(
             [shared_float_properties, engine_configuration_channel, stats_channel],
         )
         while True:
-            cmd: EnvironmentCommand = parent_conn.recv()
-            if cmd.name == "step":
-                all_action_info = cmd.payload
+            req: EnvironmentRequest = parent_conn.recv()
+            if req.cmd == EnvironmentCommand.STEP:
+                all_action_info = req.payload
                 for brain_name, action_info in all_action_info.items():
                     if len(action_info.action) != 0:
                         env.set_actions(brain_name, action_info.action)
@@ -148,20 +158,20 @@ def worker(
                 step_response = StepResponse(
                     all_step_result, get_timer_root(), env_stats
                 )
-                step_queue.put(EnvironmentResponse("step", worker_id, step_response))
+                step_queue.put(EnvironmentResponse(EnvironmentCommand.STEP, worker_id, step_response))
                 reset_timers()
-            elif cmd.name == "external_brains":
-                _send_response("external_brains", external_brains())
-            elif cmd.name == "get_properties":
+            elif req.cmd == EnvironmentCommand.EXTERNAL_BRAINS:
+                _send_response(EnvironmentCommand.EXTERNAL_BRAINS, external_brains())
+            elif req.cmd == EnvironmentCommand.GET_PROPERTIES:
                 reset_params = shared_float_properties.get_property_dict_copy()
-                _send_response("get_properties", reset_params)
-            elif cmd.name == "reset":
-                for k, v in cmd.payload.items():
+                _send_response(EnvironmentCommand.GET_PROPERTIES, reset_params)
+            elif req.cmd == EnvironmentCommand.RESET:
+                for k, v in req.payload.items():
                     shared_float_properties.set_property(k, v)
                 env.reset()
                 all_step_result = _generate_all_results()
-                _send_response("reset", all_step_result)
-            elif cmd.name == "close":
+                _send_response(EnvironmentCommand.RESET, all_step_result)
+            elif req.cmd == EnvironmentCommand.CLOSE:
                 break
     except (
         KeyboardInterrupt,
@@ -170,8 +180,10 @@ def worker(
         UnityEnvironmentException,
     ) as ex:
         logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
-        step_queue.put(EnvironmentResponse("env_close", worker_id, ex))
-        _send_response("env_close", ex)
+        step_queue.put(
+            EnvironmentResponse(EnvironmentCommand.ENV_EXITED, worker_id, ex)
+        )
+        _send_response(EnvironmentCommand.ENV_EXITED, ex)
     finally:
         # If this worker has put an item in the step queue that hasn't been processed by the EnvManager, the process
         # will hang until the item is processed. We avoid this behavior by using Queue.cancel_join_thread()
@@ -232,7 +244,7 @@ class SubprocessEnvManager(EnvManager):
             if not env_worker.waiting:
                 env_action_info = self._take_step(env_worker.previous_step)
                 env_worker.previous_all_action_info = env_action_info
-                env_worker.send("step", env_action_info)
+                env_worker.send(EnvironmentCommand.STEP, env_action_info)
                 env_worker.waiting = True
 
     def _step(self) -> List[EnvironmentStep]:
@@ -246,8 +258,8 @@ class SubprocessEnvManager(EnvManager):
         while len(worker_steps) < 1:
             try:
                 while True:
-                    step = self.step_queue.get_nowait()
-                    if step.name == "env_close":
+                    step: EnvironmentResponse = self.step_queue.get_nowait()
+                    if step.cmd == EnvironmentCommand.ENV_EXITED:
                         env_exception: Exception = step.payload
                         raise env_exception
                     self.env_workers[step.worker_id].waiting = False
@@ -267,7 +279,7 @@ class SubprocessEnvManager(EnvManager):
                 self.env_workers[step.worker_id].waiting = False
         # First enqueue reset commands for all workers so that they reset in parallel
         for ew in self.env_workers:
-            ew.send("reset", config)
+            ew.send(EnvironmentCommand.RESET, config)
         # Next (synchronously) collect the reset observations from each worker in sequence
         for ew in self.env_workers:
             ew.previous_step = EnvironmentStep(ew.recv().payload, ew.worker_id, {}, {})
@@ -275,12 +287,12 @@ class SubprocessEnvManager(EnvManager):
 
     @property
     def external_brains(self) -> Dict[AgentGroup, BrainParameters]:
-        self.env_workers[0].send("external_brains")
+        self.env_workers[0].send(EnvironmentCommand.EXTERNAL_BRAINS)
         return self.env_workers[0].recv().payload
 
     @property
     def get_properties(self) -> Dict[AgentGroup, float]:
-        self.env_workers[0].send("get_properties")
+        self.env_workers[0].send(EnvironmentCommand.GET_PROPERTIES)
         return self.env_workers[0].recv().payload
 
     def close(self) -> None:

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -136,7 +136,7 @@ def worker(
         return result
 
     try:
-        env: BaseEnv = env_factory(
+        env = env_factory(
             worker_id,
             [shared_float_properties, engine_configuration_channel, stats_channel],
         )
@@ -158,7 +158,11 @@ def worker(
                 step_response = StepResponse(
                     all_step_result, get_timer_root(), env_stats
                 )
-                step_queue.put(EnvironmentResponse(EnvironmentCommand.STEP, worker_id, step_response))
+                step_queue.put(
+                    EnvironmentResponse(
+                        EnvironmentCommand.STEP, worker_id, step_response
+                    )
+                )
                 reset_timers()
             elif req.cmd == EnvironmentCommand.EXTERNAL_BRAINS:
                 _send_response(EnvironmentCommand.EXTERNAL_BRAINS, external_brains())

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -223,7 +223,7 @@ class TrainerController(object):
                 pass
             else:
                 # If the environment failed, we want to make sure to raise
-                # the exception so we get the correct error code.
+                # the exception so we exit the process with an return code of 1.
                 raise ex
         if self.train_model:
             self._export_graph()

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -211,10 +211,20 @@ class TrainerController(object):
             # Final save Tensorflow model
             if global_step != 0 and self.train_model:
                 self._save_model()
-        except (KeyboardInterrupt, UnityCommunicationException):
+        except (
+            KeyboardInterrupt,
+            UnityCommunicationException,
+            UnityEnvironmentException,
+        ) as ex:
             if self.train_model:
                 self._save_model_when_interrupted()
-            pass
+
+            if isinstance(ex, KeyboardInterrupt):
+                pass
+            else:
+                # If the environment failed, we want to make sure to raise
+                # the exception so we get the correct error code.
+                raise ex
         if self.train_model:
             self._export_graph()
 


### PR DESCRIPTION
### Proposed change(s)

This commit surfaces exceptions from environment worker subprocesses,
and changes the SubprocessEnvManager to raise those exceptions when
caught.  Additionally TrainerController was changed to treat environment
exceptions differently than KeyboardInterrupts.  We now raise the
environment exceptions after exporting the model, so that ML-Agents will
correctly exit with a non-zero return code.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
