### PR TITLE
[MLA-825] Add default values for SideChannel IncomingMessages methods

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)
  - Added a feature to allow sending stats from C# environments to TensorBoard (and other python StatsWriters). To do this from your code, use `SideChannelUtils.GetSideChannel<StatsSideChannel>().AddStat(key, value)` (#3660)
  - Renamed 'Generalization' feature to 'Environment Parameter Randomization'.
+ - SideChannel IncomingMessages methods now take an optional default argument, which is used when trying to read more data than the message contains.
  - The way that UnityEnvironment decides the port was changed. If no port is specified, the behavior will depend on the `file_name` parameter. If it is `None`, 5004 (the editor port) will be used; otherwise 5005 (the base environment port) will be used.
  - Fixed an issue where exceptions from environments provided a returncode of 0. (#3680)
  - Running `mlagents-learn` with the same `--run-id` twice will no longer overwrite the existing files. (#3705)

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices
+using System.Runtime.CompilerServices;
 using System;
 using System.IO;
 using System.Text;

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices
 using System;
 using System.IO;
 using System.Text;

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -26,38 +26,43 @@ namespace MLAgents.SideChannels
         }
 
         /// <summary>
-        /// Read a boolan value from the message.
+        /// Read a boolean value from the message.
         /// </summary>
         /// <returns></returns>
-        public bool ReadBoolean()
+        public bool ReadBoolean(bool defaultValue = false)
         {
-            return m_Reader.ReadBoolean();
+            return CanReadMore() ? m_Reader.ReadBoolean() : defaultValue;
         }
 
         /// <summary>
         /// Read an integer value from the message.
         /// </summary>
         /// <returns></returns>
-        public int ReadInt32()
+        public int ReadInt32(int defaultValue = 0)
         {
-            return m_Reader.ReadInt32();
+            return CanReadMore() ? m_Reader.ReadInt32() : defaultValue;
         }
 
         /// <summary>
         /// Read a float value from the message.
         /// </summary>
         /// <returns></returns>
-        public float ReadFloat32()
+        public float ReadFloat32(float defaultValue = 0.0f)
         {
-            return m_Reader.ReadSingle();
+            return CanReadMore() ? m_Reader.ReadSingle() : defaultValue;
         }
 
         /// <summary>
         /// Read a string value from the message.
         /// </summary>
         /// <returns></returns>
-        public string ReadString()
+        public string ReadString(string defaultValue = default)
         {
+            if (!CanReadMore())
+            {
+                return defaultValue;
+            }
+
             var strLength = ReadInt32();
             var str = Encoding.ASCII.GetString(m_Reader.ReadBytes(strLength));
             return str;
@@ -67,8 +72,13 @@ namespace MLAgents.SideChannels
         /// Reads a list of floats from the message. The length of the list is stored in the message.
         /// </summary>
         /// <returns></returns>
-        public IList<float> ReadFloatList()
+        public IList<float> ReadFloatList(IList<float> defaultValue = default)
         {
+            if (!CanReadMore())
+            {
+                return defaultValue;
+            }
+
             var len = ReadInt32();
             var output = new float[len];
             for (var i = 0; i < len; i++)
@@ -96,6 +106,11 @@ namespace MLAgents.SideChannels
         {
             m_Reader?.Dispose();
             m_Stream?.Dispose();
+        }
+
+        bool CanReadMore()
+        {
+            return m_Stream.Position < m_Stream.Length;
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -28,6 +28,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Read a boolean value from the message.
         /// </summary>
+        /// <param name="defaultValue">Default value to use if the end of the message is reached.</param>
         /// <returns></returns>
         public bool ReadBoolean(bool defaultValue = false)
         {
@@ -37,6 +38,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Read an integer value from the message.
         /// </summary>
+        /// <param name="defaultValue">Default value to use if the end of the message is reached.</param>
         /// <returns></returns>
         public int ReadInt32(int defaultValue = 0)
         {
@@ -46,6 +48,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Read a float value from the message.
         /// </summary>
+        /// <param name="defaultValue">Default value to use if the end of the message is reached.</param>
         /// <returns></returns>
         public float ReadFloat32(float defaultValue = 0.0f)
         {
@@ -55,6 +58,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Read a string value from the message.
         /// </summary>
+        /// <param name="defaultValue">Default value to use if the end of the message is reached.</param>
         /// <returns></returns>
         public string ReadString(string defaultValue = default)
         {
@@ -71,6 +75,7 @@ namespace MLAgents.SideChannels
         /// <summary>
         /// Reads a list of floats from the message. The length of the list is stored in the message.
         /// </summary>
+        /// <param name="defaultValue">Default value to use if the end of the message is reached.</param>
         /// <returns></returns>
         public IList<float> ReadFloatList(IList<float> defaultValue = default)
         {
@@ -108,6 +113,10 @@ namespace MLAgents.SideChannels
             m_Stream?.Dispose();
         }
 
+        /// <summary>
+        /// Whether or not there is more data left in the stream that can be read.
+        /// </summary>
+        /// <returns></returns>
         bool CanReadMore()
         {
             return m_Stream.Position < m_Stream.Length;

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -117,6 +117,7 @@ namespace MLAgents.SideChannels
         /// Whether or not there is more data left in the stream that can be read.
         /// </summary>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         bool CanReadMore()
         {
             return m_Stream.Position < m_Stream.Length;

--- a/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
@@ -163,5 +163,31 @@ namespace MLAgents.Tests
             Assert.AreEqual(stringVal, incomingMsg.ReadString());
             Assert.AreEqual(floatListVal, incomingMsg.ReadFloatList());
         }
+
+        [Test]
+        public void TestMessageReadDefaults()
+        {
+            // Make sure reading past the end of a message will apply defaults.
+            IncomingMessage incomingMsg;
+            using (var outgoingMsg = new OutgoingMessage())
+            {
+                incomingMsg = new IncomingMessage(outgoingMsg.ToByteArray());
+            }
+
+            Assert.AreEqual(false, incomingMsg.ReadBoolean());
+            Assert.AreEqual(true, incomingMsg.ReadBoolean(defaultValue: true));
+
+            Assert.AreEqual(0, incomingMsg.ReadInt32());
+            Assert.AreEqual(42, incomingMsg.ReadInt32(defaultValue: 42));
+
+            Assert.AreEqual(0.0f, incomingMsg.ReadFloat32());
+            Assert.AreEqual(1337.0f, incomingMsg.ReadFloat32(defaultValue: 1337.0f));
+
+            Assert.AreEqual(default(string), incomingMsg.ReadString());
+            Assert.AreEqual("foo", incomingMsg.ReadString(defaultValue: "foo"));
+
+            Assert.AreEqual(default(float[]), incomingMsg.ReadFloatList());
+            Assert.AreEqual(new float[] { 1001, 1002 }, incomingMsg.ReadFloatList(new float[] { 1001, 1002 }));
+        }
     }
 }

--- a/ml-agents-envs/mlagents_envs/side_channel/incoming_message.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/incoming_message.py
@@ -15,44 +15,69 @@ class IncomingMessage:
         self.buffer = buffer
         self.offset = offset
 
-    def read_bool(self) -> bool:
+    def read_bool(self, default_value: bool = False) -> bool:
         """
         Read a boolean value from the message buffer.
+        :param default_value: Default value to use if the end of the message is reached.
+        :return: The value read from the message, or the default value if the end was reached.
         """
+        if self._at_end_of_buffer():
+            return default_value
+
         val = struct.unpack_from("<?", self.buffer, self.offset)[0]
         self.offset += 1
         return val
 
-    def read_int32(self) -> int:
+    def read_int32(self, default_value: int = 0) -> int:
         """
         Read an integer value from the message buffer.
+        :param default_value: Default value to use if the end of the message is reached.
+        :return: The value read from the message, or the default value if the end was reached.
         """
+        if self._at_end_of_buffer():
+            return default_value
+
         val = struct.unpack_from("<i", self.buffer, self.offset)[0]
         self.offset += 4
         return val
 
-    def read_float32(self) -> float:
+    def read_float32(self, default_value: float = 0.0) -> float:
         """
         Read a float value from the message buffer.
+        :param default_value: Default value to use if the end of the message is reached.
+        :return: The value read from the message, or the default value if the end was reached.
         """
+        if self._at_end_of_buffer():
+            return default_value
+
         val = struct.unpack_from("<f", self.buffer, self.offset)[0]
         self.offset += 4
         return val
 
-    def read_float32_list(self) -> List[float]:
+    def read_float32_list(self, default_value: List[float] = None) -> List[float]:
         """
         Read a list of float values from the message buffer.
+        :param default_value: Default value to use if the end of the message is reached.
+        :return: The value read from the message, or the default value if the end was reached.
         """
+        if self._at_end_of_buffer():
+            return [] if default_value is None else default_value
+
         list_len = self.read_int32()
         output = []
         for _ in range(list_len):
             output.append(self.read_float32())
         return output
 
-    def read_string(self) -> str:
+    def read_string(self, default_value: str = "") -> str:
         """
         Read a string value from the message buffer.
+        :param default_value: Default value to use if the end of the message is reached.
+        :return: The value read from the message, or the default value if the end was reached.
         """
+        if self._at_end_of_buffer():
+            return default_value
+
         encoded_str_len = self.read_int32()
         val = self.buffer[self.offset : self.offset + encoded_str_len].decode("ascii")
         self.offset += encoded_str_len
@@ -63,3 +88,6 @@ class IncomingMessage:
         Get a copy of the internal bytes used by the message.
         """
         return bytearray(self.buffer)
+
+    def _at_end_of_buffer(self) -> bool:
+        return self.offset >= len(self.buffer)

--- a/ml-agents-envs/mlagents_envs/tests/test_side_channel.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_side_channel.py
@@ -95,6 +95,10 @@ def test_message_bool():
         read_vals.append(msg_in.read_bool())
     assert vals == read_vals
 
+    # Test reading with defaults
+    assert msg_in.read_bool() is False
+    assert msg_in.read_bool(default_value=True) is True
+
 
 def test_message_int32():
     val = 1337
@@ -104,6 +108,10 @@ def test_message_int32():
     msg_in = IncomingMessage(msg_out.buffer)
     read_val = msg_in.read_int32()
     assert val == read_val
+
+    # Test reading with defaults
+    assert 0 == msg_in.read_int32()
+    assert val == msg_in.read_int32(default_value=val)
 
 
 def test_message_float32():
@@ -116,6 +124,10 @@ def test_message_float32():
     # These won't be exactly equal in general, since python floats are 64-bit.
     assert val == read_val
 
+    # Test reading with defaults
+    assert 0.0 == msg_in.read_float32()
+    assert val == msg_in.read_float32(default_value=val)
+
 
 def test_message_string():
     val = "mlagents!"
@@ -125,6 +137,10 @@ def test_message_string():
     msg_in = IncomingMessage(msg_out.buffer)
     read_val = msg_in.read_string()
     assert val == read_val
+
+    # Test reading with defaults
+    assert "" == msg_in.read_string()
+    assert val == msg_in.read_string(default_value=val)
 
 
 def test_message_float_list():
@@ -136,3 +152,7 @@ def test_message_float_list():
     read_val = msg_in.read_float32_list()
     # These won't be exactly equal in general, since python floats are 64-bit.
     assert val == read_val
+
+    # Test reading with defaults
+    assert [] == msg_in.read_float32_list()
+    assert val == msg_in.read_float32_list(default_value=val)


### PR DESCRIPTION
### Proposed change(s)

To assist with backwards compatibility across side channels, this adds a default value when reading from IncomingMessages. This will let us add data to the messages in the future, but still allow reading from older versions.

Note that this only falls back to the default if it's at the end of the buffer. Trying to read an int when there's only 1 byte left will still raise/throw, but I think this is the correct behavior in that case.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-825


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
