### PR TITLE
Add runningAverage to gauge stats

### DIFF
--- a/com.unity.ml-agents/Tests/Editor/TimerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TimerTest.cs
@@ -40,5 +40,46 @@ namespace MLAgents.Tests
             myTimer.Reset();
             Assert.AreEqual(myTimer.RootNode.Children, null);
         }
+
+        [Test]
+        public void TestGauges()
+        {
+            TimerStack myTimer = TimerStack.Instance;
+            myTimer.Reset();
+
+            // Simple test - adding 1's should keep that for the weighted and running averages.
+            myTimer.SetGauge("one", 1.0f);
+            var oneNode = myTimer.RootNode.Gauges["one"];
+            Assert.AreEqual(oneNode.weightedAverage, 1.0f);
+            Assert.AreEqual(oneNode.runningAverage, 1.0f);
+
+            for (int i = 0; i < 10; i++)
+            {
+                myTimer.SetGauge("one", 1.0f);
+            }
+
+            Assert.AreEqual(oneNode.weightedAverage, 1.0f);
+            Assert.AreEqual(oneNode.runningAverage, 1.0f);
+
+            // Try some more interesting values
+            myTimer.SetGauge("increasing", 1.0f);
+            myTimer.SetGauge("increasing", 2.0f);
+            myTimer.SetGauge("increasing", 3.0f);
+
+            myTimer.SetGauge("decreasing", 3.0f);
+            myTimer.SetGauge("decreasing", 2.0f);
+            myTimer.SetGauge("decreasing", 1.0f);
+            var increasingNode = myTimer.RootNode.Gauges["increasing"];
+            var decreasingNode = myTimer.RootNode.Gauges["decreasing"];
+
+            // Expect the running average to be (roughly) the same,
+            // but weighted averages will be biased differently.
+            Assert.AreEqual(increasingNode.runningAverage, 2.0f);
+            Assert.AreEqual(decreasingNode.runningAverage, 2.0f);
+
+            Assert.Greater(increasingNode.weightedAverage, decreasingNode.weightedAverage);
+
+
+        }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/TimerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TimerTest.cs
@@ -77,7 +77,9 @@ namespace MLAgents.Tests
             Assert.AreEqual(increasingNode.runningAverage, 2.0f);
             Assert.AreEqual(decreasingNode.runningAverage, 2.0f);
 
-            Assert.Greater(increasingNode.weightedAverage, decreasingNode.weightedAverage);
+            // The older values are actually weighted more heavily, so we expect the
+            // increasing series to have a lower moving average.
+            Assert.Less(increasingNode.weightedAverage, decreasingNode.weightedAverage);
 
 
         }


### PR DESCRIPTION
### Proposed change(s)
This is a better stat to measure inference rewards with. For the pushblock model that I was testing: 
```
        "Override_PushBlock.CumulativeReward": {
            "count": 46,
            "max": 4.9956,
            "min": -0.99994123,
            "runningAverage": 2.46747136,
            "value": -0.99994123,
            "weightedAverage": -0.975214243
        }
```
`runningAverage` is a lot more representative of the training average (2.191 in this case); `value` is just the most recent reward, and `weightedAverage` will be more heavily biased towards agents that ended the episode without reaching a goal.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://www.johndcook.com/blog/standard_deviation

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
