### PR TITLE
handle multiple dones in a single step

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The way that UnityEnvironment decides the port was changed. If no port is specified, the behavior will depend on the `file_name` parameter. If it is `None`, 5004 (the editor port) will be used; otherwise 5005 (the base environment port) will be used.
  - Fixed an issue where switching models using `SetModel()` during training would use an excessive amount of memory. (#3664)
  - Environment subprocesses now close immediately on timeout or wrong API version. (#3679)
+ - Fixed an issue in the gym wrapper that would raise an exception if an Agent called EndEpisode multiple times in the same step. (#3700)
 
 ## [0.15.0-preview] - 2020-03-18
 ### Major Changes

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -588,9 +588,13 @@ class AgentIdIndexMapperSlow:
         self._gym_id_order = list(agent_ids)
 
     def mark_agent_done(self, agent_id: int, reward: float) -> None:
-        gym_index = self._gym_id_order.index(agent_id)
-        self._done_agents_index_to_last_reward[gym_index] = reward
-        self._gym_id_order[gym_index] = -1
+        try:
+            gym_index = self._gym_id_order.index(agent_id)
+            self._done_agents_index_to_last_reward[gym_index] = reward
+            self._gym_id_order[gym_index] = -1
+        except ValueError:
+            # Agent was never registered in the first place (e.g. EndEpisode called multiple times)
+            pass
 
     def register_new_agent_id(self, agent_id: int) -> float:
         original_index = self._gym_id_order.index(-1)

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -129,6 +129,50 @@ def test_sanitize_action_one_agent_done(mock_env):
         assert expected_agent_id == agent_id
 
 
+@mock.patch("gym_unity.envs.UnityEnvironment")
+def test_sanitize_action_new_agent_done(mock_env):
+    mock_spec = create_mock_group_spec(
+        vector_action_space_type="discrete", vector_action_space_size=[2, 2, 3]
+    )
+    mock_step = create_mock_vector_step_result(num_agents=3)
+    mock_step.agent_id = np.array(range(5))
+    setup_mock_unityenvironment(mock_env, mock_spec, mock_step)
+    env = UnityEnv(" ", use_visual=False, multiagent=True)
+
+    received_step_result = create_mock_vector_step_result(num_agents=7)
+    received_step_result.agent_id = np.array(range(7))
+    # agent #3 (id = 2) is Done
+    # so is the "new" agent (id = 5)
+    done = [False] * 7
+    done[2] = True
+    done[5] = True
+    received_step_result.done = np.array(done)
+    sanitized_result = env._sanitize_info(received_step_result)
+    for expected_agent_id, agent_id in zip([0, 1, 6, 3, 4], sanitized_result.agent_id):
+        assert expected_agent_id == agent_id
+
+
+@mock.patch("gym_unity.envs.UnityEnvironment")
+def test_sanitize_action_single_agent_multiple_done(mock_env):
+    mock_spec = create_mock_group_spec(
+        vector_action_space_type="discrete", vector_action_space_size=[2, 2, 3]
+    )
+    mock_step = create_mock_vector_step_result(num_agents=1)
+    mock_step.agent_id = np.array(range(1))
+    setup_mock_unityenvironment(mock_env, mock_spec, mock_step)
+    env = UnityEnv(" ", use_visual=False, multiagent=False)
+
+    received_step_result = create_mock_vector_step_result(num_agents=3)
+    received_step_result.agent_id = np.array(range(3))
+    # original agent (id = 0) is Done
+    # so is the "new" agent (id = 1)
+    done = [True, True, False]
+    received_step_result.done = np.array(done)
+    sanitized_result = env._sanitize_info(received_step_result)
+    for expected_agent_id, agent_id in zip([2], sanitized_result.agent_id):
+        assert expected_agent_id == agent_id
+
+
 # Helper methods
 
 

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -244,6 +244,10 @@ def test_agent_id_index_mapper(mapper_cls):
     mapper.mark_agent_done(1001, 42.0)
     mapper.mark_agent_done(1004, 1337.0)
 
+    # Make sure we can handle an unknown agent id being marked done.
+    # This can happen when an agent ends an episode on the same step it starts.
+    mapper.mark_agent_done(9999, -1.0)
+
     # Now add new agents, and get the rewards of the agent they replaced.
     old_reward1 = mapper.register_new_agent_id(2001)
     old_reward2 = mapper.register_new_agent_id(2002)


### PR DESCRIPTION
### Proposed change(s)

Fix two bugs in the gym interface that could happen if an Agent called EndEpisode() multiple times in the same step:
1) The bookkeeping would try to remove the "transient" agent before it was added, which would fail. We also need to avoid adding it since it's already done.
2) For a single Agent, the checks in `_sanitize_info()` was too strict - we could have the case where `step_result.n_agents()=3 self._n_agents=1 n_extra_agents=2` because there we 2 "done" agents in the step.

This would show up with stack traces:
```
Traceback (most recent call last):
  File "test_gym.py", line 38, in <module>
    observation, reward, done, info = multi_env.step(multi_env.action_space.sample())
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 222, in step
    step_result = self._step()
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 449, in _step
    return self._sanitize_info(info)
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 371, in _sanitize_info
    "The number of agents in the scene does not match the expected number."
gym_unity.envs.UnityGymException: The number of agents in the scene does not match the expected number.
```
with multiagent=False, or 
```
Traceback (most recent call last):
  File "test_gym.py", line 32, in <module>
    observations, rewards, dones, info = multi_env.step(actions)
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 222, in step
    step_result = self._step()
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 445, in _step
    self.agent_mapper.mark_agent_done(agent_id, reward)
  File "/Users/chris.elion/code/ml-agents/gym-unity/gym_unity/envs/__init__.py", line 531, in mark_agent_done
    gym_index = self._agent_id_to_gym_index.pop(agent_id)
KeyError: 2
```
with multiagent=True

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://forum.unity.com/threads/errors-when-using-gym-unity-0-14-1-and-0-15-0.852586/

https://github.com/Unity-Technologies/ml-agents/issues/3531#issuecomment-592663967

https://jira.unity3d.com/browse/MLA-805

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
