### PR TITLE
Deprecating Academy.Instance.FloatProperties

### DIFF
--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
@@ -13,7 +13,7 @@ public class Ball3DAgent : Agent
     public override void Initialize()
     {
         m_BallRb = ball.GetComponent<Rigidbody>();
-        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
         SetResetParameters();
     }
 

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
@@ -13,7 +13,7 @@ public class Ball3DAgent : Agent
     public override void Initialize()
     {
         m_BallRb = ball.GetComponent<Rigidbody>();
-        m_ResetParams = Academy.Instance.FloatProperties;
+        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
         SetResetParameters();
     }
 

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
@@ -13,7 +13,7 @@ public class Ball3DHardAgent : Agent
     public override void Initialize()
     {
         m_BallRb = ball.GetComponent<Rigidbody>();
-        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
         SetResetParameters();
     }
 

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
@@ -13,7 +13,7 @@ public class Ball3DHardAgent : Agent
     public override void Initialize()
     {
         m_BallRb = ball.GetComponent<Rigidbody>();
-        m_ResetParams = Academy.Instance.FloatProperties;
+        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
         SetResetParameters();
     }
 

--- a/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
@@ -22,7 +22,7 @@ public class BouncerAgent : Agent
         m_Rb = gameObject.GetComponent<Rigidbody>();
         m_LookDir = Vector3.zero;
 
-        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 
         SetResetParameters();
     }

--- a/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
@@ -22,7 +22,7 @@ public class BouncerAgent : Agent
         m_Rb = gameObject.GetComponent<Rigidbody>();
         m_LookDir = Vector3.zero;
 
-        m_ResetParams = Academy.Instance.FloatProperties;
+        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 
         SetResetParameters();
     }

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using MLAgents;
 using MLAgents.Sensors;
+using MLAgents.SideChannels;
 
 public class FoodCollectorAgent : Agent
 {
@@ -272,12 +273,12 @@ public class FoodCollectorAgent : Agent
 
     public void SetLaserLengths()
     {
-        m_LaserLength = Academy.Instance.FloatProperties.GetPropertyWithDefault("laser_length", 1.0f);
+        m_LaserLength = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("laser_length", 1.0f);
     }
 
     public void SetAgentScale()
     {
-        float agentScale = Academy.Instance.FloatProperties.GetPropertyWithDefault("agent_scale", 1.0f);
+        float agentScale = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("agent_scale", 1.0f);
         gameObject.transform.localScale = new Vector3(agentScale, agentScale, agentScale);
     }
 

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -273,12 +273,12 @@ public class FoodCollectorAgent : Agent
 
     public void SetLaserLengths()
     {
-        m_LaserLength = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("laser_length", 1.0f);
+        m_LaserLength = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("laser_length", 1.0f);
     }
 
     public void SetAgentScale()
     {
-        float agentScale = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("agent_scale", 1.0f);
+        float agentScale = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("agent_scale", 1.0f);
         gameObject.transform.localScale = new Vector3(agentScale, agentScale, agentScale);
     }
 

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
@@ -19,7 +19,7 @@ public class FoodCollectorSettings : MonoBehaviour
     public void Awake()
     {
         Academy.Instance.OnEnvironmentReset += EnvironmentReset;
-        m_statsSideChannel = Academy.Instance.GetSideChannel<StatsSideChannel>();
+        m_statsSideChannel = SideChannelUtils.GetSideChannel<StatsSideChannel>();
     }
 
     public void EnvironmentReset()

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -37,7 +37,7 @@ public class GridAgent : Agent
            // Prevents the agent from picking an action that would make it collide with a wall
             var positionX = (int)transform.position.x;
             var positionZ = (int)transform.position.z;
-            var maxPosition = (int)Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("gridSize", 5f) - 1;
+            var maxPosition = (int)SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("gridSize", 5f) - 1;
 
             if (positionX == 0)
             {

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using MLAgents;
 using MLAgents.Sensors;
 using UnityEngine.Serialization;
+using MLAgents.SideChannels;
 
 public class GridAgent : Agent
 {
@@ -36,7 +37,7 @@ public class GridAgent : Agent
            // Prevents the agent from picking an action that would make it collide with a wall
             var positionX = (int)transform.position.x;
             var positionZ = (int)transform.position.z;
-            var maxPosition = (int)Academy.Instance.FloatProperties.GetPropertyWithDefault("gridSize", 5f) - 1;
+            var maxPosition = (int)Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("gridSize", 5f) - 1;
 
             if (positionX == 0)
             {

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
@@ -32,7 +32,7 @@ public class GridArea : MonoBehaviour
 
     public void Start()
     {
-        m_ResetParameters = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParameters = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 
         m_Objects = new[] { goalPref, pitPref };
 

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
@@ -32,7 +32,7 @@ public class GridArea : MonoBehaviour
 
     public void Start()
     {
-        m_ResetParameters = Academy.Instance.FloatProperties;
+        m_ResetParameters = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 
         m_Objects = new[] { goalPref, pitPref };
 

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using MLAgents;
+using MLAgents.SideChannels;
 
 public class GridSettings : MonoBehaviour
 {
@@ -7,7 +8,7 @@ public class GridSettings : MonoBehaviour
 
     public void Awake()
     {
-        Academy.Instance.FloatProperties.RegisterCallback("gridSize", f =>
+        Academy.Instance.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gridSize", f =>
         {
             MainCamera.transform.position = new Vector3(-(f - 1) / 2f, f * 1.25f, -(f - 1) / 2f);
             MainCamera.orthographicSize = (f + 5f) / 2f;

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
@@ -8,7 +8,7 @@ public class GridSettings : MonoBehaviour
 
     public void Awake()
     {
-        Academy.Instance.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gridSize", f =>
+        SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gridSize", f =>
         {
             MainCamera.transform.position = new Vector3(-(f - 1) / 2f, f * 1.25f, -(f - 1) / 2f);
             MainCamera.orthographicSize = (f + 5f) / 2f;

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -3,6 +3,7 @@
 using System.Collections;
 using UnityEngine;
 using MLAgents;
+using MLAgents.SideChannels;
 
 public class PushAgentBasic : Agent
 {
@@ -225,7 +226,7 @@ public class PushAgentBasic : Agent
 
     public void SetGroundMaterialFriction()
     {
-        var resetParams = Academy.Instance.FloatProperties;
+        var resetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 
         var groundCollider = ground.GetComponent<Collider>();
 
@@ -235,7 +236,7 @@ public class PushAgentBasic : Agent
 
     public void SetBlockProperties()
     {
-        var resetParams = Academy.Instance.FloatProperties;
+        var resetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 
         var scale = resetParams.GetPropertyWithDefault("block_scale", 2);
         //Set the scale of the block

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -226,7 +226,7 @@ public class PushAgentBasic : Agent
 
     public void SetGroundMaterialFriction()
     {
-        var resetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        var resetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 
         var groundCollider = ground.GetComponent<Collider>();
 
@@ -236,7 +236,7 @@ public class PushAgentBasic : Agent
 
     public void SetBlockProperties()
     {
-        var resetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        var resetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 
         var scale = resetParams.GetPropertyWithDefault("block_scale", 2);
         //Set the scale of the block

--- a/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using MLAgents;
 using MLAgents.Sensors;
+using MLAgents.SideChannels;
 
 public class ReacherAgent : Agent
 {
@@ -109,7 +110,7 @@ public class ReacherAgent : Agent
 
     public void SetResetParameters()
     {
-        var fp = Academy.Instance.FloatProperties;
+        var fp = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
         m_GoalSize = fp.GetPropertyWithDefault("goal_size", 5);
         m_GoalSpeed = Random.Range(-1f, 1f) * fp.GetPropertyWithDefault("goal_speed", 1);
         m_Deviation = fp.GetPropertyWithDefault("deviation", 0);

--- a/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
@@ -110,7 +110,7 @@ public class ReacherAgent : Agent
 
     public void SetResetParameters()
     {
-        var fp = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        var fp = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
         m_GoalSize = fp.GetPropertyWithDefault("goal_size", 5);
         m_GoalSpeed = Random.Range(-1f, 1f) * fp.GetPropertyWithDefault("goal_speed", 1);
         m_Deviation = fp.GetPropertyWithDefault("deviation", 0);

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using MLAgents;
+using MLAgents.SideChannels;
 
 namespace MLAgentsExamples
 {
@@ -42,7 +43,7 @@ namespace MLAgentsExamples
             Physics.defaultSolverIterations = solverIterations;
             Physics.defaultSolverVelocityIterations = solverVelocityIterations;
 
-            Academy.Instance.FloatProperties.RegisterCallback("gravity", f => { Physics.gravity = new Vector3(0, -f, 0); });
+            Academy.Instance.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gravity", f => { Physics.gravity = new Vector3(0, -f, 0); });
         }
 
         public void OnDestroy()

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
@@ -43,7 +43,7 @@ namespace MLAgentsExamples
             Physics.defaultSolverIterations = solverIterations;
             Physics.defaultSolverVelocityIterations = solverVelocityIterations;
 
-            Academy.Instance.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gravity", f => { Physics.gravity = new Vector3(0, -f, 0); });
+            SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().RegisterCallback("gravity", f => { Physics.gravity = new Vector3(0, -f, 0); });
         }
 
         public void OnDestroy()

--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
@@ -84,7 +84,7 @@ public class SoccerFieldArea : MonoBehaviour
         ballRb.velocity = Vector3.zero;
         ballRb.angularVelocity = Vector3.zero;
 
-        var ballScale = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("ball_scale", 0.015f);
+        var ballScale = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("ball_scale", 0.015f);
         ballRb.transform.localScale = new Vector3(ballScale, ballScale, ballScale);
     }
 }

--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using MLAgents;
+using MLAgents.SideChannels;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -83,7 +84,7 @@ public class SoccerFieldArea : MonoBehaviour
         ballRb.velocity = Vector3.zero;
         ballRb.angularVelocity = Vector3.zero;
 
-        var ballScale = Academy.Instance.FloatProperties.GetPropertyWithDefault("ball_scale", 0.015f);
+        var ballScale = Academy.Instance.GetSideChannel<FloatPropertiesChannel>().GetPropertyWithDefault("ball_scale", 0.015f);
         ballRb.transform.localScale = new Vector3(ballScale, ballScale, ballScale);
     }
 }

--- a/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
@@ -32,7 +32,7 @@ public class TennisAgent : Agent
         m_BallRb = ball.GetComponent<Rigidbody>();
         var canvas = GameObject.Find(k_CanvasName);
         GameObject scoreBoard;
-        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
         if (invertX)
         {
             scoreBoard = canvas.transform.Find(k_ScoreBoardBName).gameObject;

--- a/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
@@ -32,7 +32,7 @@ public class TennisAgent : Agent
         m_BallRb = ball.GetComponent<Rigidbody>();
         var canvas = GameObject.Find(k_CanvasName);
         GameObject scoreBoard;
-        m_ResetParams = Academy.Instance.FloatProperties;
+        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
         if (invertX)
         {
             scoreBoard = canvas.transform.Find(k_ScoreBoardBName).gameObject;

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -60,7 +60,7 @@ public class WalkerAgent : Agent
         m_ChestRb = chest.GetComponent<Rigidbody>();
         m_SpineRb = spine.GetComponent<Rigidbody>();
 
-        m_ResetParams = Academy.Instance.FloatProperties;
+        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 
         SetResetParameters();
     }

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -60,7 +60,7 @@ public class WalkerAgent : Agent
         m_ChestRb = chest.GetComponent<Rigidbody>();
         m_SpineRb = spine.GetComponent<Rigidbody>();
 
-        m_ResetParams = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_ResetParams = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 
         SetResetParameters();
     }

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -57,7 +57,7 @@ public class WallJumpAgent : Agent
 
         spawnArea.SetActive(false);
 
-        m_FloatProperties = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+        m_FloatProperties = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
     }
 
     // Begin the jump sequence

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using MLAgents;
 using Barracuda;
 using MLAgents.Sensors;
+using MLAgents.SideChannels;
 
 public class WallJumpAgent : Agent
 {
@@ -41,6 +42,8 @@ public class WallJumpAgent : Agent
     Vector3 m_JumpTargetPos;
     Vector3 m_JumpStartingPos;
 
+    FloatPropertiesChannel m_FloatProperties;
+
     public override void Initialize()
     {
         m_WallJumpSettings = FindObjectOfType<WallJumpSettings>();
@@ -53,6 +56,8 @@ public class WallJumpAgent : Agent
         m_GroundMaterial = m_GroundRenderer.material;
 
         spawnArea.SetActive(false);
+
+        m_FloatProperties = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
     }
 
     // Begin the jump sequence
@@ -313,7 +318,7 @@ public class WallJumpAgent : Agent
         {
             localScale = new Vector3(
                 localScale.x,
-                Academy.Instance.FloatProperties.GetPropertyWithDefault("no_wall_height", 0),
+                m_FloatProperties.GetPropertyWithDefault("no_wall_height", 0),
                 localScale.z);
             wall.transform.localScale = localScale;
             SetModel("SmallWallJump", noWallBrain);
@@ -322,15 +327,15 @@ public class WallJumpAgent : Agent
         {
             localScale = new Vector3(
                 localScale.x,
-                Academy.Instance.FloatProperties.GetPropertyWithDefault("small_wall_height", 4),
+                m_FloatProperties.GetPropertyWithDefault("small_wall_height", 4),
                 localScale.z);
             wall.transform.localScale = localScale;
             SetModel("SmallWallJump", smallWallBrain);
         }
         else
         {
-            var min = Academy.Instance.FloatProperties.GetPropertyWithDefault("big_wall_min_height", 8);
-            var max = Academy.Instance.FloatProperties.GetPropertyWithDefault("big_wall_max_height", 8);
+            var min = m_FloatProperties.GetPropertyWithDefault("big_wall_min_height", 8);
+            var max = m_FloatProperties.GetPropertyWithDefault("big_wall_max_height", 8);
             var height = min + Random.value * (max - min);
             localScale = new Vector3(
                 localScale.x,

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Major Changes
- - `Academy.FloatProperties` was deprecated, please use `Academy.GetSideChannel<FloatPropertiesChannel>()` instead.
+ - Introduced the `SideChannelUtils` to register, unregister and access side channels.
+ - `Academy.FloatProperties` was removed, please use `SideChannelUtils.GetSideChannel<FloatPropertiesChannel>()` instead.
 
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Major Changes
+ - `Academy.FloatProperties` was deprecated, please use `Academy.GetSideChannel<FloatPropertiesChannel>()` instead.
 
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)
  - Raise the wall in CrawlerStatic scene to prevent Agent from falling off. (#3650)
- - Added a feature to allow sending stats from C# environments to TensorBoard (and other python StatsWriters). To do this from your code, use `Academy.Instance.GetSideChannel<StatsSideChannel>().AddStat(key, value)` (#3660)
+ - Added a feature to allow sending stats from C# environments to TensorBoard (and other python StatsWriters). To do this from your code, use `SideChannelUtils.GetSideChannel<StatsSideChannel>().AddStat(key, value)` (#3660)
  - Renamed 'Generalization' feature to 'Environment Parameter Randomization'.
  - Fixed an issue where specifying `vis_encode_type` was required only for SAC. (#3677)
  - The way that UnityEnvironment decides the port was changed. If no port is specified, the behavior will depend on the `file_name` parameter. If it is `None`, 5004 (the editor port) will be used; otherwise 5005 (the base environment port) will be used.

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -439,6 +439,12 @@ namespace MLAgents
                 DecideAction?.Invoke();
             }
 
+            // If the communicator is not on, we need to clear the SideChannel sending queue
+            if (!IsCommunicatorOn)
+            {
+                SideChannelUtils.GetSideChannelMessage();
+            }
+
             using (TimerStack.Instance.Scoped("AgentAct"))
             {
                 AgentAct?.Invoke();

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -89,6 +89,7 @@ namespace MLAgents
         /// <summary>
         /// Collection of float properties (indexed by a string).
         /// </summary>
+        [Obsolete("Academy.FloatProperties has been deprecated, use Academy.GetSideChannel<>() instead.")]
         public FloatPropertiesChannel FloatProperties;
 
 
@@ -343,7 +344,9 @@ namespace MLAgents
             EnableAutomaticStepping();
 
             var floatProperties = new FloatPropertiesChannel();
+#pragma warning disable 0618
             FloatProperties = floatProperties;
+#pragma warning restore 0618
 
             // Try to launch the communicator by using the arguments passed at launch
             var port = ReadPortFromArgs();
@@ -563,8 +566,9 @@ namespace MLAgents
             // TODO - Pass worker ID or some other identifier,
             // so that multiple envs won't overwrite each others stats.
             TimerStack.Instance.SaveJsonTimers();
-
+#pragma warning disable 0618
             FloatProperties = null;
+#pragma warning restore 0618
             m_Initialized = false;
 
             // Reset the Lazy instance

--- a/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
@@ -154,34 +154,5 @@ namespace MLAgents
         /// <param name="agentId">A key to identify which Agent actions to get.</param>
         /// <returns></returns>
         float[] GetActions(string key, int agentId);
-
-        /// <summary>
-        /// Registers a side channel to the communicator. The side channel will exchange
-        /// messages with its Python equivalent.
-        /// </summary>
-        /// <param name="sideChannel"> The side channel to be registered.</param>
-        void RegisterSideChannel(SideChannel sideChannel);
-
-        /// <summary>
-        /// Unregisters a side channel from the communicator.
-        /// </summary>
-        /// <param name="sideChannel"> The side channel to be unregistered.</param>
-        void UnregisterSideChannel(SideChannel sideChannel);
-
-        /// <summary>
-        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
-        /// If there are multiple SideChannels of the same type registered, the returned instance is arbitrary.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        T GetSideChannel<T>() where T : SideChannel;
-
-        /// <summary>
-        /// Returns all SideChannels of Type T that are registered. Use <see cref="GetSideChannel{T}()"/> if possible,
-        /// as that does not make any memory allocations.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        List<T> GetSideChannels<T>() where T : SideChannel;
     }
 }

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -12,7 +12,6 @@ using MLAgents.CommunicatorObjects;
 using MLAgents.Sensors;
 using MLAgents.Policies;
 using MLAgents.SideChannels;
-using System.IO;
 using Google.Protobuf;
 
 namespace MLAgents
@@ -50,8 +49,6 @@ namespace MLAgents
 #endif
         /// The communicator parameters sent at construction
         CommunicatorInitParameters m_CommunicatorInitParameters;
-
-        Dictionary<Guid, SideChannel> m_SideChannels = new Dictionary<Guid, SideChannel>();
 
         /// <summary>
         /// Initializes a new instance of the RPCCommunicator class.
@@ -160,7 +157,7 @@ namespace MLAgents
 
         void UpdateEnvironmentWithInput(UnityRLInputProto rlInput)
         {
-            ProcessSideChannelData(m_SideChannels, rlInput.SideChannel.ToArray());
+            SideChannelUtils.ProcessSideChannelData(rlInput.SideChannel.ToArray());
             SendCommandEvent(rlInput.Command);
         }
 
@@ -324,7 +321,7 @@ namespace MLAgents
                 message.RlInitializationOutput = tempUnityRlInitializationOutput;
             }
 
-            byte[] messageAggregated = GetSideChannelMessage(m_SideChannels);
+            byte[] messageAggregated = SideChannelUtils.GetSideChannelMessage();
             message.RlOutput.SideChannel = ByteString.CopyFrom(messageAggregated);
 
             var input = Exchange(message);
@@ -489,194 +486,6 @@ namespace MLAgents
             {
                 m_SentBrainKeys.Add(brainProto.BrainName);
                 m_UnsentBrainKeys.Remove(brainProto.BrainName);
-            }
-        }
-
-        #endregion
-
-
-        #region Handling side channels
-
-        /// <summary>
-        /// Registers a side channel to the communicator. The side channel will exchange
-        /// messages with its Python equivalent.
-        /// </summary>
-        /// <param name="sideChannel"> The side channel to be registered.</param>
-        public void RegisterSideChannel(SideChannel sideChannel)
-        {
-            var channelId = sideChannel.ChannelId;
-            if (m_SideChannels.ContainsKey(channelId))
-            {
-                throw new UnityAgentsException(string.Format(
-                    "A side channel with type index {0} is already registered. You cannot register multiple " +
-                    "side channels of the same id.", channelId));
-            }
-
-            // Process any messages that we've already received for this channel ID.
-            var numMessages = m_CachedMessages.Count;
-            for (int i = 0; i < numMessages; i++)
-            {
-                var cachedMessage = m_CachedMessages.Dequeue();
-                if (channelId == cachedMessage.ChannelId)
-                {
-                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
-                    {
-                        sideChannel.OnMessageReceived(incomingMsg);
-                    }
-                }
-                else
-                {
-                    m_CachedMessages.Enqueue(cachedMessage);
-                }
-            }
-            m_SideChannels.Add(channelId, sideChannel);
-        }
-
-        /// <summary>
-        /// Unregisters a side channel from the communicator.
-        /// </summary>
-        /// <param name="sideChannel"> The side channel to be unregistered.</param>
-        public void UnregisterSideChannel(SideChannel sideChannel)
-        {
-            if (m_SideChannels.ContainsKey(sideChannel.ChannelId))
-            {
-                m_SideChannels.Remove(sideChannel.ChannelId);
-            }
-        }
-
-        /// <inheritdoc/>
-        public T GetSideChannel<T>() where T: SideChannel
-        {
-            foreach (var sc in m_SideChannels.Values)
-            {
-                if (sc.GetType() == typeof(T))
-                {
-                    return (T) sc;
-                }
-            }
-            return null;
-        }
-
-        /// <inheritdoc/>
-        public List<T> GetSideChannels<T>() where T: SideChannel
-        {
-            var output = new List<T>();
-
-            foreach (var sc in m_SideChannels.Values)
-            {
-                if (sc.GetType() == typeof(T))
-                {
-                    output.Add((T) sc);
-                }
-            }
-            return output;
-        }
-
-        /// <summary>
-        /// Grabs the messages that the registered side channels will send to Python at the current step
-        /// into a singe byte array.
-        /// </summary>
-        /// <param name="sideChannels"> A dictionary of channel type to channel.</param>
-        /// <returns></returns>
-        public static byte[] GetSideChannelMessage(Dictionary<Guid, SideChannel> sideChannels)
-        {
-            using (var memStream = new MemoryStream())
-            {
-                using (var binaryWriter = new BinaryWriter(memStream))
-                {
-                    foreach (var sideChannel in sideChannels.Values)
-                    {
-                        var messageList = sideChannel.MessageQueue;
-                        foreach (var message in messageList)
-                        {
-                            binaryWriter.Write(sideChannel.ChannelId.ToByteArray());
-                            binaryWriter.Write(message.Count());
-                            binaryWriter.Write(message);
-                        }
-                        sideChannel.MessageQueue.Clear();
-                    }
-                    return memStream.ToArray();
-                }
-            }
-        }
-
-        private struct CachedSideChannelMessage
-        {
-            public Guid ChannelId;
-            public byte[] Message;
-        }
-
-        private static Queue<CachedSideChannelMessage> m_CachedMessages = new Queue<CachedSideChannelMessage>();
-
-        /// <summary>
-        /// Separates the data received from Python into individual messages for each registered side channel.
-        /// </summary>
-        /// <param name="sideChannels">A dictionary of channel type to channel.</param>
-        /// <param name="dataReceived">The byte array of data received from Python.</param>
-        public static void ProcessSideChannelData(Dictionary<Guid, SideChannel> sideChannels, byte[] dataReceived)
-        {
-            while (m_CachedMessages.Count != 0)
-            {
-                var cachedMessage = m_CachedMessages.Dequeue();
-                if (sideChannels.ContainsKey(cachedMessage.ChannelId))
-                {
-                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
-                    {
-                        sideChannels[cachedMessage.ChannelId].OnMessageReceived(incomingMsg);
-                    }
-                }
-                else
-                {
-                    Debug.Log(string.Format(
-                        "Unknown side channel data received. Channel Id is "
-                        + ": {0}", cachedMessage.ChannelId));
-                }
-            }
-
-            if (dataReceived.Length == 0)
-            {
-                return;
-            }
-            using (var memStream = new MemoryStream(dataReceived))
-            {
-                using (var binaryReader = new BinaryReader(memStream))
-                {
-                    while (memStream.Position < memStream.Length)
-                    {
-                        Guid channelId = Guid.Empty;
-                        byte[] message = null;
-                        try
-                        {
-                            channelId = new Guid(binaryReader.ReadBytes(16));
-                            var messageLength = binaryReader.ReadInt32();
-                            message = binaryReader.ReadBytes(messageLength);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new UnityAgentsException(
-                                "There was a problem reading a message in a SideChannel. Please make sure the " +
-                                "version of MLAgents in Unity is compatible with the Python version. Original error : "
-                                + ex.Message);
-                        }
-                        if (sideChannels.ContainsKey(channelId))
-                        {
-                            using (var incomingMsg = new IncomingMessage(message))
-                            {
-                                sideChannels[channelId].OnMessageReceived(incomingMsg);
-                            }
-                        }
-                        else
-                        {
-                            // Don't recognize this ID, but cache it in case the SideChannel that can handle
-                            // it is registered before the next call to ProcessSideChannelData.
-                            m_CachedMessages.Enqueue(new CachedSideChannelMessage
-                            {
-                                ChannelId = channelId,
-                                Message = message
-                            });
-                        }
-                    }
-                }
             }
         }
 

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System;
-using System.IO;
-using System.Text;
 
 namespace MLAgents.SideChannels
 {

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+
+namespace MLAgents.SideChannels
+{
+    public static class SideChannelUtils
+    {
+
+        private static Dictionary<Guid, SideChannel> RegisteredChannels = new Dictionary<Guid, SideChannel>();
+
+        private struct CachedSideChannelMessage
+        {
+            public Guid ChannelId;
+            public byte[] Message;
+        }
+
+        private static Queue<CachedSideChannelMessage> m_CachedMessages = new Queue<CachedSideChannelMessage>();
+
+        /// <summary>
+        /// Registers a side channel to the communicator. The side channel will exchange
+        /// messages with its Python equivalent.
+        /// </summary>
+        /// <param name="sideChannel"> The side channel to be registered.</param>
+        public static void RegisterSideChannel(SideChannel sideChannel)
+        {
+            var channelId = sideChannel.ChannelId;
+            if (RegisteredChannels.ContainsKey(channelId))
+            {
+                throw new UnityAgentsException(string.Format(
+                    "A side channel with type index {0} is already registered. You cannot register multiple " +
+                    "side channels of the same id.", channelId));
+            }
+
+            // Process any messages that we've already received for this channel ID.
+            var numMessages = m_CachedMessages.Count;
+            for (int i = 0; i < numMessages; i++)
+            {
+                var cachedMessage = m_CachedMessages.Dequeue();
+                if (channelId == cachedMessage.ChannelId)
+                {
+                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
+                    {
+                        sideChannel.OnMessageReceived(incomingMsg);
+                    }
+                }
+                else
+                {
+                    m_CachedMessages.Enqueue(cachedMessage);
+                }
+            }
+            RegisteredChannels.Add(channelId, sideChannel);
+        }
+
+        /// <summary>
+        /// Unregisters a side channel from the communicator.
+        /// </summary>
+        /// <param name="sideChannel"> The side channel to be unregistered.</param>
+        public static void UnregisterSideChannel(SideChannel sideChannel)
+        {
+            if (RegisteredChannels.ContainsKey(sideChannel.ChannelId))
+            {
+                RegisteredChannels.Remove(sideChannel.ChannelId);
+            }
+        }
+
+        /// <summary>
+        /// Unregisters all the side channels from the communicator.
+        /// </summary>
+        public static void UnregisterAllSideChannels()
+        {
+            RegisteredChannels = new Dictionary<Guid, SideChannel>();
+        }
+
+        /// <summary>
+        /// Returns the SideChannel of Type T if there is one registered, or null if it doesn't.
+        /// If there are multiple SideChannels of the same type registered, the returned instance is arbitrary.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static T GetSideChannel<T>() where T: SideChannel
+        {
+            foreach (var sc in RegisteredChannels.Values)
+            {
+                if (sc.GetType() == typeof(T))
+                {
+                    return (T) sc;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns all SideChannels of Type T that are registered. Use <see cref="GetSideChannel{T}()"/> if possible,
+        /// as that does not make any memory allocations.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static List<T> GetSideChannels<T>() where T: SideChannel
+        {
+            var output = new List<T>();
+
+            foreach (var sc in RegisteredChannels.Values)
+            {
+                if (sc.GetType() == typeof(T))
+                {
+                    output.Add((T) sc);
+                }
+            }
+            return output;
+        }
+
+        /// <summary>
+        /// Grabs the messages that the registered side channels will send to Python at the current step
+        /// into a singe byte array.
+        /// </summary>
+        /// <returns></returns>
+        public static byte[] GetSideChannelMessage()
+        {
+            return GetSideChannelMessage(RegisteredChannels);
+        }
+
+        /// <summary>
+        /// Grabs the messages that the registered side channels will send to Python at the current step
+        /// into a singe byte array.
+        /// </summary>
+        /// <param name="sideChannels"> A dictionary of channel type to channel.</param>
+        /// <returns></returns>
+        internal static byte[] GetSideChannelMessage(Dictionary<Guid, SideChannel> sideChannels)
+        {
+            using (var memStream = new MemoryStream())
+            {
+                using (var binaryWriter = new BinaryWriter(memStream))
+                {
+                    foreach (var sideChannel in sideChannels.Values)
+                    {
+                        var messageList = sideChannel.MessageQueue;
+                        foreach (var message in messageList)
+                        {
+                            binaryWriter.Write(sideChannel.ChannelId.ToByteArray());
+                            binaryWriter.Write(message.Length);
+                            binaryWriter.Write(message);
+                        }
+                        sideChannel.MessageQueue.Clear();
+                    }
+                    return memStream.ToArray();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Separates the data received from Python into individual messages for each registered side channel.
+        /// </summary>
+        /// <param name="dataReceived">The byte array of data received from Python.</param>
+        public static void ProcessSideChannelData(byte[] dataReceived)
+        {
+            ProcessSideChannelData(RegisteredChannels, dataReceived);
+        }
+
+        /// <summary>
+        /// Separates the data received from Python into individual messages for each registered side channel.
+        /// </summary>
+        /// <param name="sideChannels">A dictionary of channel type to channel.</param>
+        /// <param name="dataReceived">The byte array of data received from Python.</param>
+        internal static void ProcessSideChannelData(Dictionary<Guid, SideChannel> sideChannels, byte[] dataReceived)
+        {
+            while (m_CachedMessages.Count != 0)
+            {
+                var cachedMessage = m_CachedMessages.Dequeue();
+                if (sideChannels.ContainsKey(cachedMessage.ChannelId))
+                {
+                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
+                    {
+                        sideChannels[cachedMessage.ChannelId].OnMessageReceived(incomingMsg);
+                    }
+                }
+                else
+                {
+                    Debug.Log(string.Format(
+                        "Unknown side channel data received. Channel Id is "
+                        + ": {0}", cachedMessage.ChannelId));
+                }
+            }
+
+            if (dataReceived.Length == 0)
+            {
+                return;
+            }
+            using (var memStream = new MemoryStream(dataReceived))
+            {
+                using (var binaryReader = new BinaryReader(memStream))
+                {
+                    while (memStream.Position < memStream.Length)
+                    {
+                        Guid channelId = Guid.Empty;
+                        byte[] message = null;
+                        try
+                        {
+                            channelId = new Guid(binaryReader.ReadBytes(16));
+                            var messageLength = binaryReader.ReadInt32();
+                            message = binaryReader.ReadBytes(messageLength);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new UnityAgentsException(
+                                "There was a problem reading a message in a SideChannel. Please make sure the " +
+                                "version of MLAgents in Unity is compatible with the Python version. Original error : "
+                                + ex.Message);
+                        }
+                        if (sideChannels.ContainsKey(channelId))
+                        {
+                            using (var incomingMsg = new IncomingMessage(message))
+                            {
+                                sideChannels[channelId].OnMessageReceived(incomingMsg);
+                            }
+                        }
+                        else
+                        {
+                            // Don't recognize this ID, but cache it in case the SideChannel that can handle
+                            // it is registered before the next call to ProcessSideChannelData.
+                            m_CachedMessages.Enqueue(new CachedSideChannelMessage
+                            {
+                                ChannelId = channelId,
+                                Message = message
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
@@ -116,7 +116,7 @@ namespace MLAgents.SideChannels
         /// into a singe byte array.
         /// </summary>
         /// <returns></returns>
-        public static byte[] GetSideChannelMessage()
+        internal static byte[] GetSideChannelMessage()
         {
             return GetSideChannelMessage(RegisteredChannels);
         }
@@ -153,7 +153,7 @@ namespace MLAgents.SideChannels
         /// Separates the data received from Python into individual messages for each registered side channel.
         /// </summary>
         /// <param name="dataReceived">The byte array of data received from Python.</param>
-        public static void ProcessSideChannelData(byte[] dataReceived)
+        internal static void ProcessSideChannelData(byte[] dataReceived)
         {
             ProcessSideChannelData(RegisteredChannels, dataReceived);
         }

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs.meta
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2506dff31271f49298fbff21e13fa8b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -195,7 +195,7 @@ namespace MLAgents.Tests
             Assert.AreEqual(0, aca.EpisodeCount);
             Assert.AreEqual(0, aca.StepCount);
             Assert.AreEqual(0, aca.TotalStepCount);
-            Assert.AreNotEqual(null, aca.GetSideChannel<FloatPropertiesChannel>());
+            Assert.AreNotEqual(null, SideChannelUtils.GetSideChannel<FloatPropertiesChannel>());
 
             // Check that Dispose is idempotent
             aca.Dispose();
@@ -206,10 +206,11 @@ namespace MLAgents.Tests
         [Test]
         public void TestAcademyDispose()
         {
-            var floatProperties1 = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+            var floatProperties1 = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
             Academy.Instance.Dispose();
 
-            var floatProperties2 = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+            Academy.Instance.LazyInitialize();
+            var floatProperties2 = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
             Academy.Instance.Dispose();
 
             Assert.AreNotEqual(floatProperties1, floatProperties2);

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using MLAgents.Sensors;
 using MLAgents.Policies;
+using MLAgents.SideChannels;
 
 namespace MLAgents.Tests
 {
@@ -194,7 +195,7 @@ namespace MLAgents.Tests
             Assert.AreEqual(0, aca.EpisodeCount);
             Assert.AreEqual(0, aca.StepCount);
             Assert.AreEqual(0, aca.TotalStepCount);
-            Assert.AreNotEqual(null, aca.FloatProperties);
+            Assert.AreNotEqual(null, aca.GetSideChannel<FloatPropertiesChannel>());
 
             // Check that Dispose is idempotent
             aca.Dispose();
@@ -205,10 +206,10 @@ namespace MLAgents.Tests
         [Test]
         public void TestAcademyDispose()
         {
-            var floatProperties1 = Academy.Instance.FloatProperties;
+            var floatProperties1 = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
             Academy.Instance.Dispose();
 
-            var floatProperties2 = Academy.Instance.FloatProperties;
+            var floatProperties2 = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
             Academy.Instance.Dispose();
 
             Assert.AreNotEqual(floatProperties1, floatProperties2);

--- a/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
@@ -45,8 +45,8 @@ namespace MLAgents.Tests
             intSender.SendInt(5);
             intSender.SendInt(6);
 
-            byte[] fakeData = RpcCommunicator.GetSideChannelMessage(dictSender);
-            RpcCommunicator.ProcessSideChannelData(dictReceiver, fakeData);
+            byte[] fakeData = SideChannelUtils.GetSideChannelMessage(dictSender);
+            SideChannelUtils.ProcessSideChannelData(dictReceiver, fakeData);
 
             Assert.AreEqual(intReceiver.messagesReceived[0], 4);
             Assert.AreEqual(intReceiver.messagesReceived[1], 5);
@@ -67,8 +67,8 @@ namespace MLAgents.Tests
             strSender.SendRawBytes(Encoding.ASCII.GetBytes(str1));
             strSender.SendRawBytes(Encoding.ASCII.GetBytes(str2));
 
-            byte[] fakeData = RpcCommunicator.GetSideChannelMessage(dictSender);
-            RpcCommunicator.ProcessSideChannelData(dictReceiver, fakeData);
+            byte[] fakeData = SideChannelUtils.GetSideChannelMessage(dictSender);
+            SideChannelUtils.ProcessSideChannelData(dictReceiver, fakeData);
 
             var messages = strReceiver.GetAndClearReceivedMessages();
 
@@ -96,8 +96,8 @@ namespace MLAgents.Tests
             tmp = propB.GetPropertyWithDefault(k2, 3.0f);
             Assert.AreEqual(tmp, 1.0f);
 
-            byte[] fakeData = RpcCommunicator.GetSideChannelMessage(dictSender);
-            RpcCommunicator.ProcessSideChannelData(dictReceiver, fakeData);
+            byte[] fakeData = SideChannelUtils.GetSideChannelMessage(dictSender);
+            SideChannelUtils.ProcessSideChannelData(dictReceiver, fakeData);
 
             tmp = propA.GetPropertyWithDefault(k2, 3.0f);
             Assert.AreEqual(tmp, 1.0f);
@@ -105,8 +105,8 @@ namespace MLAgents.Tests
             Assert.AreEqual(wasCalled, 0);
             propB.SetProperty(k1, 1.0f);
             Assert.AreEqual(wasCalled, 0);
-            fakeData = RpcCommunicator.GetSideChannelMessage(dictSender);
-            RpcCommunicator.ProcessSideChannelData(dictReceiver, fakeData);
+            fakeData = SideChannelUtils.GetSideChannelMessage(dictSender);
+            SideChannelUtils.ProcessSideChannelData(dictReceiver, fakeData);
             Assert.AreEqual(wasCalled, 1);
 
             var keysA = propA.ListProperties();

--- a/docs/Custom-SideChannels.md
+++ b/docs/Custom-SideChannels.md
@@ -122,7 +122,7 @@ public class RegisterStringLogSideChannel : MonoBehaviour
         // When a Debug.Log message is created, we send it to the stringChannel
         Application.logMessageReceived += stringChannel.SendDebugStatementToPython;
 
-        // The channel must be registered with the Academy
+        // The channel must be registered with the SideChannelUtils class
         SideChannelUtils.RegisterSideChannel(stringChannel);
     }
 

--- a/docs/Custom-SideChannels.md
+++ b/docs/Custom-SideChannels.md
@@ -24,7 +24,7 @@ To send data from C# to Python, create an `OutgoingMessage` instance, add data t
 `base.QueueMessageToSend(msg)` method inside the side channel, and call the
 `OutgoingMessage.Dispose()` method.
 
-To register a side channel on the Unity side, call `Academy.Instance.RegisterSideChannel` with the side channel
+To register a side channel on the Unity side, call `SideChannelUtils.RegisterSideChannel` with the side channel
 as only argument.
 
 ### Python side
@@ -123,7 +123,7 @@ public class RegisterStringLogSideChannel : MonoBehaviour
         Application.logMessageReceived += stringChannel.SendDebugStatementToPython;
 
         // The channel must be registered with the Academy
-        Academy.Instance.RegisterSideChannel(stringChannel);
+        SideChannelUtils.RegisterSideChannel(stringChannel);
     }
 
     public void OnDestroy()
@@ -131,7 +131,7 @@ public class RegisterStringLogSideChannel : MonoBehaviour
         // De-register the Debug.Log callback
         Application.logMessageReceived -= stringChannel.SendDebugStatementToPython;
         if (Academy.IsInitialized){
-            Academy.Instance.UnregisterSideChannel(stringChannel);
+            SideChannelUtils.UnregisterSideChannel(stringChannel);
         }
     }
 

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -10,8 +10,10 @@ The versions can be found in
 ## Migrating from 0.15 to latest
 
 ### Important changes
+* `Academy.FloatProperties` was deprecated. It will be removed in a later release.
 
 ### Steps to Migrate
+* Replace `Academy.FloatProperties` with `Academy.GetSideChannel<FloatPropertiesChannel>()`.
 
 
 ## Migrating from 0.14 to 0.15

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -10,10 +10,14 @@ The versions can be found in
 ## Migrating from 0.15 to latest
 
 ### Important changes
-* `Academy.FloatProperties` was deprecated. It will be removed in a later release.
+* `Academy.FloatProperties` was removed.
+* `Academy.RegisterSideChannel` and `Academy.UnregisterSideChannel` were removed.
+
 
 ### Steps to Migrate
-* Replace `Academy.FloatProperties` with `Academy.GetSideChannel<FloatPropertiesChannel>()`.
+* Replace `Academy.FloatProperties` with `SideChannelUtils.GetSideChannel<FloatPropertiesChannel>()`.
+* Replace `Academy.RegisterSideChannel` with `SideChannelUtils.RegisterSideChannel()`.
+* Replace `Academy.UnregisterSideChannel` with `SideChannelUtils.UnregisterSideChannel`.
 
 
 ## Migrating from 0.14 to 0.15

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -280,7 +280,7 @@ readout_value = channel.get_property("parameter_2")
 Once a property has been modified in Python, you can access it in C# after the next call to `step` as follows:
 
 ```csharp
-var sharedProperties = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
+var sharedProperties = SideChannelUtils.GetSideChannel<FloatPropertiesChannel>();
 float property1 = sharedProperties.GetPropertyWithDefault("parameter_1", 0.0f);
 ```
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -280,7 +280,7 @@ readout_value = channel.get_property("parameter_2")
 Once a property has been modified in Python, you can access it in C# after the next call to `step` as follows:
 
 ```csharp
-var sharedProperties = Academy.Instance.FloatProperties;
+var sharedProperties = Academy.Instance.GetSideChannel<FloatPropertiesChannel>();
 float property1 = sharedProperties.GetPropertyWithDefault("parameter_1", 0.0f);
 ```
 

--- a/docs/Training-Curriculum-Learning.md
+++ b/docs/Training-Curriculum-Learning.md
@@ -41,7 +41,7 @@ the same environment.
 In order to define the curricula, the first step is to decide which parameters of
 the environment will vary. In the case of the Wall Jump environment,
 the height of the wall is what varies. We define this as a `Shared Float Property`
-that can be accessed in `Academy.Instance.GetSideChannel<FloatPropertiesChannel>()`, and by doing
+that can be accessed in `SideChannelUtils.GetSideChannel<FloatPropertiesChannel>()`, and by doing
 so it becomes adjustable via the Python API.
 Rather than adjusting it by hand, we will create a YAML file which
 describes the structure of the curricula. Within it, we can specify which

--- a/docs/Training-Curriculum-Learning.md
+++ b/docs/Training-Curriculum-Learning.md
@@ -41,7 +41,7 @@ the same environment.
 In order to define the curricula, the first step is to decide which parameters of
 the environment will vary. In the case of the Wall Jump environment,
 the height of the wall is what varies. We define this as a `Shared Float Property`
-that can be accessed in `Academy.Instance.FloatProperties`, and by doing
+that can be accessed in `Academy.Instance.GetSideChannel<FloatPropertiesChannel>()`, and by doing
 so it becomes adjustable via the Python API.
 Rather than adjusting it by hand, we will create a YAML file which
 describes the structure of the curricula. Within it, we can specify which

--- a/docs/Training-Environment-Parameter-Randomization.md
+++ b/docs/Training-Environment-Parameter-Randomization.md
@@ -20,7 +20,7 @@ Ball scale of 0.5          |  Ball scale of 4
 
 
 To enable variations in the environments, we implemented `Environment Parameters`.
-`Environment Parameters` are `Academy.Instance.FloatProperties` that can be read when setting
+`Environment Parameters` are values in the Academy's `FloatPropertiesChannel` that can be read when setting
 up the environment. We
 also included different sampling methods and the ability to create new kinds of
 sampling methods for each `Environment Parameter`. In the 3D ball environment example displayed
@@ -71,7 +71,7 @@ train under a particular environment configuration before resetting the
 environment with a new sample of `Environment Parameters`.
 
 * `Environment Parameter` - Name of the `Environment Parameter` like `mass`, `gravity` and `scale`. This should match the name
-specified in the `FloatProperties` of the environment being trained. If a parameter specified in the file doesn't exist in the
+specified in the `FloatPropertiesChannel` of the environment being trained. If a parameter specified in the file doesn't exist in the
 environment, then this parameter will be ignored.  Within each `Environment Parameter`
 
     * `sampler-type` - Specify the sampler type to use for the `Environment Parameter`.

--- a/docs/Training-Environment-Parameter-Randomization.md
+++ b/docs/Training-Environment-Parameter-Randomization.md
@@ -20,7 +20,7 @@ Ball scale of 0.5          |  Ball scale of 4
 
 
 To enable variations in the environments, we implemented `Environment Parameters`.
-`Environment Parameters` are values in the Academy's `FloatPropertiesChannel` that can be read when setting
+`Environment Parameters` are values in the `FloatPropertiesChannel` that can be read when setting
 up the environment. We
 also included different sampling methods and the ability to create new kinds of
 sampling methods for each `Environment Parameter`. In the 3D ball environment example displayed

--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -91,6 +91,6 @@ The ML-Agents training program saves the following statistics:
 ## Custom Metrics from C#
 To get custom metrics from a C# environment into Tensorboard, you can use the StatsSideChannel:
 ```csharp
-var statsSideChannel = Academy.Instance.GetSideChannel<StatsSideChannel>();
+var statsSideChannel = SideChannelUtils.GetSideChannel<StatsSideChannel>();
 statsSideChannel.AddStat("MyMetric", 1.0);
 ```


### PR DESCRIPTION
### Proposed change(s)

 - Introduce the `SideChannelUtils` static class that maintains a static dictionary from GUID to SideChannel. This `SideChannelUtils` is the entry point for registering/unregistering/get Side Channlels
 - Replace `Academy.Instance.FloatProperties` with `SideChannelUtils.GetSideChannel<FloatPropertiesChannel>()` 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
[JIRA MLA-799](https://jira.unity3d.com/browse/MLA-799)


### Types of change(s)

- ~[ ] Bug fix~
- ~[ ] New feature~
- [x] Code refactor
- [x] Breaking change
- ~[ ] Documentation update~
- ~[ ] Other (please describe)~

### Checklist
- ~[ ] Added tests that prove my fix is effective or that my feature works~
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
