### PR TITLE
decouple py and c# versions in update script

### DIFF
--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -42,16 +42,16 @@ def check_versions() -> bool:
     return True
 
 
-def set_version(new_version: str) -> None:
-    new_contents = f'{VERSION_LINE_START}"{new_version}"\n'
+def set_version(python_version: str, csharp_version: str) -> None:
+    new_contents = f'{VERSION_LINE_START}"{python_version}"\n'
     for directory in DIRECTORIES:
         path = os.path.join(directory, "__init__.py")
-        print(f"Setting {path} to version {new_version}")
+        print(f"Setting {path} to version {python_version}")
         with open(path, "w") as f:
             f.write(new_contents)
-    # Package version is a bit stricter - only set it if we're not a "dev" version.
-    if "dev" not in new_version:
-        package_version = new_version + "-preview"
+
+    if csharp_version is not None:
+        package_version = csharp_version + "-preview"
         print(
             f"Setting package version to {package_version} in {UNITY_PACKAGE_JSON_PATH}"
         )
@@ -90,13 +90,17 @@ def set_academy_version_string(new_version):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--new-version", default=None)
+    parser.add_argument("--python-version", default=None)
+    parser.add_argument("--csharp-version", default=None)
     # unused, but allows precommit to pass filenames
     parser.add_argument("files", nargs="*")
     args = parser.parse_args()
-    if args.new_version:
-        print(f"Updating to verison {args.new_version}")
-        set_version(args.new_version)
+
+    if args.python_version:
+        print(f"Updating python library to version {args.python_version}")
+        if args.csharp_version:
+            print(f"Updating C# package to version {args.csharp_version}")
+        set_version(args.python_version, args.csharp_version)
     else:
         ok = check_versions()
         return_code = 0 if ok else 1


### PR DESCRIPTION
### Proposed change(s)
Part one of updating the release process. This changes the script that we run to update the version strings, in order to handle different C# and python versions. I'll update the release checklist after this is merged.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
