### PR TITLE
AcademyStepper to DontDestroyOnLoad

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
+++ b/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using MLAgents;
 
 /// <summary>
@@ -22,10 +23,14 @@ public class BasicController : MonoBehaviour
 
     Agent m_Agent;
 
+
     public void OnEnable()
     {
         m_Agent = GetComponent<Agent>();
-        ResetAgent();
+        m_Position = 10;
+        transform.position = new Vector3(m_Position - 10f, 0f, 0f);
+        smallGoal.transform.position = new Vector3(k_SmallGoalPosition - 10f, 0f, 0f);
+        largeGoal.transform.position = new Vector3(k_LargeGoalPosition - 10f, 0f, 0f);
     }
 
     /// <summary>
@@ -72,10 +77,10 @@ public class BasicController : MonoBehaviour
     }
 
     public void ResetAgent()
-    {
-        m_Position = 10;
-        smallGoal.transform.position = new Vector3(k_SmallGoalPosition - 10f, 0f, 0f);
-        largeGoal.transform.position = new Vector3(k_LargeGoalPosition - 10f, 0f, 0f);
+    {   
+        SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+        m_Agent = null; // LoadScene only takes effect at the next Update.
+        // We set the Agent to null to avoid using the Agent before the reload
     }
 
     public void FixedUpdate()
@@ -85,11 +90,15 @@ public class BasicController : MonoBehaviour
 
     void WaitTimeInference()
     {
+        if (m_Agent == null)
+        {
+            return;
+        }
         if (Academy.Instance.IsCommunicatorOn)
         {
             // Apply the previous step's actions
             ApplyAction(m_Agent.GetAction());
-            m_Agent.RequestDecision();
+            m_Agent?.RequestDecision();
         }
         else
         {
@@ -99,7 +108,7 @@ public class BasicController : MonoBehaviour
                 ApplyAction(m_Agent.GetAction());
 
                 m_TimeSinceDecision = 0f;
-                m_Agent.RequestDecision();
+                m_Agent?.RequestDecision();
             }
             else
             {

--- a/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
+++ b/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
@@ -78,6 +78,7 @@ public class BasicController : MonoBehaviour
 
     public void ResetAgent()
     {   
+        // This is a very inefficient way to reset the scene. Used here for testing.
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
         m_Agent = null; // LoadScene only takes effect at the next Update.
         // We set the Agent to null to avoid using the Agent before the reload

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -209,7 +209,12 @@ namespace MLAgents
             // Don't show this object in the hierarchy
             m_StepperObject.hideFlags = HideFlags.HideInHierarchy;
             m_FixedUpdateStepper = m_StepperObject.AddComponent<AcademyFixedUpdateStepper>();
-            GameObject.DontDestroyOnLoad(m_StepperObject);
+            try
+            {
+                // This try-catch is because DontDestroyOnLoad cannot be used in Editor Tests
+                GameObject.DontDestroyOnLoad(m_StepperObject);
+            }
+            catch {}
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -209,6 +209,7 @@ namespace MLAgents
             // Don't show this object in the hierarchy
             m_StepperObject.hideFlags = HideFlags.HideInHierarchy;
             m_FixedUpdateStepper = m_StepperObject.AddComponent<AcademyFixedUpdateStepper>();
+            GameObject.DontDestroyOnLoad(m_StepperObject);
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -318,6 +318,11 @@ namespace MLAgents
 
         void NotifyAgentDone(DoneReason doneReason)
         {
+            if (m_Info.done)
+            {
+                // The Agent was already marked as Done and should not be notified again
+                return;
+            }
             m_Info.episodeId = m_EpisodeId;
             m_Info.reward = m_Reward;
             m_Info.done = true;


### PR DESCRIPTION
### Proposed change(s)

 - Added `DontDestroyOnLoad` to the AcademyStepper.
 - Modified *Basic* to use scene reload for reset logic
 - Made it so that it is not possible to Terminate an episode more than once (reloading the scene destroys the agents in the scene causing them to end their episode again)  

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
