### PR TITLE
Remove "docker target" feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,4 +137,4 @@ RUN pip install -e .
 # so allow enough ports for several environments.
 EXPOSE 5004-5050
 
-ENTRYPOINT ["mlagents-learn"]
+ENTRYPOINT ["xvfb-run", "--auto-servernum", "--server-args='-screen 0 640x480x24'", "mlagents-learn"]

--- a/docs/Using-Docker.md
+++ b/docs/Using-Docker.md
@@ -95,7 +95,6 @@ docker run -it --name <container-name> \
            -p 5005:5005 \
            -p 6006:6006 \
            <image-name>:latest \
-           --docker-target-name=unity-volume \
            <trainer-config-file> \
            --env=<environment-name> \
            --train \
@@ -117,9 +116,6 @@ Notes on argument values:
 - `source`: Reference to the path in your host OS where you will store the Unity
   executable.
 - `target`: Tells Docker to mount the `source` path as a disk with this name.
-- `docker-target-name`: Tells the ML-Agents Python package what the name of the
-  disk where it can read the Unity executable and store the graph. **This should
-  therefore be identical to `target`.**
 - `trainer-config-file`, `train`, `run-id`: ML-Agents arguments passed to
   `mlagents-learn`. `trainer-config-file` is the filename of the trainer config
   file, `train` trains the algorithm, and `run-id` is used to tag each
@@ -134,9 +130,8 @@ docker run -it --name 3DBallContainer.first.trial \
            -p 5005:5005 \
            -p 6006:6006 \
            balance.ball.v0.1:latest 3DBall \
-           --docker-target-name=unity-volume \
-           trainer_config.yaml \
-           --env=3DBall \
+           /unity-volume/trainer_config.yaml \
+           --env=/unity-volume/3DBall \
            --train \
            --run-id=3dball_first_trial
 ```

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -3,8 +3,6 @@ import logging
 import argparse
 
 import os
-import glob
-import shutil
 import numpy as np
 import json
 
@@ -102,12 +100,6 @@ def _create_parser():
         help="Number of parallel environments to use for training",
     )
     argparser.add_argument(
-        "--docker-target-name",
-        default=None,
-        dest="docker_target_name",
-        help="Docker volume to store training-specific files",
-    )
-    argparser.add_argument(
         "--no-graphics",
         default=False,
         action="store_true",
@@ -185,7 +177,6 @@ class RunOptions(NamedTuple):
     no_graphics: bool = parser.get_default("no_graphics")
     multi_gpu: bool = parser.get_default("multi_gpu")
     sampler_config: Optional[Dict] = None
-    docker_target_name: Optional[str] = parser.get_default("docker_target_name")
     env_args: Optional[List[str]] = parser.get_default("env_args")
     cpu: bool = parser.get_default("cpu")
     width: int = parser.get_default("width")
@@ -204,15 +195,8 @@ class RunOptions(NamedTuple):
           configs loaded from files.
         """
         argparse_args = vars(args)
-        docker_target_name = argparse_args["docker_target_name"]
         trainer_config_path = argparse_args["trainer_config_path"]
         curriculum_config_path = argparse_args["curriculum_config_path"]
-        if docker_target_name is not None:
-            trainer_config_path = f"/{docker_target_name}/{trainer_config_path}"
-            if curriculum_config_path is not None:
-                curriculum_config_path = (
-                    f"/{docker_target_name}/{curriculum_config_path}"
-                )
         argparse_args["trainer_config"] = load_config(trainer_config_path)
         if curriculum_config_path is not None:
             argparse_args["curriculum_config"] = load_config(curriculum_config_path)
@@ -251,13 +235,8 @@ def run_training(run_seed: int, options: RunOptions) -> None:
     :param run_options: Command line arguments for training.
     """
     with hierarchical_timer("run_training.setup"):
-        # Recognize and use docker volume if one is passed as an argument
-        if not options.docker_target_name:
-            model_path = f"./models/{options.run_id}"
-            summaries_dir = "./summaries"
-        else:
-            model_path = f"/{options.docker_target_name}/models/{options.run_id}"
-            summaries_dir = f"/{options.docker_target_name}/summaries"
+        model_path = f"./models/{options.run_id}"
+        summaries_dir = "./summaries"
         port = options.base_port
 
         # Configure CSV, Tensorboard Writers and StatsReporter
@@ -280,12 +259,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
         if options.env_path is None:
             port = UnityEnvironment.DEFAULT_EDITOR_PORT
         env_factory = create_environment_factory(
-            options.env_path,
-            options.docker_target_name,
-            options.no_graphics,
-            run_seed,
-            port,
-            options.env_args,
+            options.env_path, options.no_graphics, run_seed, port, options.env_args
         )
         engine_config = EngineConfig(
             options.width,
@@ -381,31 +355,8 @@ def try_create_meta_curriculum(
         return meta_curriculum
 
 
-def prepare_for_docker_run(docker_target_name, env_path):
-    for f in glob.glob(
-        "/{docker_target_name}/*".format(docker_target_name=docker_target_name)
-    ):
-        if env_path in f:
-            try:
-                b = os.path.basename(f)
-                if os.path.isdir(f):
-                    shutil.copytree(f, "/ml-agents/{b}".format(b=b))
-                else:
-                    src_f = "/{docker_target_name}/{b}".format(
-                        docker_target_name=docker_target_name, b=b
-                    )
-                    dst_f = "/ml-agents/{b}".format(b=b)
-                    shutil.copyfile(src_f, dst_f)
-                    os.chmod(dst_f, 0o775)  # Make executable
-            except Exception as e:
-                logging.getLogger("mlagents.trainers").info(e)
-    env_path = "/ml-agents/{env_path}".format(env_path=env_path)
-    return env_path
-
-
 def create_environment_factory(
     env_path: Optional[str],
-    docker_target_name: Optional[str],
     no_graphics: bool,
     seed: int,
     start_port: int,
@@ -417,15 +368,6 @@ def create_environment_factory(
             raise UnityEnvironmentException(
                 f"Couldn't launch the {env_path} environment. Provided filename does not match any environments."
             )
-    docker_training = docker_target_name is not None
-    if docker_training and env_path is not None:
-        #     Comments for future maintenance:
-        #         Some OS/VM instances (e.g. COS GCP Image) mount filesystems
-        #         with COS flag which prevents execution of the Unity scene,
-        #         to get around this, we will copy the executable into the
-        #         container.
-        # Navigate in docker path and find env_path and copy it.
-        env_path = prepare_for_docker_run(docker_target_name, env_path)
 
     def create_unity_environment(
         worker_id: int, side_channels: List[SideChannel]
@@ -436,7 +378,6 @@ def create_environment_factory(
             file_name=env_path,
             worker_id=worker_id,
             seed=env_seed,
-            docker_training=docker_training,
             no_graphics=no_graphics,
             base_port=start_port,
             args=env_args,

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -53,37 +53,10 @@ def test_run_training(
     StatsReporter.writers.clear()  # make sure there aren't any writers as added by learn.py
 
 
-@patch("mlagents.trainers.learn.SamplerManager")
-@patch("mlagents.trainers.learn.SubprocessEnvManager")
-@patch("mlagents.trainers.learn.create_environment_factory")
-@patch("mlagents.trainers.learn.load_config")
-def test_docker_target_path(
-    load_config, create_environment_factory, subproc_env_mock, sampler_manager_mock
-):
-    mock_env = MagicMock()
-    mock_env.external_brain_names = []
-    mock_env.academy_name = "TestAcademyName"
-    create_environment_factory.return_value = mock_env
-    trainer_config_mock = MagicMock()
-    load_config.return_value = trainer_config_mock
-
-    options_with_docker_target = basic_options({"--docker-target-name": "dockertarget"})
-
-    mock_init = MagicMock(return_value=None)
-    with patch.object(TrainerController, "__init__", mock_init):
-        with patch.object(TrainerController, "start_learning", MagicMock()):
-            learn.run_training(0, options_with_docker_target)
-            mock_init.assert_called_once()
-            assert mock_init.call_args[0][1] == "/dockertarget/models/ppo"
-            assert mock_init.call_args[0][2] == "/dockertarget/summaries"
-    StatsReporter.writers.clear()  # make sure there aren't any writers as added by learn.py
-
-
 def test_bad_env_path():
     with pytest.raises(UnityEnvironmentException):
         learn.create_environment_factory(
             env_path="/foo/bar",
-            docker_target_name=None,
             no_graphics=True,
             seed=None,
             start_port=8000,
@@ -113,7 +86,6 @@ def test_commandline_args(mock_file):
     assert opt.train_model is False
     assert opt.base_port == 5005
     assert opt.num_envs == 1
-    assert opt.docker_target_name is None
     assert opt.no_graphics is False
     assert opt.debug is False
     assert opt.env_args is None
@@ -132,7 +104,6 @@ def test_commandline_args(mock_file):
         "--train",
         "--base-port=4004",
         "--num-envs=2",
-        "--docker-target-name=mydockertarget",
         "--no-graphics",
         "--debug",
     ]
@@ -151,7 +122,6 @@ def test_commandline_args(mock_file):
     assert opt.train_model is True
     assert opt.base_port == 4004
     assert opt.num_envs == 2
-    assert opt.docker_target_name == "mydockertarget"
     assert opt.no_graphics is True
     assert opt.debug is True
 


### PR DESCRIPTION
### Proposed change(s)

The "docker target" feature and associated command-line flag
--docker-target-name were created for use with the now-deprecated
Docker setup.  This feature redirects the paths used by learn.py
for the environment and config files to be based from a directory
other than the current working directory.  Additionally it wrapped
the environment execution with xvfb-run.

This change removes the "docker target" feature because:

* Renaming the paths doesn't fix any problem.  Absolute paths can
  already be passed for configs and environment executables.
* Use of xserver, Xvfb, or xvfb-run are independent of mlagents-learn
  and can be used outside of the mlagents-learn call.  Further, xvfb-run
  is not the only solution for software rendering.
* The feature is confusing, since it doesn't actually involve the Docker tool
   at all.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [x] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
