### PR TITLE
Wrapped trainer has internal policy in ghost trainer

### DIFF
--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -301,28 +301,17 @@ class GhostTrainer(Trainer):
     def save_model(self, name_behavior_id: str) -> None:
         """
         Forwarding call to wrapped trainers save_model
-        Loads the latest policy weights, saves it, then reloads
-        the current policy weights before resuming training.
         """
         parsed_behavior_id = self._name_to_parsed_behavior_id[name_behavior_id]
         brain_name = parsed_behavior_id.brain_name
-        policy = self.trainer.get_policy(brain_name)
-        reload_weights = policy.get_weights()
-        # save current snapshot to policy
-        policy.load_weights(self.current_policy_snapshot[brain_name])
-        self.trainer.save_model(name_behavior_id)
-        # reload
-        policy.load_weights(reload_weights)
+        self.trainer.save_model(brain_name)
 
     def export_model(self, name_behavior_id: str) -> None:
         """
         Forwarding call to wrapped trainers export_model.
-        First loads the latest snapshot.
         """
         parsed_behavior_id = self._name_to_parsed_behavior_id[name_behavior_id]
         brain_name = parsed_behavior_id.brain_name
-        policy = self.trainer.get_policy(brain_name)
-        policy.load_weights(self.current_policy_snapshot[brain_name])
         self.trainer.export_model(brain_name)
 
     def create_policy(self, brain_parameters: BrainParameters) -> TFPolicy:
@@ -332,7 +321,7 @@ class GhostTrainer(Trainer):
         return self.trainer.create_policy(brain_parameters)
 
     def add_policy(
-        self, parsed_behavior_id: BehaviorIdentifiers, policy: TFPolicy
+        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
     ) -> None:
         """
         Adds policy to trainer. The first policy encountered sets the wrapped
@@ -345,21 +334,33 @@ class GhostTrainer(Trainer):
         name_behavior_id = parsed_behavior_id.behavior_id
         team_id = parsed_behavior_id.team_id
         self.controller.subscribe_team_id(team_id, self)
-        self.policies[name_behavior_id] = policy
+        policy = self.create_policy(brain_parameters)
+        policy.init_load_weights()
         policy.create_tf_graph()
+        self.policies[name_behavior_id] = policy
 
         self._name_to_parsed_behavior_id[name_behavior_id] = parsed_behavior_id
         # for saving/swapping snapshots
-        policy.init_load_weights()
 
         # First policy or a new agent on the same team encountered
         if self.wrapped_trainer_team is None or team_id == self.wrapped_trainer_team:
+            # creates an internal trainer policy. This always contains the current learning policy
+            # parameterization and is the object the wrapped trainer uses to compute gradients.
+            self.trainer.add_policy(parsed_behavior_id, brain_parameters)
+            internal_trainer_policy = self.trainer.get_policy(
+                parsed_behavior_id.brain_name
+            )
+            internal_trainer_policy.init_load_weights()
+            internal_trainer_policy.create_tf_graph()
+
             self.current_policy_snapshot[
                 parsed_behavior_id.brain_name
-            ] = policy.get_weights()
+            ] = internal_trainer_policy.get_weights()
+
+            # initialize ghost level policy to have the same weights
+            policy.load(internal_trainer_policy.get_weights())
 
             self._save_snapshot()  # Need to save after trainer initializes policy
-            self.trainer.add_policy(parsed_behavior_id, policy)
             self._learning_team = self.controller.get_learning_team
             self.wrapped_trainer_team = team_id
 

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -335,8 +335,8 @@ class GhostTrainer(Trainer):
         team_id = parsed_behavior_id.team_id
         self.controller.subscribe_team_id(team_id, self)
         policy = self.create_policy(brain_parameters)
-        policy.init_load_weights()
         policy.create_tf_graph()
+        policy.init_load_weights()
         self.policies[name_behavior_id] = policy
 
         self._name_to_parsed_behavior_id[name_behavior_id] = parsed_behavior_id
@@ -350,15 +350,15 @@ class GhostTrainer(Trainer):
             internal_trainer_policy = self.trainer.get_policy(
                 parsed_behavior_id.brain_name
             )
-            internal_trainer_policy.init_load_weights()
             internal_trainer_policy.create_tf_graph()
+            internal_trainer_policy.init_load_weights()
 
             self.current_policy_snapshot[
                 parsed_behavior_id.brain_name
             ] = internal_trainer_policy.get_weights()
 
             # initialize ghost level policy to have the same weights
-            policy.load(internal_trainer_policy.get_weights())
+            policy.load_weights(internal_trainer_policy.get_weights())
 
             self._save_snapshot()  # Need to save after trainer initializes policy
             self._learning_team = self.controller.get_learning_team

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -70,7 +70,7 @@ class PPOTrainer(RLTrainer):
         self._check_param_keys()
         self.load = load
         self.seed = seed
-        self.policy: NNPolicy = None  # type: ignore
+        self.policy: TFPolicy = None  # type: ignore
 
     def _check_param_keys(self):
         super()._check_param_keys()
@@ -239,7 +239,7 @@ class PPOTrainer(RLTrainer):
         return policy
 
     def add_policy(
-        self, parsed_behavior_id: BehaviorIdentifiers, policy: TFPolicy
+        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
     ) -> None:
         """
         Adds policy to trainer.
@@ -253,14 +253,12 @@ class PPOTrainer(RLTrainer):
                     self.__class__.__name__
                 )
             )
-        if not isinstance(policy, NNPolicy):
-            raise RuntimeError("Non-NNPolicy passed to PPOTrainer.add_policy()")
-        self.policy = policy
+        self.policy = self.create_policy(brain_parameters)
         self.optimizer = PPOOptimizer(self.policy, self.trainer_parameters)
         for _reward_signal in self.optimizer.reward_signals.keys():
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
         # Needed to resume loads properly
-        self.step = policy.get_current_step()
+        self.step = self.policy.get_current_step()
         self.next_summary_step = self._get_next_summary_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -80,7 +80,7 @@ class SACTrainer(RLTrainer):
         self._check_param_keys()
         self.load = load
         self.seed = seed
-        self.policy: NNPolicy = None  # type: ignore
+        self.policy: TFPolicy = None  # type: ignore
         self.optimizer: SACOptimizer = None  # type: ignore
 
         self.step = 0
@@ -339,7 +339,7 @@ class SACTrainer(RLTrainer):
             self._stats_reporter.add_stat(stat, np.mean(stat_list))
 
     def add_policy(
-        self, parsed_behavior_id: BehaviorIdentifiers, policy: TFPolicy
+        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
     ) -> None:
         """
         Adds policy to trainer.
@@ -352,14 +352,12 @@ class SACTrainer(RLTrainer):
                     self.__class__.__name__
                 )
             )
-        if not isinstance(policy, NNPolicy):
-            raise RuntimeError("Non-SACPolicy passed to SACTrainer.add_policy()")
-        self.policy = policy
+        self.policy = self.create_policy(brain_parameters)
         self.optimizer = SACOptimizer(self.policy, self.trainer_parameters)
         for _reward_signal in self.optimizer.reward_signals.keys():
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
         # Needed to resume loads properly
-        self.step = policy.get_current_step()
+        self.step = self.policy.get_current_step()
         self.next_summary_step = self._get_next_summary_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:

--- a/ml-agents/mlagents/trainers/tests/test_ghost.py
+++ b/ml-agents/mlagents/trainers/tests/test_ghost.py
@@ -126,20 +126,18 @@ def test_process_trajectory(dummy_config):
     )
 
     # first policy encountered becomes policy trained by wrapped PPO
-    policy = trainer.create_policy(brain_params_team0)
     parsed_behavior_id0 = BehaviorIdentifiers.from_name_behavior_id(
         brain_params_team0.brain_name
     )
-    trainer.add_policy(parsed_behavior_id0, policy)
+    trainer.add_policy(parsed_behavior_id0, brain_params_team0)
     trajectory_queue0 = AgentManagerQueue(brain_params_team0.brain_name)
     trainer.subscribe_trajectory_queue(trajectory_queue0)
 
     # Ghost trainer should ignore this queue because off policy
-    policy = trainer.create_policy(brain_params_team1)
     parsed_behavior_id1 = BehaviorIdentifiers.from_name_behavior_id(
         brain_params_team1.brain_name
     )
-    trainer.add_policy(parsed_behavior_id1, policy)
+    trainer.add_policy(parsed_behavior_id1, brain_params_team1)
     trajectory_queue1 = AgentManagerQueue(brain_params_team1.brain_name)
     trainer.subscribe_trajectory_queue(trajectory_queue1)
 
@@ -200,17 +198,15 @@ def test_publish_queue(dummy_config):
 
     # First policy encountered becomes policy trained by wrapped PPO
     # This queue should remain empty after swap snapshot
-    policy = trainer.create_policy(brain_params_team0)
-    trainer.add_policy(parsed_behavior_id0, policy)
+    trainer.add_policy(parsed_behavior_id0, brain_params_team0)
     policy_queue0 = AgentManagerQueue(brain_params_team0.brain_name)
     trainer.publish_policy_queue(policy_queue0)
 
     # Ghost trainer should use this queue for ghost policy swap
-    policy = trainer.create_policy(brain_params_team1)
     parsed_behavior_id1 = BehaviorIdentifiers.from_name_behavior_id(
         brain_params_team1.brain_name
     )
-    trainer.add_policy(parsed_behavior_id1, policy)
+    trainer.add_policy(parsed_behavior_id1, brain_params_team1)
     policy_queue1 = AgentManagerQueue(brain_params_team1.brain_name)
     trainer.publish_policy_queue(policy_queue1)
 

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -380,7 +380,6 @@ def test_add_get_policy(ppo_optimizer, nn_policy, dummy_config):
     dummy_config["summary_path"] = "./summaries/test_trainer_summary"
     dummy_config["model_path"] = "./models/test_trainer_models/TestModel"
 
-    # nn_policy.get_current_step.return_value = 2000
     trainer = PPOTrainer(brain_params, 0, dummy_config, True, False, 0, "0")
     trainer.add_policy(brain_params.brain_name, brain_params)
 

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -233,12 +233,22 @@ def test_rl_functions():
     )
 
 
+@mock.patch("mlagents.trainers.ppo.trainer.NNPolicy")
 @mock.patch("mlagents.trainers.ppo.trainer.PPOOptimizer")
-def test_trainer_increment_step(ppo_optimizer, dummy_config):
+def test_trainer_increment_step(ppo_optimizer, nn_policy, dummy_config):
     trainer_params = dummy_config
     mock_optimizer = mock.Mock()
     mock_optimizer.reward_signals = {}
     ppo_optimizer.return_value = mock_optimizer
+
+    mock_policy = mock.Mock()
+    mock_policy.get_current_step = mock.Mock(return_value=0)
+    step_count = (
+        5
+    )  # 10 hacked because this function is no longer called through trainer
+
+    mock_policy.increment_step = mock.Mock(return_value=step_count)
+    nn_policy.return_value = mock_policy
 
     brain_params = BrainParameters(
         brain_name="test_brain",
@@ -252,17 +262,12 @@ def test_trainer_increment_step(ppo_optimizer, dummy_config):
     trainer = PPOTrainer(
         brain_params.brain_name, 0, trainer_params, True, False, 0, "0"
     )
-    policy_mock = mock.Mock(spec=NNPolicy)
-    policy_mock.get_current_step.return_value = 0
-    step_count = (
-        5
-    )  # 10 hacked because this function is no longer called through trainer
-    policy_mock.increment_step = mock.Mock(return_value=step_count)
-    trainer.add_policy("testbehavior", policy_mock)
+    trainer.add_policy("testbehavior", brain_params)
+    policy = trainer.get_policy("testbehavior")
 
     trainer._increment_step(5, "testbehavior")
-    policy_mock.increment_step.assert_called_with(5)
     assert trainer.step == step_count
+    policy.increment_step.assert_called_with(5)
 
 
 @pytest.mark.parametrize("use_discrete", [True, False])
@@ -285,8 +290,7 @@ def test_trainer_update_policy(dummy_config, use_discrete):
     trainer_params["reward_signals"]["curiosity"]["encoding_size"] = 128
 
     trainer = PPOTrainer(mock_brain.brain_name, 0, trainer_params, True, False, 0, "0")
-    policy = trainer.create_policy(mock_brain)
-    trainer.add_policy(mock_brain.brain_name, policy)
+    trainer.add_policy(mock_brain.brain_name, mock_brain)
     # Test update with sequence length smaller than batch size
     buffer = mb.simulate_rollout(BUFFER_INIT_SAMPLES, mock_brain)
     # Mock out reward signal eval
@@ -314,8 +318,7 @@ def test_process_trajectory(dummy_config):
     dummy_config["summary_path"] = "./summaries/test_trainer_summary"
     dummy_config["model_path"] = "./models/test_trainer_models/TestModel"
     trainer = PPOTrainer(brain_params, 0, dummy_config, True, False, 0, "0")
-    policy = trainer.create_policy(brain_params)
-    trainer.add_policy(brain_params.brain_name, policy)
+    trainer.add_policy(brain_params.brain_name, brain_params)
     trajectory_queue = AgentManagerQueue("testbrain")
     trainer.subscribe_trajectory_queue(trajectory_queue)
     time_horizon = 15
@@ -361,8 +364,9 @@ def test_process_trajectory(dummy_config):
     assert trainer.stats_reporter.get_stats_summaries("Policy/Extrinsic Reward").num > 0
 
 
+@mock.patch("mlagents.trainers.ppo.trainer.NNPolicy")
 @mock.patch("mlagents.trainers.ppo.trainer.PPOOptimizer")
-def test_add_get_policy(ppo_optimizer, dummy_config):
+def test_add_get_policy(ppo_optimizer, nn_policy, dummy_config):
     brain_params = make_brain_parameters(
         discrete_action=False, visual_inputs=0, vec_obs_size=6
     )
@@ -370,23 +374,19 @@ def test_add_get_policy(ppo_optimizer, dummy_config):
     mock_optimizer.reward_signals = {}
     ppo_optimizer.return_value = mock_optimizer
 
+    mock_policy = mock.Mock()
+    mock_policy.get_current_step = mock.Mock(return_value=2000)
+    nn_policy.return_value = mock_policy
     dummy_config["summary_path"] = "./summaries/test_trainer_summary"
     dummy_config["model_path"] = "./models/test_trainer_models/TestModel"
-    trainer = PPOTrainer(brain_params, 0, dummy_config, True, False, 0, "0")
-    policy = mock.Mock(spec=NNPolicy)
-    policy.get_current_step.return_value = 2000
 
-    trainer.add_policy(brain_params.brain_name, policy)
-    assert trainer.get_policy(brain_params.brain_name) == policy
+    # nn_policy.get_current_step.return_value = 2000
+    trainer = PPOTrainer(brain_params, 0, dummy_config, True, False, 0, "0")
+    trainer.add_policy(brain_params.brain_name, brain_params)
 
     # Make sure the summary steps were loaded properly
     assert trainer.get_step == 2000
     assert trainer.next_summary_step > 2000
-
-    # Test incorrect class of policy
-    policy = mock.Mock()
-    with pytest.raises(RuntimeError):
-        trainer.add_policy(brain_params, policy)
 
 
 def test_bad_config(dummy_config):

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -402,7 +402,7 @@ def test_simple_asymm_ghost_fails(use_discrete):
     processed_rewards = [
         default_reward_processor(rewards) for rewards in env.final_rewards.values()
     ]
-    success_threshold = 0.99
+    success_threshold = 0.9
     assert any(reward > success_threshold for reward in processed_rewards) and any(
         reward < success_threshold for reward in processed_rewards
     )

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -140,7 +140,7 @@ class Trainer(abc.ABC):
 
     @abc.abstractmethod
     def add_policy(
-        self, parsed_behavior_id: BehaviorIdentifiers, policy: TFPolicy
+        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
     ) -> None:
         """
         Adds policy to trainer.

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -164,8 +164,10 @@ class TrainerController(object):
             trainer = self.trainer_factory.generate(brain_name)
             self.trainers[brain_name] = trainer
 
-        policy = trainer.create_policy(env_manager.external_brains[name_behavior_id])
-        trainer.add_policy(parsed_behavior_id, policy)
+        trainer.add_policy(
+            parsed_behavior_id, env_manager.external_brains[name_behavior_id]
+        )
+        policy = trainer.get_policy(name_behavior_id)
 
         agent_manager = AgentManager(
             policy,


### PR DESCRIPTION
### Proposed change(s)

Fixing potential bug in symmetric games introduced by team change.  The fix creates an internal policy to be used by the wrapped trainer for training so the wrapped trainer always has the latest model.  This simplifies the save/export functions in the ghost trainer. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
