### PR TITLE
reuse built player in CI tests

### DIFF
--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -25,4 +25,8 @@ test_mac_standalone_{{ editor.version }}:
         - "*.md"
         - "com.unity.ml-agents/*.md"
         - "com.unity.ml-agents/**/*.md"
+  artifacts:
+    standalonebuild:
+      paths:
+        - "Project/testPlayer*/**"
 {% endfor %}

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -19,6 +19,8 @@ test_mac_training_int_{{ editor.version }}:
     # to be disabled until the next release.
     - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.15.0
     - python -u -m ml-agents.tests.yamato.training_int_tests --csharp=0.15.0
+  dependencies:
+    - .yamato/standalone-build-test.yml#test_mac_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
     changes:

--- a/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
+++ b/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
@@ -22,10 +22,11 @@ namespace MLAgents
                 if (args[i] == k_outputCommandLineFlag)
                 {
                     outputPath = args[i + 1];
+                    Debug.Log($"Overriding output path to {outputPath}");
                 }
                 else if (args[i] == k_sceneCommandLineFlag)
                 {
-                    outputPath = args[i + 1];
+                    scenePath = args[i + 1];
                 }
             }
 

--- a/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
+++ b/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
@@ -7,10 +7,35 @@ namespace MLAgents
 {
     public class StandaloneBuildTest
     {
+        const string k_outputCommandLineFlag = "--mlagents-build-output-path";
+        const string k_sceneCommandLineFlag = "--mlagents-build-scene-path";
+
         public static void BuildStandalonePlayerOSX()
         {
-            string[] scenes = { "Assets/ML-Agents/Examples/3DBall/Scenes/3DBall.unity" };
-            var buildResult = BuildPipeline.BuildPlayer(scenes, "testPlayer", BuildTarget.StandaloneOSX, BuildOptions.None);
+            // Read commandline arguments for options
+            var outputPath = "testPlayer";
+            var scenePath = "Assets/ML-Agents/Examples/3DBall/Scenes/3DBall.unity";
+
+            var args = Environment.GetCommandLineArgs();
+            for (var i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i] == k_outputCommandLineFlag)
+                {
+                    outputPath = args[i + 1];
+                }
+                else if (args[i] == k_sceneCommandLineFlag)
+                {
+                    outputPath = args[i + 1];
+                }
+            }
+
+            string[] scenes = { scenePath };
+            var buildResult = BuildPipeline.BuildPlayer(
+                scenes,
+                outputPath,
+                BuildTarget.StandaloneOSX,
+                BuildOptions.None
+            );
             var isOk = buildResult.summary.result == BuildResult.Succeeded;
             var error = "";
             foreach (var stepInfo in buildResult.steps)

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -41,7 +41,7 @@ def run_training(python_version, csharp_version):
         os.rename(full_player_path, temp_player_path)
 
         checkout_csharp_version(csharp_version)
-        build_returncode = run_standalone_build(base_path, verbose=True)
+        build_returncode = run_standalone_build(base_path)
 
         if build_returncode != 0:
             print("Standalone build FAILED!")

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import os
 import sys
 import subprocess
@@ -38,12 +39,14 @@ def run_training(python_version, csharp_version):
         # Only build the standalone player if we're overriding the C# version
         # Otherwise we'll use the one built earlier in the pipeline.
         build_returncode = run_standalone_build(
-            base_path, output_path=standalone_player_path
+            base_path, output_path=standalone_player_path, verbose=True
         )
 
         if build_returncode != 0:
             print("Standalone build FAILED!")
             sys.exit(build_returncode)
+        else:
+            print(glob.glob("Project/testPlayer*"))
 
     venv_path = init_venv(python_version)
 

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -31,7 +31,9 @@ def run_training(python_version, csharp_version):
 
     standalone_player_path = "testPlayer"
     if csharp_version is not None:
-        standalone_player_path += "_" + csharp_version
+        # Something in the BuildPipeline removes trailing ".0"
+        # TODO - get a repro case for platform team, workaround for now.
+        standalone_player_path += "_" + csharp_version.replace(".", "_")
         checkout_csharp_version(csharp_version)
         # Only build the standalone player if we're overriding the C# version
         # Otherwise we'll use the one built earlier in the pipeline.

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import os
 import sys
 import subprocess
@@ -30,23 +29,30 @@ def run_training(python_version, csharp_version):
     base_path = get_base_path()
     print(f"Running in base path {base_path}")
 
-    standalone_player_path = "testPlayer"
+    # Only build the standalone player if we're overriding the C# version
+    # Otherwise we'll use the one built earlier in the pipeline.
     if csharp_version is not None:
-        # Something in the BuildPipeline removes trailing ".0"
-        # TODO - get a repro case for platform team, workaround for now.
-        standalone_player_path += "_" + csharp_version.replace(".", "_")
+        # We can't rely on the old C# code recognizing the commandline argument to set the output
+        # So rename testPlayer (containing the most recent build) to something else temporarily
+        full_player_path = os.path.join("Project", "testPlayer.app")
+        temp_player_path = os.path.join("Project", "temp_testPlayer.app")
+        final_player_path = os.path.join("Project", f"testPlayer_{csharp_version}.app")
+
+        os.rename(full_player_path, temp_player_path)
+
         checkout_csharp_version(csharp_version)
-        # Only build the standalone player if we're overriding the C# version
-        # Otherwise we'll use the one built earlier in the pipeline.
-        build_returncode = run_standalone_build(
-            base_path, output_path=standalone_player_path, verbose=True
-        )
+        build_returncode = run_standalone_build(base_path, verbose=True)
 
         if build_returncode != 0:
             print("Standalone build FAILED!")
             sys.exit(build_returncode)
-        else:
-            print(glob.glob("Project/testPlayer*"))
+
+        # Now rename the newly-built executable, and restore the old one
+        os.rename(full_player_path, final_player_path)
+        os.rename(temp_player_path, full_player_path)
+        standalone_player_path = f"testPlayer_{csharp_version}"
+    else:
+        standalone_player_path = "testPlayer"
 
     venv_path = init_venv(python_version)
 

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -23,11 +23,11 @@ def get_base_path():
     return os.getcwd()
 
 
-def run_standalone_build(base_path: str, verbose: bool = False) -> int:
+def run_standalone_build(
+    base_path: str, verbose: bool = False, output_path: str = None
+) -> int:
     """
-    Run BuildStandalonePlayerOSX test to produce a player at Project/testPlayer
-    :param base_path:
-    :return:
+    Run BuildStandalonePlayerOSX test to produce a player. The location defaults to Project/testPlayer.
     """
     unity_exe = get_unity_executable_path()
     print(f"Running BuildStandalonePlayerOSX via {unity_exe}")
@@ -42,6 +42,8 @@ def run_standalone_build(base_path: str, verbose: bool = False) -> int:
     ]
     if verbose:
         test_args += ["-logfile", "-"]
+    if output_path is not None:
+        test_args += ["--mlagents-build-output-path", output_path]
     print(f"{' '.join(test_args)} ...")
 
     timeout = 30 * 60  # 30 minutes, just in case


### PR DESCRIPTION
### Proposed change(s)

* Make the standalone player build take options for the output path and scene (latter is currently unused, but might be handy)
* Save the built player directory as an artifact in yamato
* Make the training tests depend on the standalone build step
* Reuse the player when possible (not when doing backcompat against old C#)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Prep work for https://jira.unity3d.com/browse/MLA-800


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
