### PR TITLE
check demonstration version before loading

### DIFF
--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -23,7 +23,7 @@ from google.protobuf.internal.encoder import _EncodeVarint  # type: ignore
 
 
 INITIAL_POS = 33
-SUPPORTED_DEMONSTRATION_VERSIONS = frozenset([1])
+SUPPORTED_DEMONSTRATION_VERSIONS = frozenset([0, 1])
 
 
 @timed

--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -22,6 +22,10 @@ from google.protobuf.internal.decoder import _DecodeVarint32  # type: ignore
 from google.protobuf.internal.encoder import _EncodeVarint  # type: ignore
 
 
+INITIAL_POS = 33
+SUPPORTED_DEMONSTRATION_VERSIONS = frozenset([1])
+
+
 @timed
 def make_demo_buffer(
     pair_infos: List[AgentInfoActionPairProto],
@@ -115,9 +119,6 @@ def get_demo_files(path: str) -> List[str]:
         )
 
 
-INITIAL_POS = 33
-
-
 @timed
 def load_demonstration(
     file_path: str
@@ -144,6 +145,13 @@ def load_demonstration(
                 if obs_decoded == 0:
                     meta_data_proto = DemonstrationMetaProto()
                     meta_data_proto.ParseFromString(data[pos : pos + next_pos])
+                    if (
+                        meta_data_proto.api_version
+                        not in SUPPORTED_DEMONSTRATION_VERSIONS
+                    ):
+                        raise RuntimeError(
+                            f"Can't load Demonstration data from an unsupported version ({meta_data_proto.api_version})"
+                        )
                     total_expected += meta_data_proto.number_steps
                     pos = INITIAL_POS
                 if obs_decoded == 1:

--- a/ml-agents/mlagents/trainers/tests/test_demo_loader.py
+++ b/ml-agents/mlagents/trainers/tests/test_demo_loader.py
@@ -1,6 +1,6 @@
 import io
 import os
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 import tempfile

--- a/ml-agents/mlagents/trainers/tests/test_demo_loader.py
+++ b/ml-agents/mlagents/trainers/tests/test_demo_loader.py
@@ -1,12 +1,19 @@
+import io
 import os
+import mock
 import numpy as np
 import pytest
 import tempfile
+
+from mlagents_envs.communicator_objects.demonstration_meta_pb2 import (
+    DemonstrationMetaProto,
+)
 
 from mlagents.trainers.demo_loader import (
     load_demonstration,
     demo_to_buffer,
     get_demo_files,
+    write_delimited,
 )
 
 
@@ -61,3 +68,20 @@ def test_edge_cases():
         assert get_demo_files(valid_fname) == [valid_fname]
         # valid directory
         assert get_demo_files(tmpdirname) == [valid_fname]
+
+
+@mock.patch("mlagents.trainers.demo_loader.get_demo_files", return_value=["foo.demo"])
+def test_unsupported_version_raises_error(mock_get_demo_files):
+    # Create a metadata proto with an unsupported version
+    bad_metadata = DemonstrationMetaProto()
+    bad_metadata.api_version = 1337
+
+    # Write the metadata to a temporary buffer, which will get returned by open()
+    buffer = io.BytesIO()
+    write_delimited(buffer, bad_metadata)
+    m = mock.mock_open(read_data=buffer.getvalue())
+
+    # Make sure that we get a RuntimeError when trying to load this.
+    with mock.patch("builtins.open", m):
+        with pytest.raises(RuntimeError):
+            load_demonstration("foo")


### PR DESCRIPTION
### Proposed change(s)
Currently the demonstration version is always set to 1:
https://github.com/Unity-Technologies/ml-agents/blob/d4810e28d16a13efb580337eab40db7b99cd9a8c/com.unity.ml-agents/Runtime/Demonstrations/Demonstration.cs#L36

If we decide to change the version later, we can either make the loading code handle both versions, or drop support for version 1 (hopefully the former). In the meantime, we should make sure that any attempt to load a new version in old code is unsupported.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-840


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
