### PR TITLE
Fix walljump warning. 

### DIFF
--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -319,9 +319,12 @@ namespace MLAgents
             m_Info.reward = m_Reward;
             m_Info.done = true;
             m_Info.maxStepReached = doneReason == DoneReason.MaxStepReached;
-            // Make sure the latest observations are being passed to training.
-            collectObservationsSensor.Reset();
-            CollectObservations(collectObservationsSensor);
+            if (collectObservationsSensor != null)
+            {
+                // Make sure the latest observations are being passed to training.
+                collectObservationsSensor.Reset();
+                CollectObservations(collectObservationsSensor);
+            }
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately
             m_Brain?.RequestDecision(m_Info, sensors);

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -319,6 +319,7 @@ namespace MLAgents
             m_Info.reward = m_Reward;
             m_Info.done = true;
             m_Info.maxStepReached = doneReason == DoneReason.MaxStepReached;
+            // Make sure the latest observations are being passed to training.
             collectObservationsSensor.Reset();
             CollectObservations(collectObservationsSensor);
             // Request the last decision with no callbacks

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -319,6 +319,8 @@ namespace MLAgents
             m_Info.reward = m_Reward;
             m_Info.done = true;
             m_Info.maxStepReached = doneReason == DoneReason.MaxStepReached;
+            collectObservationsSensor.Reset();
+            CollectObservations(collectObservationsSensor);
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately
             m_Brain?.RequestDecision(m_Info, sensors);

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -13,7 +13,11 @@ namespace MLAgents.Tests
     internal class TestPolicy : IPolicy
     {
         public Action OnRequestDecision;
+        private WriteAdapter m_Adapter = new WriteAdapter();
         public void RequestDecision(AgentInfo info, List<ISensor> sensors) {
+            foreach(var sensor in sensors){
+                sensor.GetObservationProto(m_Adapter);
+            }
             OnRequestDecision?.Invoke();
         }
 
@@ -515,20 +519,14 @@ namespace MLAgents.Tests
 
             for (int i = 0; i < 20; i++)
             {
-                Debug.Log(i);
                 agent1.RequestDecision();
                 aca.EnvironmentStep();
+
             }
 
-            SensorTestHelper.CompareObservation(sensor, new[] {18f, 19f, 20f});
-
-            policy.OnRequestDecision = () =>  SensorTestHelper.CompareObservation(sensor, new[] {19f, 20f, 21f});
-
-
+            policy.OnRequestDecision = () =>  SensorTestHelper.CompareObservation(sensor, new[] {18f, 19f, 21f});
             agent1.EndEpisode();
             SensorTestHelper.CompareObservation(sensor, new[] {0f, 0f, 0f});
-
-
         }
     }
 


### PR DESCRIPTION
### Proposed change(s)

Walljump had a warning during training reading 
```
Fewer observations (0) made than vector observation size (4). The observations will be padded.
```
Calling NotifyAgentDone will now call CollectObservations to make sure the latest observations are being passed to Python.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

 [JIRA ticket](https://jira.unity3d.com/browse/MLA-838) 
[Slack message](https://unity.slack.com/archives/C8FECS6L9/p1586194728297300)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
