### PR TITLE
Remove obsolete methods from Agent class

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The internal event `Academy.AgentSetStatus` was renamed to `Academy.AgentPreStep` and made public.
  - The offset logic was removed from DecisionRequester.
  - The communication API version has been bumped up to 1.0.0 and will use [Semantic Versioning](https://semver.org/) to do compatibility checks for communication between Unity and the Python process.
- - The obsolete methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
+ - The obsolete `Agent` methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
 
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The internal event `Academy.AgentSetStatus` was renamed to `Academy.AgentPreStep` and made public.
  - The offset logic was removed from DecisionRequester.
  - The communication API version has been bumped up to 1.0.0 and will use [Semantic Versioning](https://semver.org/) to do compatibility checks for communication between Unity and the Python process.
+ - The obsolete methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
 
 ### Minor Changes
  - Format of console output has changed slightly and now matches the name of the model/summary directory. (#3630, #3616)

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -353,15 +353,6 @@ namespace MLAgents
             m_RequestDecision = false;
         }
 
-        [Obsolete("GiveModel() has been deprecated, use SetModel() instead.")]
-        public void GiveModel(
-            string behaviorName,
-            NNModel model,
-            InferenceDevice inferenceDevice = InferenceDevice.CPU)
-        {
-            SetModel(behaviorName, model, inferenceDevice);
-        }
-
         /// <summary>
         /// Updates the Model for the agent. Any model currently assigned to the
         /// agent will be replaced with the provided one. If the arguments are
@@ -470,12 +461,6 @@ namespace MLAgents
             TimerStack.Instance.SetGauge(gaugeName, GetCumulativeReward());
         }
 
-        [Obsolete("Done() has been deprecated, use EndEpisode() instead.")]
-        public void Done()
-        {
-            EndEpisode();
-        }
-
         /// <summary>
         /// Sets the done flag to true.
         /// </summary>
@@ -519,11 +504,6 @@ namespace MLAgents
             }
         }
 
-        [Obsolete("InitializeAgent() has been deprecated, use Initialize() instead.")]
-        public virtual void InitializeAgent()
-        {
-        }
-
         /// <summary>
         /// Initializes the agent, called once when the agent is enabled. Can be
         /// left empty if there is no special, unique set-up behavior for the
@@ -533,12 +513,7 @@ namespace MLAgents
         /// One sample use is to store local references to other objects in the
         /// scene which would facilitate computing this agents observation.
         /// </remarks>
-        public virtual void Initialize()
-        {
-#pragma warning disable 0618
-            InitializeAgent();
-#pragma warning restore 0618
-        }
+        public virtual void Initialize(){}
 
         /// <summary>
         /// When the Agent uses Heuristics, it will call this method every time it
@@ -721,11 +696,6 @@ namespace MLAgents
         {
         }
 
-        [Obsolete("AgentAction() has been deprecated, use OnActionReceived() instead.")]
-        public virtual void AgentAction(float[] vectorAction)
-        {
-        }
-
         /// <summary>
         /// Specifies the agent behavior at every step based on the provided
         /// action.
@@ -734,29 +704,14 @@ namespace MLAgents
         /// Vector action. Note that for discrete actions, the provided array
         /// will be of length 1.
         /// </param>
-        public virtual void OnActionReceived(float[] vectorAction)
-        {
-#pragma warning disable 0618
-            AgentAction(m_Action.vectorActions);
-#pragma warning restore 0618
-        }
-
-        [Obsolete("AgentReset() has been deprecated, use OnEpisodeBegin() instead.")]
-        public virtual void AgentReset()
-        {
-        }
+        public virtual void OnActionReceived(float[] vectorAction){}
 
         /// <summary>
         /// Specifies the agent behavior when being reset, which can be due to
         /// the agent or Academy being done (i.e. completion of local or global
         /// episode).
         /// </summary>
-        public virtual void OnEpisodeBegin()
-        {
-#pragma warning disable 0618
-            AgentReset();
-#pragma warning restore 0618
-        }
+        public virtual void OnEpisodeBegin(){}
 
         /// <summary>
         /// Returns the last action that was decided on by the Agent

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -15,6 +15,7 @@ The versions can be found in
 * The `play_against_current_self_ratio` self-play trainer hyperparameter has been renamed to `play_against_latest_model_ratio`
 * Removed the multi-agent gym option from the gym wrapper. For multi-agent scenarios, use the [Low Level Python API](Python-API.md).
 * The low level Python API has changed. You can look at the document [Low Level Python API documentation](Python-API.md) for more information. If you use `mlagents-learn` for training, this should be a transparent change.
+* The obsolete methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
 
 ### Steps to Migrate
 * Replace the `--load` flag with `--resume` when calling `mlagents-learn`, and don't use the `--train` flag as training

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -15,7 +15,7 @@ The versions can be found in
 * The `play_against_current_self_ratio` self-play trainer hyperparameter has been renamed to `play_against_latest_model_ratio`
 * Removed the multi-agent gym option from the gym wrapper. For multi-agent scenarios, use the [Low Level Python API](Python-API.md).
 * The low level Python API has changed. You can look at the document [Low Level Python API documentation](Python-API.md) for more information. If you use `mlagents-learn` for training, this should be a transparent change.
-* The obsolete methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
+* The obsolete `Agent` methods `GiveModel`, `Done`, `InitializeAgent`, `AgentAction` and `AgentReset` have been removed.
 
 ### Steps to Migrate
 * Replace the `--load` flag with `--resume` when calling `mlagents-learn`, and don't use the `--train` flag as training


### PR DESCRIPTION
### Proposed change(s)

Remove obsolete methods from Agent class

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
