### PR TITLE
rename namespaces to Unity.MLAgents

### DIFF
--- a/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
+++ b/Project/Assets/ML-Agents/Editor/Tests/StandaloneBuildTest.cs
@@ -3,7 +3,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEditor.Build.Reporting;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     public class StandaloneBuildTest
     {

--- a/Project/Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBall.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBall.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBall.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBallHard.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBallHard.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/3DBall/Demos/Expert3DBallHard.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class Ball3DAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class Ball3DHardAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Basic/Demos/ExpertBasic.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Basic/Demos/ExpertBasic.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Basic/Demos/ExpertBasic.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
+++ b/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicController.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using MLAgents;
+using Unity.MLAgents;
 
 /// <summary>
 /// An example of how to use ML-Agents without inheriting from the Agent class.

--- a/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicSensorComponent.cs
+++ b/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicSensorComponent.cs
@@ -1,8 +1,8 @@
 using System;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 using UnityEngine.Serialization;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// A simple example of a SensorComponent.

--- a/Project/Assets/ML-Agents/Examples/Bouncer/Demos/ExpertBouncer.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Bouncer/Demos/ExpertBouncer.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Bouncer/Demos/ExpertBouncer.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class BouncerAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerTarget.cs
+++ b/Project/Assets/ML-Agents/Examples/Bouncer/Scripts/BouncerTarget.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using MLAgents;
+using Unity.MLAgents;
 
 public class BouncerTarget : MonoBehaviour
 {

--- a/Project/Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerDyn.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerDyn.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerDyn.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerSta.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerSta.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Crawler/Demos/ExpertCrawlerSta.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgentsExamples;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgentsExamples;
+using Unity.MLAgents.Sensors;
 
 [RequireComponent(typeof(JointDriveController))] // Required to set joint forces
 public class CrawlerAgent : Agent

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Demos/ExpertFood.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Demos/ExpertFood.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/FoodCollector/Demos/ExpertFood.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class FoodCollectorAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorArea.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorArea.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using MLAgentsExamples;
+using Unity.MLAgentsExamples;
 
 public class FoodCollectorArea : Area
 {

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorSettings.cs
@@ -1,8 +1,8 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 
 public class FoodCollectorSettings : MonoBehaviour
 {

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Demos/ExpertGrid.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Demos/ExpertGrid.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/GridWorld/Demos/ExpertGrid.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -1,10 +1,10 @@
 using System;
 using UnityEngine;
 using System.Linq;
-using MLAgents;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
 using UnityEngine.Serialization;
-using MLAgents.SideChannels;
+using Unity.MLAgents.SideChannels;
 
 public class GridAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridArea.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 
 
 public class GridArea : MonoBehaviour

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 
 public class GridSettings : MonoBehaviour
 {

--- a/Project/Assets/ML-Agents/Examples/Hallway/Demos/ExpertHallway.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Demos/ExpertHallway.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Hallway/Demos/ExpertHallway.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
 
 public class HallwayAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Demos/ExpertPush.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Demos/ExpertPush.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/PushBlock/Demos/ExpertPush.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -2,8 +2,8 @@
 
 using System.Collections;
 using UnityEngine;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 
 public class PushAgentBasic : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
@@ -2,8 +2,8 @@ using System;
 using System.Linq;
 using UnityEngine;
 using Random = UnityEngine.Random;
-using MLAgents;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
 
 public class PyramidAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidArea.cs
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidArea.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using MLAgentsExamples;
+using Unity.MLAgentsExamples;
 
 public class PyramidArea : Area
 {

--- a/Project/Assets/ML-Agents/Examples/Reacher/Demos/ExpertReacher.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Reacher/Demos/ExpertReacher.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Reacher/Demos/ExpertReacher.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class ReacherAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/Area.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/Area.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     public class Area : MonoBehaviour
     {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/CameraFollow.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/CameraFollow.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     public class CameraFollow : MonoBehaviour
     {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/FlyCamera.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/FlyCamera.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     public class FlyCamera : MonoBehaviour
     {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/GroundContact.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/GroundContact.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
-using MLAgents;
+using Unity.MLAgents;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// This class contains logic for locomotion agents with joints which might make contact with the ground.

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/JointDriveController.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/JointDriveController.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
-using MLAgents;
+using Unity.MLAgents;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// Used to store relevant information for acting and learning for each body part in agent.

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using UnityEngine;
 using Barracuda;
 using System.IO;
-using MLAgents;
-using MLAgents.Policies;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// Utility class to allow the NNModel file for an agent to be overriden during inference.

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/Monitor.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/Monitor.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using UnityEngine;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Monitor is used to display information about the Agent within the Unity

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ProjectSettingsOverrides.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     public class ProjectSettingsOverrides : MonoBehaviour
     {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs
@@ -1,6 +1,6 @@
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// A simple sensor that provides a number default implementations.

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/TargetContact.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/TargetContact.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// This class contains logic for locomotion agents with joints which might make contact with a target.

--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
-using MLAgents;
-using MLAgents.Policies;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
 
 public class AgentSoccer : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/SoccerFieldArea.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 using UnityEngine;
 using UnityEngine.Serialization;
 

--- a/Project/Assets/ML-Agents/Examples/Startup/Scripts/Startup.cs
+++ b/Project/Assets/ML-Agents/Examples/Startup/Scripts/Startup.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     internal class Startup : MonoBehaviour
     {

--- a/Project/Assets/ML-Agents/Examples/Template/Scripts/TemplateAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Template/Scripts/TemplateAgent.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
 
 public class TemplateAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Tennis/Demos/ExpertTennis.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Tennis/Demos/ExpertTennis.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Tennis/Demos/ExpertTennis.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Tennis/Scripts/TennisAgent.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
-using MLAgents;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class TennisAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/Walker/Demos/ExpertWalker.demo.meta
+++ b/Project/Assets/ML-Agents/Examples/Walker/Demos/ExpertWalker.demo.meta
@@ -4,7 +4,7 @@ ScriptedImporter:
   fileIDToRecycleName:
     11400000: Assets/ML-Agents/Examples/Walker/Demos/ExpertWalker.demo
   externalObjects: {}
-  userData: ' (MLAgents.Demonstrations.DemonstrationSummary)'
+  userData: ' (Unity.MLAgents.Demonstrations.DemonstrationSummary)'
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 7bd65ce151aaa4a41a45312543c56be1, type: 3}

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
-using MLAgents;
-using MLAgentsExamples;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgentsExamples;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class WalkerAgent : Agent
 {

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -2,10 +2,10 @@
 
 using System.Collections;
 using UnityEngine;
-using MLAgents;
+using Unity.MLAgents;
 using Barracuda;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
 public class WallJumpAgent : Agent
 {

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Major Changes
 
+- The `MLAgents` C# namespace was renamed to `Unity.MLAgents`, and other nested
+ namespaces were similarly renamed. (#3792)
 - The `--load` and `--train` command-line flags have been deprecated. Training
   now happens by default, and use `--resume` to resume training instead. (#3705)
 - The Jupyter notebooks have been removed from the repository.

--- a/com.unity.ml-agents/Editor/AgentEditor.cs
+++ b/com.unity.ml-agents/Editor/AgentEditor.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     /*
      This code is meant to modify the behavior of the inspector on Agent Components.

--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -1,10 +1,10 @@
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 using UnityEditor;
 using Barracuda;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 using UnityEngine;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     /*
      This code is meant to modify the behavior of the inspector on Agent Components.

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using UnityEditor;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     /// <summary>
     /// PropertyDrawer for BrainParameters. Defines how BrainParameters are displayed in the

--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using UnityEditor;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     [CustomEditor(typeof(CameraSensorComponent))]
     [CanEditMultipleObjects]

--- a/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System.Text;
 using UnityEditor;
-using MLAgents.Demonstrations;
-using MLAgents.Policies;
+using Unity.MLAgents.Demonstrations;
+using Unity.MLAgents.Policies;
 
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     /// <summary>
     /// Renders a custom UI for DemonstrationSummary ScriptableObject.

--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using MLAgents.CommunicatorObjects;
+using Unity.MLAgents.CommunicatorObjects;
 using UnityEditor;
 using UnityEngine;
 using UnityEditor.Experimental.AssetImporters;
-using MLAgents.Demonstrations;
+using Unity.MLAgents.Demonstrations;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     /// <summary>
     /// Asset Importer used to parse demonstration files.

--- a/com.unity.ml-agents/Editor/EditorUtilities.cs
+++ b/com.unity.ml-agents/Editor/EditorUtilities.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     public static class EditorUtilities
     {

--- a/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
+++ b/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using UnityEditor;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Editor
+namespace Unity.MLAgents.Editor
 {
     internal class RayPerceptionSensorComponentBaseEditor : UnityEditor.Editor
     {

--- a/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/RenderTextureSensorComponentEditor.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEditor;
-using MLAgents.Sensors;
-namespace MLAgents.Editor
+using Unity.MLAgents.Sensors;
+namespace Unity.MLAgents.Editor
 {
     [CustomEditor(typeof(RenderTextureSensorComponent))]
     [CanEditMultipleObjects]

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
-using MLAgents.Inference;
-using MLAgents.Policies;
-using MLAgents.SideChannels;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.SideChannels;
 using Barracuda;
 
 /**
@@ -22,7 +22,7 @@ using Barracuda;
  * https://github.com/Unity-Technologies/ml-agents/blob/master/docs/
  */
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Helper class to step the Academy during FixedUpdate phase.

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Barracuda;
-using MLAgents.Sensors;
-using MLAgents.Demonstrations;
-using MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Demonstrations;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Struct that contains all the information for an Agent, including its

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -2,18 +2,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf;
-using MLAgents.CommunicatorObjects;
+using Unity.MLAgents.CommunicatorObjects;
 using UnityEngine;
 using System.Runtime.CompilerServices;
-using MLAgents.Sensors;
-using MLAgents.Demonstrations;
-using MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Demonstrations;
+using Unity.MLAgents.Policies;
 
 
 [assembly: InternalsVisibleTo("Unity.ML-Agents.Editor")]
 [assembly: InternalsVisibleTo("Unity.ML-Agents.Editor.Tests")]
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     internal static class GrpcExtensions
     {

--- a/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/ICommunicator.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using MLAgents.Policies;
-using MLAgents.Sensors;
-using MLAgents.SideChannels;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.SideChannels;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     internal struct CommunicatorInitParameters
     {

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -8,13 +8,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using MLAgents.CommunicatorObjects;
-using MLAgents.Sensors;
-using MLAgents.Policies;
-using MLAgents.SideChannels;
+using Unity.MLAgents.CommunicatorObjects;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.SideChannels;
 using Google.Protobuf;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// Responsible for communication with External using gRPC.
     internal class RpcCommunicator : ICommunicator

--- a/com.unity.ml-agents/Runtime/Constants.cs
+++ b/com.unity.ml-agents/Runtime/Constants.cs
@@ -1,4 +1,4 @@
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Grouping for use in AddComponentMenu (instead of nesting the menus).

--- a/com.unity.ml-agents/Runtime/DecisionRequester.cs
+++ b/com.unity.ml-agents/Runtime/DecisionRequester.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// A component that when attached to an Agent will automatically request decisions from it

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationMetaData.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationMetaData.cs
@@ -1,9 +1,9 @@
 using System;
 using UnityEngine;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Demonstrations
+namespace Unity.MLAgents.Demonstrations
 {
     /// <summary>
     /// Demonstration meta-data.

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -2,9 +2,9 @@ using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using System.IO;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Demonstrations
+namespace Unity.MLAgents.Demonstrations
 {
     /// <summary>
     /// Demonstration Recorder Component.

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationSummary.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationSummary.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Demonstrations
+namespace Unity.MLAgents.Demonstrations
 {
     /// <summary>
     /// Summary of a loaded Demonstration file. Only used for display in the Inspector.

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationWriter.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationWriter.cs
@@ -1,10 +1,10 @@
 using System.IO;
 using Google.Protobuf;
 using System.Collections.Generic;
-using MLAgents.Sensors;
-using MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Demonstrations
+namespace Unity.MLAgents.Demonstrations
 {
     /// <summary>
     /// Responsible for writing demonstration data to stream (typically a file stream).

--- a/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
+++ b/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Agents that take discrete actions can explicitly indicate that specific actions

--- a/com.unity.ml-agents/Runtime/EpisodeIdCounter.cs
+++ b/com.unity.ml-agents/Runtime/EpisodeIdCounter.cs
@@ -1,4 +1,4 @@
-namespace MLAgents
+namespace Unity.MLAgents
 {
     internal static class EpisodeIdCounter
     {

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentAction.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentAction.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/agent_action.proto</summary>
   internal static partial class AgentActionReflection {
@@ -27,12 +27,12 @@ namespace MLAgents.CommunicatorObjects {
             "CjVtbGFnZW50c19lbnZzL2NvbW11bmljYXRvcl9vYmplY3RzL2FnZW50X2Fj",
             "dGlvbi5wcm90bxIUY29tbXVuaWNhdG9yX29iamVjdHMiSwoQQWdlbnRBY3Rp",
             "b25Qcm90bxIWCg52ZWN0b3JfYWN0aW9ucxgBIAMoAhINCgV2YWx1ZRgEIAEo",
-            "AkoECAIQA0oECAMQBEoECAUQBkIfqgIcTUxBZ2VudHMuQ29tbXVuaWNhdG9y",
-            "T2JqZWN0c2IGcHJvdG8z"));
+            "AkoECAIQA0oECAMQBEoECAUQBkIlqgIiVW5pdHkuTUxBZ2VudHMuQ29tbXVu",
+            "aWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.AgentActionProto), global::MLAgents.CommunicatorObjects.AgentActionProto.Parser, new[]{ "VectorActions", "Value" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.AgentActionProto), global::Unity.MLAgents.CommunicatorObjects.AgentActionProto.Parser, new[]{ "VectorActions", "Value" }, null, null, null)
           }));
     }
     #endregion
@@ -47,7 +47,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentInfo.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentInfo.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/agent_info.proto</summary>
   internal static partial class AgentInfoReflection {
@@ -31,12 +31,12 @@ namespace MLAgents.CommunicatorObjects {
             "ChBtYXhfc3RlcF9yZWFjaGVkGAkgASgIEgoKAmlkGAogASgFEhMKC2FjdGlv",
             "bl9tYXNrGAsgAygIEjwKDG9ic2VydmF0aW9ucxgNIAMoCzImLmNvbW11bmlj",
             "YXRvcl9vYmplY3RzLk9ic2VydmF0aW9uUHJvdG9KBAgBEAJKBAgCEANKBAgD",
-            "EARKBAgEEAVKBAgFEAZKBAgGEAdKBAgMEA1CH6oCHE1MQWdlbnRzLkNvbW11",
-            "bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "EARKBAgEEAVKBAgFEAZKBAgGEAdKBAgMEA1CJaoCIlVuaXR5Lk1MQWdlbnRz",
+            "LkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.ObservationReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.ObservationReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.AgentInfoProto), global::MLAgents.CommunicatorObjects.AgentInfoProto.Parser, new[]{ "Reward", "Done", "MaxStepReached", "Id", "ActionMask", "Observations" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto), global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto.Parser, new[]{ "Reward", "Done", "MaxStepReached", "Id", "ActionMask", "Observations" }, null, null, null)
           }));
     }
     #endregion
@@ -51,7 +51,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -138,11 +138,11 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "observations" field.</summary>
     public const int ObservationsFieldNumber = 13;
-    private static readonly pb::FieldCodec<global::MLAgents.CommunicatorObjects.ObservationProto> _repeated_observations_codec
-        = pb::FieldCodec.ForMessage(106, global::MLAgents.CommunicatorObjects.ObservationProto.Parser);
-    private readonly pbc::RepeatedField<global::MLAgents.CommunicatorObjects.ObservationProto> observations_ = new pbc::RepeatedField<global::MLAgents.CommunicatorObjects.ObservationProto>();
+    private static readonly pb::FieldCodec<global::Unity.MLAgents.CommunicatorObjects.ObservationProto> _repeated_observations_codec
+        = pb::FieldCodec.ForMessage(106, global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Parser);
+    private readonly pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.ObservationProto> observations_ = new pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.ObservationProto>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::MLAgents.CommunicatorObjects.ObservationProto> Observations {
+    public pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.ObservationProto> Observations {
       get { return observations_; }
     }
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentInfoActionPair.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/AgentInfoActionPair.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/agent_info_action_pair.proto</summary>
   internal static partial class AgentInfoActionPairReflection {
@@ -31,12 +31,12 @@ namespace MLAgents.CommunicatorObjects {
             "bnRfYWN0aW9uLnByb3RvIpEBChhBZ2VudEluZm9BY3Rpb25QYWlyUHJvdG8S",
             "OAoKYWdlbnRfaW5mbxgBIAEoCzIkLmNvbW11bmljYXRvcl9vYmplY3RzLkFn",
             "ZW50SW5mb1Byb3RvEjsKC2FjdGlvbl9pbmZvGAIgASgLMiYuY29tbXVuaWNh",
-            "dG9yX29iamVjdHMuQWdlbnRBY3Rpb25Qcm90b0IfqgIcTUxBZ2VudHMuQ29t",
-            "bXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
+            "dG9yX29iamVjdHMuQWdlbnRBY3Rpb25Qcm90b0IlqgIiVW5pdHkuTUxBZ2Vu",
+            "dHMuQ29tbXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor, global::MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.AgentInfoActionPairProto), global::MLAgents.CommunicatorObjects.AgentInfoActionPairProto.Parser, new[]{ "AgentInfo", "ActionInfo" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.AgentInfoActionPairProto), global::Unity.MLAgents.CommunicatorObjects.AgentInfoActionPairProto.Parser, new[]{ "AgentInfo", "ActionInfo" }, null, null, null)
           }));
     }
     #endregion
@@ -51,7 +51,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.AgentInfoActionPairReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.AgentInfoActionPairReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -80,9 +80,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "agent_info" field.</summary>
     public const int AgentInfoFieldNumber = 1;
-    private global::MLAgents.CommunicatorObjects.AgentInfoProto agentInfo_;
+    private global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto agentInfo_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.AgentInfoProto AgentInfo {
+    public global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto AgentInfo {
       get { return agentInfo_; }
       set {
         agentInfo_ = value;
@@ -91,9 +91,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "action_info" field.</summary>
     public const int ActionInfoFieldNumber = 2;
-    private global::MLAgents.CommunicatorObjects.AgentActionProto actionInfo_;
+    private global::Unity.MLAgents.CommunicatorObjects.AgentActionProto actionInfo_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.AgentActionProto ActionInfo {
+    public global::Unity.MLAgents.CommunicatorObjects.AgentActionProto ActionInfo {
       get { return actionInfo_; }
       set {
         actionInfo_ = value;
@@ -171,13 +171,13 @@ namespace MLAgents.CommunicatorObjects {
       }
       if (other.agentInfo_ != null) {
         if (agentInfo_ == null) {
-          agentInfo_ = new global::MLAgents.CommunicatorObjects.AgentInfoProto();
+          agentInfo_ = new global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto();
         }
         AgentInfo.MergeFrom(other.AgentInfo);
       }
       if (other.actionInfo_ != null) {
         if (actionInfo_ == null) {
-          actionInfo_ = new global::MLAgents.CommunicatorObjects.AgentActionProto();
+          actionInfo_ = new global::Unity.MLAgents.CommunicatorObjects.AgentActionProto();
         }
         ActionInfo.MergeFrom(other.ActionInfo);
       }
@@ -194,14 +194,14 @@ namespace MLAgents.CommunicatorObjects {
             break;
           case 10: {
             if (agentInfo_ == null) {
-              agentInfo_ = new global::MLAgents.CommunicatorObjects.AgentInfoProto();
+              agentInfo_ = new global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto();
             }
             input.ReadMessage(agentInfo_);
             break;
           }
           case 18: {
             if (actionInfo_ == null) {
-              actionInfo_ = new global::MLAgents.CommunicatorObjects.AgentActionProto();
+              actionInfo_ = new global::Unity.MLAgents.CommunicatorObjects.AgentActionProto();
             }
             input.ReadMessage(actionInfo_);
             break;

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/BrainParameters.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/brain_parameters.proto</summary>
   internal static partial class BrainParametersReflection {
@@ -31,12 +31,12 @@ namespace MLAgents.CommunicatorObjects {
             "ZRgDIAMoBRIiChp2ZWN0b3JfYWN0aW9uX2Rlc2NyaXB0aW9ucxgFIAMoCRJG",
             "Chh2ZWN0b3JfYWN0aW9uX3NwYWNlX3R5cGUYBiABKA4yJC5jb21tdW5pY2F0",
             "b3Jfb2JqZWN0cy5TcGFjZVR5cGVQcm90bxISCgpicmFpbl9uYW1lGAcgASgJ",
-            "EhMKC2lzX3RyYWluaW5nGAggASgISgQIARACSgQIAhADSgQIBBAFQh+qAhxN",
-            "TEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
+            "EhMKC2lzX3RyYWluaW5nGAggASgISgQIARACSgQIAhADSgQIBBAFQiWqAiJV",
+            "bml0eS5NTEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.SpaceTypeReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.SpaceTypeReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.BrainParametersProto), global::MLAgents.CommunicatorObjects.BrainParametersProto.Parser, new[]{ "VectorActionSize", "VectorActionDescriptions", "VectorActionSpaceType", "BrainName", "IsTraining" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto), global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto.Parser, new[]{ "VectorActionSize", "VectorActionDescriptions", "VectorActionSpaceType", "BrainName", "IsTraining" }, null, null, null)
           }));
     }
     #endregion
@@ -51,7 +51,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.BrainParametersReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.BrainParametersReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -103,9 +103,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "vector_action_space_type" field.</summary>
     public const int VectorActionSpaceTypeFieldNumber = 6;
-    private global::MLAgents.CommunicatorObjects.SpaceTypeProto vectorActionSpaceType_ = 0;
+    private global::Unity.MLAgents.CommunicatorObjects.SpaceTypeProto vectorActionSpaceType_ = 0;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.SpaceTypeProto VectorActionSpaceType {
+    public global::Unity.MLAgents.CommunicatorObjects.SpaceTypeProto VectorActionSpaceType {
       get { return vectorActionSpaceType_; }
       set {
         vectorActionSpaceType_ = value;
@@ -252,7 +252,7 @@ namespace MLAgents.CommunicatorObjects {
             break;
           }
           case 48: {
-            vectorActionSpaceType_ = (global::MLAgents.CommunicatorObjects.SpaceTypeProto) input.ReadEnum();
+            vectorActionSpaceType_ = (global::Unity.MLAgents.CommunicatorObjects.SpaceTypeProto) input.ReadEnum();
             break;
           }
           case 58: {

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Command.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Command.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/command.proto</summary>
   internal static partial class CommandReflection {
@@ -26,11 +26,11 @@ namespace MLAgents.CommunicatorObjects {
           string.Concat(
             "CjBtbGFnZW50c19lbnZzL2NvbW11bmljYXRvcl9vYmplY3RzL2NvbW1hbmQu",
             "cHJvdG8SFGNvbW11bmljYXRvcl9vYmplY3RzKi0KDENvbW1hbmRQcm90bxII",
-            "CgRTVEVQEAASCQoFUkVTRVQQARIICgRRVUlUEAJCH6oCHE1MQWdlbnRzLkNv",
-            "bW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "CgRTVEVQEAASCQoFUkVTRVQQARIICgRRVUlUEAJCJaoCIlVuaXR5Lk1MQWdl",
+            "bnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::MLAgents.CommunicatorObjects.CommandProto), }, null));
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Unity.MLAgents.CommunicatorObjects.CommandProto), }, null));
     }
     #endregion
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/CustomResetParameters.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/CustomResetParameters.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/custom_reset_parameters.proto</summary>
   internal static partial class CustomResetParametersReflection {
@@ -26,12 +26,12 @@ namespace MLAgents.CommunicatorObjects {
           string.Concat(
             "CkBtbGFnZW50c19lbnZzL2NvbW11bmljYXRvcl9vYmplY3RzL2N1c3RvbV9y",
             "ZXNldF9wYXJhbWV0ZXJzLnByb3RvEhRjb21tdW5pY2F0b3Jfb2JqZWN0cyIc",
-            "ChpDdXN0b21SZXNldFBhcmFtZXRlcnNQcm90b0IfqgIcTUxBZ2VudHMuQ29t",
-            "bXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
+            "ChpDdXN0b21SZXNldFBhcmFtZXRlcnNQcm90b0IlqgIiVW5pdHkuTUxBZ2Vu",
+            "dHMuQ29tbXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.CustomResetParametersProto), global::MLAgents.CommunicatorObjects.CustomResetParametersProto.Parser, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.CustomResetParametersProto), global::Unity.MLAgents.CommunicatorObjects.CustomResetParametersProto.Parser, null, null, null, null)
           }));
     }
     #endregion
@@ -46,7 +46,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.CustomResetParametersReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.CustomResetParametersReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/DemonstrationMeta.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/DemonstrationMeta.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/demonstration_meta.proto</summary>
   internal static partial class DemonstrationMetaReflection {
@@ -29,11 +29,12 @@ namespace MLAgents.CommunicatorObjects {
             "bW9uc3RyYXRpb25NZXRhUHJvdG8SEwoLYXBpX3ZlcnNpb24YASABKAUSGgoS",
             "ZGVtb25zdHJhdGlvbl9uYW1lGAIgASgJEhQKDG51bWJlcl9zdGVwcxgDIAEo",
             "BRIXCg9udW1iZXJfZXBpc29kZXMYBCABKAUSEwoLbWVhbl9yZXdhcmQYBSAB",
-            "KAJCH6oCHE1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "KAJCJaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNiBnBy",
+            "b3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.DemonstrationMetaProto), global::MLAgents.CommunicatorObjects.DemonstrationMetaProto.Parser, new[]{ "ApiVersion", "DemonstrationName", "NumberSteps", "NumberEpisodes", "MeanReward" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.DemonstrationMetaProto), global::Unity.MLAgents.CommunicatorObjects.DemonstrationMetaProto.Parser, new[]{ "ApiVersion", "DemonstrationName", "NumberSteps", "NumberEpisodes", "MeanReward" }, null, null, null)
           }));
     }
     #endregion
@@ -48,7 +49,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.DemonstrationMetaReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.DemonstrationMetaReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/EngineConfiguration.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/EngineConfiguration.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/engine_configuration.proto</summary>
   internal static partial class EngineConfigurationReflection {
@@ -29,12 +29,12 @@ namespace MLAgents.CommunicatorObjects {
             "RW5naW5lQ29uZmlndXJhdGlvblByb3RvEg0KBXdpZHRoGAEgASgFEg4KBmhl",
             "aWdodBgCIAEoBRIVCg1xdWFsaXR5X2xldmVsGAMgASgFEhIKCnRpbWVfc2Nh",
             "bGUYBCABKAISGQoRdGFyZ2V0X2ZyYW1lX3JhdGUYBSABKAUSFAoMc2hvd19t",
-            "b25pdG9yGAYgASgIQh+qAhxNTEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3Rz",
-            "YgZwcm90bzM="));
+            "b25pdG9yGAYgASgIQiWqAiJVbml0eS5NTEFnZW50cy5Db21tdW5pY2F0b3JP",
+            "YmplY3RzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.EngineConfigurationProto), global::MLAgents.CommunicatorObjects.EngineConfigurationProto.Parser, new[]{ "Width", "Height", "QualityLevel", "TimeScale", "TargetFrameRate", "ShowMonitor" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.EngineConfigurationProto), global::Unity.MLAgents.CommunicatorObjects.EngineConfigurationProto.Parser, new[]{ "Width", "Height", "QualityLevel", "TimeScale", "TargetFrameRate", "ShowMonitor" }, null, null, null)
           }));
     }
     #endregion
@@ -49,7 +49,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.EngineConfigurationReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.EngineConfigurationReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Header.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Header.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/header.proto</summary>
   internal static partial class HeaderReflection {
@@ -26,12 +26,12 @@ namespace MLAgents.CommunicatorObjects {
           string.Concat(
             "Ci9tbGFnZW50c19lbnZzL2NvbW11bmljYXRvcl9vYmplY3RzL2hlYWRlci5w",
             "cm90bxIUY29tbXVuaWNhdG9yX29iamVjdHMiLgoLSGVhZGVyUHJvdG8SDgoG",
-            "c3RhdHVzGAEgASgFEg8KB21lc3NhZ2UYAiABKAlCH6oCHE1MQWdlbnRzLkNv",
-            "bW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "c3RhdHVzGAEgASgFEg8KB21lc3NhZ2UYAiABKAlCJaoCIlVuaXR5Lk1MQWdl",
+            "bnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.HeaderProto), global::MLAgents.CommunicatorObjects.HeaderProto.Parser, new[]{ "Status", "Message" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.HeaderProto), global::Unity.MLAgents.CommunicatorObjects.HeaderProto.Parser, new[]{ "Status", "Message" }, null, null, null)
           }));
     }
     #endregion
@@ -46,7 +46,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.HeaderReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.HeaderReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Observation.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Observation.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/observation.proto</summary>
   internal static partial class ObservationReflection {
@@ -32,12 +32,12 @@ namespace MLAgents.CommunicatorObjects {
             "IAEoCzIwLmNvbW11bmljYXRvcl9vYmplY3RzLk9ic2VydmF0aW9uUHJvdG8u",
             "RmxvYXREYXRhSAAaGQoJRmxvYXREYXRhEgwKBGRhdGEYASADKAJCEgoQb2Jz",
             "ZXJ2YXRpb25fZGF0YSopChRDb21wcmVzc2lvblR5cGVQcm90bxIICgROT05F",
-            "EAASBwoDUE5HEAFCH6oCHE1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNi",
-            "BnByb3RvMw=="));
+            "EAASBwoDUE5HEAFCJaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11bmljYXRvck9i",
+            "amVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::MLAgents.CommunicatorObjects.CompressionTypeProto), }, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.ObservationProto), global::MLAgents.CommunicatorObjects.ObservationProto.Parser, new[]{ "Shape", "CompressionType", "CompressedData", "FloatData" }, new[]{ "ObservationData" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData), global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData.Parser, new[]{ "Data" }, null, null, null)})
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Unity.MLAgents.CommunicatorObjects.CompressionTypeProto), }, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.ObservationProto), global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Parser, new[]{ "Shape", "CompressionType", "CompressedData", "FloatData" }, new[]{ "ObservationData" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData), global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData.Parser, new[]{ "Data" }, null, null, null)})
           }));
     }
     #endregion
@@ -60,7 +60,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.ObservationReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.ObservationReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -108,9 +108,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "compression_type" field.</summary>
     public const int CompressionTypeFieldNumber = 2;
-    private global::MLAgents.CommunicatorObjects.CompressionTypeProto compressionType_ = 0;
+    private global::Unity.MLAgents.CommunicatorObjects.CompressionTypeProto compressionType_ = 0;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.CompressionTypeProto CompressionType {
+    public global::Unity.MLAgents.CommunicatorObjects.CompressionTypeProto CompressionType {
       get { return compressionType_; }
       set {
         compressionType_ = value;
@@ -131,8 +131,8 @@ namespace MLAgents.CommunicatorObjects {
     /// <summary>Field number for the "float_data" field.</summary>
     public const int FloatDataFieldNumber = 4;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData FloatData {
-      get { return observationDataCase_ == ObservationDataOneofCase.FloatData ? (global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData) observationData_ : null; }
+    public global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData FloatData {
+      get { return observationDataCase_ == ObservationDataOneofCase.FloatData ? (global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData) observationData_ : null; }
       set {
         observationData_ = value;
         observationDataCase_ = value == null ? ObservationDataOneofCase.None : ObservationDataOneofCase.FloatData;
@@ -252,7 +252,7 @@ namespace MLAgents.CommunicatorObjects {
           break;
         case ObservationDataOneofCase.FloatData:
           if (FloatData == null) {
-            FloatData = new global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData();
+            FloatData = new global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData();
           }
           FloatData.MergeFrom(other.FloatData);
           break;
@@ -275,7 +275,7 @@ namespace MLAgents.CommunicatorObjects {
             break;
           }
           case 16: {
-            compressionType_ = (global::MLAgents.CommunicatorObjects.CompressionTypeProto) input.ReadEnum();
+            compressionType_ = (global::Unity.MLAgents.CommunicatorObjects.CompressionTypeProto) input.ReadEnum();
             break;
           }
           case 26: {
@@ -283,7 +283,7 @@ namespace MLAgents.CommunicatorObjects {
             break;
           }
           case 34: {
-            global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData subBuilder = new global::MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData();
+            global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData subBuilder = new global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Types.FloatData();
             if (observationDataCase_ == ObservationDataOneofCase.FloatData) {
               subBuilder.MergeFrom(FloatData);
             }
@@ -307,7 +307,7 @@ namespace MLAgents.CommunicatorObjects {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::MLAgents.CommunicatorObjects.ObservationProto.Descriptor.NestedTypes[0]; }
+          get { return global::Unity.MLAgents.CommunicatorObjects.ObservationProto.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/SpaceType.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/SpaceType.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/space_type.proto</summary>
   internal static partial class SpaceTypeReflection {
@@ -26,11 +26,11 @@ namespace MLAgents.CommunicatorObjects {
           string.Concat(
             "CjNtbGFnZW50c19lbnZzL2NvbW11bmljYXRvcl9vYmplY3RzL3NwYWNlX3R5",
             "cGUucHJvdG8SFGNvbW11bmljYXRvcl9vYmplY3RzKi4KDlNwYWNlVHlwZVBy",
-            "b3RvEgwKCGRpc2NyZXRlEAASDgoKY29udGludW91cxABQh+qAhxNTEFnZW50",
-            "cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
+            "b3RvEgwKCGRpc2NyZXRlEAASDgoKY29udGludW91cxABQiWqAiJVbml0eS5N",
+            "TEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::MLAgents.CommunicatorObjects.SpaceTypeProto), }, null));
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Unity.MLAgents.CommunicatorObjects.SpaceTypeProto), }, null));
     }
     #endregion
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityInput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityInput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_input.proto</summary>
   internal static partial class UnityInputReflection {
@@ -32,12 +32,12 @@ namespace MLAgents.CommunicatorObjects {
             "EjkKCHJsX2lucHV0GAEgASgLMicuY29tbXVuaWNhdG9yX29iamVjdHMuVW5p",
             "dHlSTElucHV0UHJvdG8SVgoXcmxfaW5pdGlhbGl6YXRpb25faW5wdXQYAiAB",
             "KAsyNS5jb21tdW5pY2F0b3Jfb2JqZWN0cy5Vbml0eVJMSW5pdGlhbGl6YXRp",
-            "b25JbnB1dFByb3RvQh+qAhxNTEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3Rz",
-            "YgZwcm90bzM="));
+            "b25JbnB1dFByb3RvQiWqAiJVbml0eS5NTEFnZW50cy5Db21tdW5pY2F0b3JP",
+            "YmplY3RzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.UnityRlInputReflection.Descriptor, global::MLAgents.CommunicatorObjects.UnityRlInitializationInputReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.UnityRlInputReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.UnityRlInitializationInputReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityInputProto), global::MLAgents.CommunicatorObjects.UnityInputProto.Parser, new[]{ "RlInput", "RlInitializationInput" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityInputProto), global::Unity.MLAgents.CommunicatorObjects.UnityInputProto.Parser, new[]{ "RlInput", "RlInitializationInput" }, null, null, null)
           }));
     }
     #endregion
@@ -52,7 +52,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityInputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityInputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -81,9 +81,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "rl_input" field.</summary>
     public const int RlInputFieldNumber = 1;
-    private global::MLAgents.CommunicatorObjects.UnityRLInputProto rlInput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto rlInput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityRLInputProto RlInput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto RlInput {
       get { return rlInput_; }
       set {
         rlInput_ = value;
@@ -92,9 +92,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "rl_initialization_input" field.</summary>
     public const int RlInitializationInputFieldNumber = 2;
-    private global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto rlInitializationInput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto rlInitializationInput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto RlInitializationInput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto RlInitializationInput {
       get { return rlInitializationInput_; }
       set {
         rlInitializationInput_ = value;
@@ -172,13 +172,13 @@ namespace MLAgents.CommunicatorObjects {
       }
       if (other.rlInput_ != null) {
         if (rlInput_ == null) {
-          rlInput_ = new global::MLAgents.CommunicatorObjects.UnityRLInputProto();
+          rlInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto();
         }
         RlInput.MergeFrom(other.RlInput);
       }
       if (other.rlInitializationInput_ != null) {
         if (rlInitializationInput_ == null) {
-          rlInitializationInput_ = new global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto();
+          rlInitializationInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto();
         }
         RlInitializationInput.MergeFrom(other.RlInitializationInput);
       }
@@ -195,14 +195,14 @@ namespace MLAgents.CommunicatorObjects {
             break;
           case 10: {
             if (rlInput_ == null) {
-              rlInput_ = new global::MLAgents.CommunicatorObjects.UnityRLInputProto();
+              rlInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto();
             }
             input.ReadMessage(rlInput_);
             break;
           }
           case 18: {
             if (rlInitializationInput_ == null) {
-              rlInitializationInput_ = new global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto();
+              rlInitializationInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto();
             }
             input.ReadMessage(rlInitializationInput_);
             break;

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityMessage.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityMessage.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_message.proto</summary>
   internal static partial class UnityMessageReflection {
@@ -33,12 +33,12 @@ namespace MLAgents.CommunicatorObjects {
             "IAEoCzIhLmNvbW11bmljYXRvcl9vYmplY3RzLkhlYWRlclByb3RvEjwKDHVu",
             "aXR5X291dHB1dBgCIAEoCzImLmNvbW11bmljYXRvcl9vYmplY3RzLlVuaXR5",
             "T3V0cHV0UHJvdG8SOgoLdW5pdHlfaW5wdXQYAyABKAsyJS5jb21tdW5pY2F0",
-            "b3Jfb2JqZWN0cy5Vbml0eUlucHV0UHJvdG9CH6oCHE1MQWdlbnRzLkNvbW11",
-            "bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "b3Jfb2JqZWN0cy5Vbml0eUlucHV0UHJvdG9CJaoCIlVuaXR5Lk1MQWdlbnRz",
+            "LkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.UnityOutputReflection.Descriptor, global::MLAgents.CommunicatorObjects.UnityInputReflection.Descriptor, global::MLAgents.CommunicatorObjects.HeaderReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.UnityOutputReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.UnityInputReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.HeaderReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityMessageProto), global::MLAgents.CommunicatorObjects.UnityMessageProto.Parser, new[]{ "Header", "UnityOutput", "UnityInput" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto), global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto.Parser, new[]{ "Header", "UnityOutput", "UnityInput" }, null, null, null)
           }));
     }
     #endregion
@@ -53,7 +53,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityMessageReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityMessageReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -83,9 +83,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "header" field.</summary>
     public const int HeaderFieldNumber = 1;
-    private global::MLAgents.CommunicatorObjects.HeaderProto header_;
+    private global::Unity.MLAgents.CommunicatorObjects.HeaderProto header_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.HeaderProto Header {
+    public global::Unity.MLAgents.CommunicatorObjects.HeaderProto Header {
       get { return header_; }
       set {
         header_ = value;
@@ -94,9 +94,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "unity_output" field.</summary>
     public const int UnityOutputFieldNumber = 2;
-    private global::MLAgents.CommunicatorObjects.UnityOutputProto unityOutput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto unityOutput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityOutputProto UnityOutput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto UnityOutput {
       get { return unityOutput_; }
       set {
         unityOutput_ = value;
@@ -105,9 +105,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "unity_input" field.</summary>
     public const int UnityInputFieldNumber = 3;
-    private global::MLAgents.CommunicatorObjects.UnityInputProto unityInput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityInputProto unityInput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityInputProto UnityInput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityInputProto UnityInput {
       get { return unityInput_; }
       set {
         unityInput_ = value;
@@ -194,19 +194,19 @@ namespace MLAgents.CommunicatorObjects {
       }
       if (other.header_ != null) {
         if (header_ == null) {
-          header_ = new global::MLAgents.CommunicatorObjects.HeaderProto();
+          header_ = new global::Unity.MLAgents.CommunicatorObjects.HeaderProto();
         }
         Header.MergeFrom(other.Header);
       }
       if (other.unityOutput_ != null) {
         if (unityOutput_ == null) {
-          unityOutput_ = new global::MLAgents.CommunicatorObjects.UnityOutputProto();
+          unityOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto();
         }
         UnityOutput.MergeFrom(other.UnityOutput);
       }
       if (other.unityInput_ != null) {
         if (unityInput_ == null) {
-          unityInput_ = new global::MLAgents.CommunicatorObjects.UnityInputProto();
+          unityInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityInputProto();
         }
         UnityInput.MergeFrom(other.UnityInput);
       }
@@ -223,21 +223,21 @@ namespace MLAgents.CommunicatorObjects {
             break;
           case 10: {
             if (header_ == null) {
-              header_ = new global::MLAgents.CommunicatorObjects.HeaderProto();
+              header_ = new global::Unity.MLAgents.CommunicatorObjects.HeaderProto();
             }
             input.ReadMessage(header_);
             break;
           }
           case 18: {
             if (unityOutput_ == null) {
-              unityOutput_ = new global::MLAgents.CommunicatorObjects.UnityOutputProto();
+              unityOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto();
             }
             input.ReadMessage(unityOutput_);
             break;
           }
           case 26: {
             if (unityInput_ == null) {
-              unityInput_ = new global::MLAgents.CommunicatorObjects.UnityInputProto();
+              unityInput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityInputProto();
             }
             input.ReadMessage(unityInput_);
             break;

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityOutput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityOutput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_output.proto</summary>
   internal static partial class UnityOutputReflection {
@@ -32,12 +32,12 @@ namespace MLAgents.CommunicatorObjects {
             "cm90bxI7CglybF9vdXRwdXQYASABKAsyKC5jb21tdW5pY2F0b3Jfb2JqZWN0",
             "cy5Vbml0eVJMT3V0cHV0UHJvdG8SWAoYcmxfaW5pdGlhbGl6YXRpb25fb3V0",
             "cHV0GAIgASgLMjYuY29tbXVuaWNhdG9yX29iamVjdHMuVW5pdHlSTEluaXRp",
-            "YWxpemF0aW9uT3V0cHV0UHJvdG9CH6oCHE1MQWdlbnRzLkNvbW11bmljYXRv",
-            "ck9iamVjdHNiBnByb3RvMw=="));
+            "YWxpemF0aW9uT3V0cHV0UHJvdG9CJaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11",
+            "bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.UnityRlOutputReflection.Descriptor, global::MLAgents.CommunicatorObjects.UnityRlInitializationOutputReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.UnityRlOutputReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.UnityRlInitializationOutputReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityOutputProto), global::MLAgents.CommunicatorObjects.UnityOutputProto.Parser, new[]{ "RlOutput", "RlInitializationOutput" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto), global::Unity.MLAgents.CommunicatorObjects.UnityOutputProto.Parser, new[]{ "RlOutput", "RlInitializationOutput" }, null, null, null)
           }));
     }
     #endregion
@@ -52,7 +52,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityOutputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityOutputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -81,9 +81,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "rl_output" field.</summary>
     public const int RlOutputFieldNumber = 1;
-    private global::MLAgents.CommunicatorObjects.UnityRLOutputProto rlOutput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto rlOutput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityRLOutputProto RlOutput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto RlOutput {
       get { return rlOutput_; }
       set {
         rlOutput_ = value;
@@ -92,9 +92,9 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "rl_initialization_output" field.</summary>
     public const int RlInitializationOutputFieldNumber = 2;
-    private global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto rlInitializationOutput_;
+    private global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto rlInitializationOutput_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto RlInitializationOutput {
+    public global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto RlInitializationOutput {
       get { return rlInitializationOutput_; }
       set {
         rlInitializationOutput_ = value;
@@ -172,13 +172,13 @@ namespace MLAgents.CommunicatorObjects {
       }
       if (other.rlOutput_ != null) {
         if (rlOutput_ == null) {
-          rlOutput_ = new global::MLAgents.CommunicatorObjects.UnityRLOutputProto();
+          rlOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto();
         }
         RlOutput.MergeFrom(other.RlOutput);
       }
       if (other.rlInitializationOutput_ != null) {
         if (rlInitializationOutput_ == null) {
-          rlInitializationOutput_ = new global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto();
+          rlInitializationOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto();
         }
         RlInitializationOutput.MergeFrom(other.RlInitializationOutput);
       }
@@ -195,14 +195,14 @@ namespace MLAgents.CommunicatorObjects {
             break;
           case 10: {
             if (rlOutput_ == null) {
-              rlOutput_ = new global::MLAgents.CommunicatorObjects.UnityRLOutputProto();
+              rlOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto();
             }
             input.ReadMessage(rlOutput_);
             break;
           }
           case 18: {
             if (rlInitializationOutput_ == null) {
-              rlInitializationOutput_ = new global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto();
+              rlInitializationOutput_ = new global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto();
             }
             input.ReadMessage(rlInitializationOutput_);
             break;

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInitializationInput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInitializationInput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_rl_initialization_input.proto</summary>
   internal static partial class UnityRlInitializationInputReflection {
@@ -28,12 +28,12 @@ namespace MLAgents.CommunicatorObjects {
             "X2luaXRpYWxpemF0aW9uX2lucHV0LnByb3RvEhRjb21tdW5pY2F0b3Jfb2Jq",
             "ZWN0cyJnCh9Vbml0eVJMSW5pdGlhbGl6YXRpb25JbnB1dFByb3RvEgwKBHNl",
             "ZWQYASABKAUSHQoVY29tbXVuaWNhdGlvbl92ZXJzaW9uGAIgASgJEhcKD3Bh",
-            "Y2thZ2VfdmVyc2lvbhgDIAEoCUIfqgIcTUxBZ2VudHMuQ29tbXVuaWNhdG9y",
-            "T2JqZWN0c2IGcHJvdG8z"));
+            "Y2thZ2VfdmVyc2lvbhgDIAEoCUIlqgIiVW5pdHkuTUxBZ2VudHMuQ29tbXVu",
+            "aWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto), global::MLAgents.CommunicatorObjects.UnityRLInitializationInputProto.Parser, new[]{ "Seed", "CommunicationVersion", "PackageVersion" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationInputProto.Parser, new[]{ "Seed", "CommunicationVersion", "PackageVersion" }, null, null, null)
           }));
     }
     #endregion
@@ -51,7 +51,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityRlInitializationInputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityRlInitializationInputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInitializationOutput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInitializationOutput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_rl_initialization_output.proto</summary>
   internal static partial class UnityRlInitializationOutputReflection {
@@ -31,12 +31,12 @@ namespace MLAgents.CommunicatorObjects {
             "T3V0cHV0UHJvdG8SDAoEbmFtZRgBIAEoCRIdChVjb21tdW5pY2F0aW9uX3Zl",
             "cnNpb24YAiABKAkSEAoIbG9nX3BhdGgYAyABKAkSRAoQYnJhaW5fcGFyYW1l",
             "dGVycxgFIAMoCzIqLmNvbW11bmljYXRvcl9vYmplY3RzLkJyYWluUGFyYW1l",
-            "dGVyc1Byb3RvEhcKD3BhY2thZ2VfdmVyc2lvbhgHIAEoCUoECAYQB0IfqgIc",
-            "TUxBZ2VudHMuQ29tbXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
+            "dGVyc1Byb3RvEhcKD3BhY2thZ2VfdmVyc2lvbhgHIAEoCUoECAYQB0IlqgIi",
+            "VW5pdHkuTUxBZ2VudHMuQ29tbXVuaWNhdG9yT2JqZWN0c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.BrainParametersReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.BrainParametersReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto), global::MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto.Parser, new[]{ "Name", "CommunicationVersion", "LogPath", "BrainParameters", "PackageVersion" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLInitializationOutputProto.Parser, new[]{ "Name", "CommunicationVersion", "LogPath", "BrainParameters", "PackageVersion" }, null, null, null)
           }));
     }
     #endregion
@@ -54,7 +54,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityRlInitializationOutputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityRlInitializationOutputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -122,11 +122,11 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "brain_parameters" field.</summary>
     public const int BrainParametersFieldNumber = 5;
-    private static readonly pb::FieldCodec<global::MLAgents.CommunicatorObjects.BrainParametersProto> _repeated_brainParameters_codec
-        = pb::FieldCodec.ForMessage(42, global::MLAgents.CommunicatorObjects.BrainParametersProto.Parser);
-    private readonly pbc::RepeatedField<global::MLAgents.CommunicatorObjects.BrainParametersProto> brainParameters_ = new pbc::RepeatedField<global::MLAgents.CommunicatorObjects.BrainParametersProto>();
+    private static readonly pb::FieldCodec<global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto> _repeated_brainParameters_codec
+        = pb::FieldCodec.ForMessage(42, global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto.Parser);
+    private readonly pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto> brainParameters_ = new pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::MLAgents.CommunicatorObjects.BrainParametersProto> BrainParameters {
+    public pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.BrainParametersProto> BrainParameters {
       get { return brainParameters_; }
     }
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlInput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_rl_input.proto</summary>
   internal static partial class UnityRlInputReflection {
@@ -36,12 +36,12 @@ namespace MLAgents.CommunicatorObjects {
             "Y29tbXVuaWNhdG9yX29iamVjdHMuQWdlbnRBY3Rpb25Qcm90bxpxChFBZ2Vu",
             "dEFjdGlvbnNFbnRyeRILCgNrZXkYASABKAkSSwoFdmFsdWUYAiABKAsyPC5j",
             "b21tdW5pY2F0b3Jfb2JqZWN0cy5Vbml0eVJMSW5wdXRQcm90by5MaXN0QWdl",
-            "bnRBY3Rpb25Qcm90bzoCOAFKBAgCEANKBAgDEARCH6oCHE1MQWdlbnRzLkNv",
-            "bW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "bnRBY3Rpb25Qcm90bzoCOAFKBAgCEANKBAgDEARCJaoCIlVuaXR5Lk1MQWdl",
+            "bnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor, global::MLAgents.CommunicatorObjects.CommandReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.AgentActionReflection.Descriptor, global::Unity.MLAgents.CommunicatorObjects.CommandReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLInputProto), global::MLAgents.CommunicatorObjects.UnityRLInputProto.Parser, new[]{ "AgentActions", "Command", "SideChannel" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto), global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto.Parser, new[]{ "Value" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Parser, new[]{ "AgentActions", "Command", "SideChannel" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto.Parser, new[]{ "Value" }, null, null, null),
             null, })
           }));
     }
@@ -57,7 +57,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityRlInputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityRlInputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -87,19 +87,19 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "agent_actions" field.</summary>
     public const int AgentActionsFieldNumber = 1;
-    private static readonly pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>.Codec _map_agentActions_codec
-        = new pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto.Parser), 10);
-    private readonly pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto> agentActions_ = new pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>();
+    private static readonly pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>.Codec _map_agentActions_codec
+        = new pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto.Parser), 10);
+    private readonly pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto> agentActions_ = new pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto> AgentActions {
+    public pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Types.ListAgentActionProto> AgentActions {
       get { return agentActions_; }
     }
 
     /// <summary>Field number for the "command" field.</summary>
     public const int CommandFieldNumber = 4;
-    private global::MLAgents.CommunicatorObjects.CommandProto command_ = 0;
+    private global::Unity.MLAgents.CommunicatorObjects.CommandProto command_ = 0;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::MLAgents.CommunicatorObjects.CommandProto Command {
+    public global::Unity.MLAgents.CommunicatorObjects.CommandProto Command {
       get { return command_; }
       set {
         command_ = value;
@@ -213,7 +213,7 @@ namespace MLAgents.CommunicatorObjects {
             break;
           }
           case 32: {
-            command_ = (global::MLAgents.CommunicatorObjects.CommandProto) input.ReadEnum();
+            command_ = (global::Unity.MLAgents.CommunicatorObjects.CommandProto) input.ReadEnum();
             break;
           }
           case 42: {
@@ -236,7 +236,7 @@ namespace MLAgents.CommunicatorObjects {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::MLAgents.CommunicatorObjects.UnityRLInputProto.Descriptor.NestedTypes[0]; }
+          get { return global::Unity.MLAgents.CommunicatorObjects.UnityRLInputProto.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -264,11 +264,11 @@ namespace MLAgents.CommunicatorObjects {
 
         /// <summary>Field number for the "value" field.</summary>
         public const int ValueFieldNumber = 1;
-        private static readonly pb::FieldCodec<global::MLAgents.CommunicatorObjects.AgentActionProto> _repeated_value_codec
-            = pb::FieldCodec.ForMessage(10, global::MLAgents.CommunicatorObjects.AgentActionProto.Parser);
-        private readonly pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentActionProto> value_ = new pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentActionProto>();
+        private static readonly pb::FieldCodec<global::Unity.MLAgents.CommunicatorObjects.AgentActionProto> _repeated_value_codec
+            = pb::FieldCodec.ForMessage(10, global::Unity.MLAgents.CommunicatorObjects.AgentActionProto.Parser);
+        private readonly pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentActionProto> value_ = new pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentActionProto>();
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentActionProto> Value {
+        public pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentActionProto> Value {
           get { return value_; }
         }
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlOutput.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityRlOutput.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_rl_output.proto</summary>
   internal static partial class UnityRlOutputReflection {
@@ -34,11 +34,12 @@ namespace MLAgents.CommunicatorObjects {
             "cy5BZ2VudEluZm9Qcm90bxpuCg9BZ2VudEluZm9zRW50cnkSCwoDa2V5GAEg",
             "ASgJEkoKBXZhbHVlGAIgASgLMjsuY29tbXVuaWNhdG9yX29iamVjdHMuVW5p",
             "dHlSTE91dHB1dFByb3RvLkxpc3RBZ2VudEluZm9Qcm90bzoCOAFKBAgBEAJC",
-            "H6oCHE1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3RvMw=="));
+            "JaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNiBnByb3Rv",
+            "Mw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.AgentInfoReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLOutputProto), global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Parser, new[]{ "AgentInfos", "SideChannel" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto), global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto.Parser, new[]{ "Value" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Parser, new[]{ "AgentInfos", "SideChannel" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto), global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto.Parser, new[]{ "Value" }, null, null, null),
             null, })
           }));
     }
@@ -54,7 +55,7 @@ namespace MLAgents.CommunicatorObjects {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::MLAgents.CommunicatorObjects.UnityRlOutputReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityRlOutputReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -83,11 +84,11 @@ namespace MLAgents.CommunicatorObjects {
 
     /// <summary>Field number for the "agentInfos" field.</summary>
     public const int AgentInfosFieldNumber = 2;
-    private static readonly pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>.Codec _map_agentInfos_codec
-        = new pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto.Parser), 18);
-    private readonly pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto> agentInfos_ = new pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>();
+    private static readonly pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>.Codec _map_agentInfos_codec
+        = new pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto.Parser), 18);
+    private readonly pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto> agentInfos_ = new pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::MapField<string, global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto> AgentInfos {
+    public pbc::MapField<string, global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Types.ListAgentInfoProto> AgentInfos {
       get { return agentInfos_; }
     }
 
@@ -205,7 +206,7 @@ namespace MLAgents.CommunicatorObjects {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::MLAgents.CommunicatorObjects.UnityRLOutputProto.Descriptor.NestedTypes[0]; }
+          get { return global::Unity.MLAgents.CommunicatorObjects.UnityRLOutputProto.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -233,11 +234,11 @@ namespace MLAgents.CommunicatorObjects {
 
         /// <summary>Field number for the "value" field.</summary>
         public const int ValueFieldNumber = 1;
-        private static readonly pb::FieldCodec<global::MLAgents.CommunicatorObjects.AgentInfoProto> _repeated_value_codec
-            = pb::FieldCodec.ForMessage(10, global::MLAgents.CommunicatorObjects.AgentInfoProto.Parser);
-        private readonly pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentInfoProto> value_ = new pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentInfoProto>();
+        private static readonly pb::FieldCodec<global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto> _repeated_value_codec
+            = pb::FieldCodec.ForMessage(10, global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto.Parser);
+        private readonly pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto> value_ = new pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto>();
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::MLAgents.CommunicatorObjects.AgentInfoProto> Value {
+        public pbc::RepeatedField<global::Unity.MLAgents.CommunicatorObjects.AgentInfoProto> Value {
           get { return value_; }
         }
 

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityToExternal.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityToExternal.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
 
   /// <summary>Holder for reflection information generated from mlagents_envs/communicator_objects/unity_to_external.proto</summary>
   public static partial class UnityToExternalReflection {
@@ -29,10 +29,10 @@ namespace MLAgents.CommunicatorObjects {
             "dHNfZW52cy9jb21tdW5pY2F0b3Jfb2JqZWN0cy91bml0eV9tZXNzYWdlLnBy",
             "b3RvMnYKFFVuaXR5VG9FeHRlcm5hbFByb3RvEl4KCEV4Y2hhbmdlEicuY29t",
             "bXVuaWNhdG9yX29iamVjdHMuVW5pdHlNZXNzYWdlUHJvdG8aJy5jb21tdW5p",
-            "Y2F0b3Jfb2JqZWN0cy5Vbml0eU1lc3NhZ2VQcm90byIAQh+qAhxNTEFnZW50",
-            "cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
+            "Y2F0b3Jfb2JqZWN0cy5Vbml0eU1lc3NhZ2VQcm90byIAQiWqAiJVbml0eS5N",
+            "TEFnZW50cy5Db21tdW5pY2F0b3JPYmplY3RzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::MLAgents.CommunicatorObjects.UnityMessageReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Unity.MLAgents.CommunicatorObjects.UnityMessageReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null));
     }
     #endregion

--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityToExternalGrpc.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/UnityToExternalGrpc.cs
@@ -8,14 +8,14 @@
 
 using grpc = global::Grpc.Core;
 
-namespace MLAgents.CommunicatorObjects {
+namespace Unity.MLAgents.CommunicatorObjects {
   internal static partial class UnityToExternalProto
   {
     static readonly string __ServiceName = "communicator_objects.UnityToExternalProto";
 
-    static readonly grpc::Marshaller<global::MLAgents.CommunicatorObjects.UnityMessageProto> __Marshaller_communicator_objects_UnityMessageProto = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::MLAgents.CommunicatorObjects.UnityMessageProto.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto> __Marshaller_communicator_objects_UnityMessageProto = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto.Parser.ParseFrom);
 
-    static readonly grpc::Method<global::MLAgents.CommunicatorObjects.UnityMessageProto, global::MLAgents.CommunicatorObjects.UnityMessageProto> __Method_Exchange = new grpc::Method<global::MLAgents.CommunicatorObjects.UnityMessageProto, global::MLAgents.CommunicatorObjects.UnityMessageProto>(
+    static readonly grpc::Method<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto, global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto> __Method_Exchange = new grpc::Method<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto, global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto>(
         grpc::MethodType.Unary,
         __ServiceName,
         "Exchange",
@@ -25,7 +25,7 @@ namespace MLAgents.CommunicatorObjects {
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
     {
-      get { return global::MLAgents.CommunicatorObjects.UnityToExternalReflection.Descriptor.Services[0]; }
+      get { return global::Unity.MLAgents.CommunicatorObjects.UnityToExternalReflection.Descriptor.Services[0]; }
     }
 
     /// <summary>Base class for server-side implementations of UnityToExternalProto</summary>
@@ -37,7 +37,7 @@ namespace MLAgents.CommunicatorObjects {
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::MLAgents.CommunicatorObjects.UnityMessageProto> Exchange(global::MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto> Exchange(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -75,7 +75,7 @@ namespace MLAgents.CommunicatorObjects {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::MLAgents.CommunicatorObjects.UnityMessageProto Exchange(global::MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto Exchange(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Exchange(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -85,7 +85,7 @@ namespace MLAgents.CommunicatorObjects {
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::MLAgents.CommunicatorObjects.UnityMessageProto Exchange(global::MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::CallOptions options)
+      public virtual global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto Exchange(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_Exchange, null, options, request);
       }
@@ -97,7 +97,7 @@ namespace MLAgents.CommunicatorObjects {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::MLAgents.CommunicatorObjects.UnityMessageProto> ExchangeAsync(global::MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto> ExchangeAsync(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ExchangeAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -107,7 +107,7 @@ namespace MLAgents.CommunicatorObjects {
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::MLAgents.CommunicatorObjects.UnityMessageProto> ExchangeAsync(global::MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto> ExchangeAsync(global::Unity.MLAgents.CommunicatorObjects.UnityMessageProto request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_Exchange, null, options, request);
       }

--- a/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Barracuda;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference.Utils;
 using UnityEngine;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// The Applier for the Continuous Action output tensor. Tensor is assumed to contain the

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Barracuda;
-using MLAgents.Sensors;
-using MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Prepares the Tensors for the Learning Brain and exposes a list of failed checks if Model

--- a/com.unity.ml-agents/Runtime/Inference/GeneratorImpl.cs
+++ b/com.unity.ml-agents/Runtime/Inference/GeneratorImpl.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System;
 using Barracuda;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference.Utils;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Reshapes a Tensor so that its first dimension becomes equal to the current batch size

--- a/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using Barracuda;
 using UnityEngine.Profiling;
-using MLAgents.Sensors;
-using MLAgents.Policies;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     internal struct AgentInfoSensorsPair
     {

--- a/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Barracuda;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Mapping between the output tensor names and the method that will use the

--- a/com.unity.ml-agents/Runtime/Inference/TensorGenerator.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorGenerator.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Barracuda;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Mapping between Tensor names and generators.

--- a/com.unity.ml-agents/Runtime/Inference/TensorNames.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorNames.cs
@@ -1,4 +1,4 @@
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Contains the names of the input and output tensors for the Inference Brain.

--- a/com.unity.ml-agents/Runtime/Inference/TensorProxy.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorProxy.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Barracuda;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference.Utils;
 
-namespace MLAgents.Inference
+namespace Unity.MLAgents.Inference
 {
     /// <summary>
     /// Tensor - A class to encapsulate a Tensor used for inference.

--- a/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
@@ -1,4 +1,4 @@
-namespace MLAgents.Inference.Utils
+namespace Unity.MLAgents.Inference.Utils
 {
     /// <summary>
     /// Multinomial - Draws samples from a multinomial distribution given a (potentially unscaled)

--- a/com.unity.ml-agents/Runtime/Inference/Utils/RandomNormal.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/RandomNormal.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace MLAgents.Inference.Utils
+namespace Unity.MLAgents.Inference.Utils
 {
     /// <summary>
     /// RandomNormal - A random number generator that produces normally distributed random

--- a/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
@@ -1,9 +1,9 @@
 using Barracuda;
 using System.Collections.Generic;
-using MLAgents.Inference;
-using MLAgents.Sensors;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// Where to perform inference.

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -3,7 +3,7 @@ using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// Defines what type of behavior the Agent will be using

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// Whether the action space is discrete or continuous.

--- a/com.unity.ml-agents/Runtime/Policies/HeuristicPolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/HeuristicPolicy.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System;
 using System.Collections;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// The Heuristic Policy uses a hards coded Heuristic method

--- a/com.unity.ml-agents/Runtime/Policies/IPolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/IPolicy.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// IPolicy is connected to a single Agent. Each time the agent needs

--- a/com.unity.ml-agents/Runtime/Policies/RemotePolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/RemotePolicy.cs
@@ -1,9 +1,9 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Policies
+namespace Unity.MLAgents.Policies
 {
     /// <summary>
     /// The Remote Policy only works when training.

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A sensor that wraps a Camera object to generate visual observations for an agent.

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A SensorComponent that creates a <see cref="CameraSensor"/>.

--- a/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
@@ -1,4 +1,4 @@
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// The compression setting for visual/camera observations.

--- a/com.unity.ml-agents/Runtime/Sensors/Observation.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Observation.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     internal struct Observation
     {

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Determines which dimensions the sensor will perform the casts in.

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A component for 2D Ray Perception.

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A component for 3D Ray Perception.

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A base class to support sensor components for raycast-based sensors.

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Sensor class that wraps a <see cref="RenderTexture"/> instance.

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Component that wraps a <see cref="RenderTextureSensor"/>.

--- a/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Editor components for creating Sensors. Generally an ISensor implementation should have a

--- a/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     internal class SensorShapeValidator
     {

--- a/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Sensor that wraps around another Sensor to provide temporal stacking.

--- a/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// A sensor implementation for vector observations.

--- a/com.unity.ml-agents/Runtime/Sensors/WriteAdapter.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/WriteAdapter.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Barracuda;
-using MLAgents.Inference;
+using Unity.MLAgents.Inference;
 
-namespace MLAgents.Sensors
+namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Allows sensors to write to both TensorProxy and float arrays/lists.

--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Side channel that supports modifying attributes specific to the Unity Engine.

--- a/com.unity.ml-agents/Runtime/SideChannels/FloatPropertiesChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/FloatPropertiesChannel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Side channel that is comprised of a collection of float variables, represented by

--- a/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/IncomingMessage.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Utility class for reading the data sent to the SideChannel.

--- a/com.unity.ml-agents/Runtime/SideChannels/OutgoingMessage.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/OutgoingMessage.cs
@@ -3,7 +3,7 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Utility class for forming the data that is sent to the SideChannel.

--- a/com.unity.ml-agents/Runtime/SideChannels/RawBytesChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/RawBytesChannel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Side channel for managing raw bytes of data. It is up to the clients of this side channel

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Side channels provide an alternative mechanism of sending/receiving data from Unity

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannelUtils.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
 
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     public static class SideChannelUtils
     {

--- a/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
@@ -1,5 +1,5 @@
 using System;
-namespace MLAgents.SideChannels
+namespace Unity.MLAgents.SideChannels
 {
     /// <summary>
     /// Determines the behavior of how multiple stats within the same summary period are combined.

--- a/com.unity.ml-agents/Runtime/Timer.cs
+++ b/com.unity.ml-agents/Runtime/Timer.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using UnityEngine.SceneManagement;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     [DataContract]
     internal class TimerNode

--- a/com.unity.ml-agents/Runtime/UnityAgentsException.cs
+++ b/com.unity.ml-agents/Runtime/UnityAgentsException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     /// <summary>
     /// Contains exceptions specific to ML-Agents.

--- a/com.unity.ml-agents/Runtime/Utilities.cs
+++ b/com.unity.ml-agents/Runtime/Utilities.cs
@@ -1,8 +1,8 @@
 using System;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents
+namespace Unity.MLAgents
 {
     internal static class Utilities
     {

--- a/com.unity.ml-agents/Tests/Editor/AcademyTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/AcademyTests.cs
@@ -1,9 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
-using MLAgents;
+using Unity.MLAgents;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class AcademyTests

--- a/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
@@ -1,9 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents;
-using MLAgents.Policies;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class BehaviorParameterTests

--- a/com.unity.ml-agents/Tests/Editor/Communicator/RpcCommunicatorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Communicator/RpcCommunicatorTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace MLAgents.Tests.Communicator
+namespace Unity.MLAgents.Tests.Communicator
 {
     [TestFixture]
     public class RpcCommunicatorTests

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -2,12 +2,12 @@ using NUnit.Framework;
 using UnityEngine;
 using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
-using MLAgents.CommunicatorObjects;
-using MLAgents.Sensors;
-using MLAgents.Demonstrations;
-using MLAgents.Policies;
+using Unity.MLAgents.CommunicatorObjects;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Demonstrations;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class DemonstrationTests

--- a/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
@@ -2,10 +2,10 @@ using System;
 using Barracuda;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Inference;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Inference.Utils;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class DiscreteActionOutputApplierTest
     {

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class EditModeTestActionMasker
     {

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorApplier.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorApplier.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Barracuda;
-using MLAgents.Inference;
-using MLAgents.Policies;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class EditModeTestInternalBrainTensorApplier
     {

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 using Barracuda;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Inference;
-using MLAgents.Policies;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class EditModeTestInternalBrainTensorGenerator

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 using NUnit.Framework;
 using System.Reflection;
 using System.Collections.Generic;
-using MLAgents.Sensors;
-using MLAgents.Policies;
-using MLAgents.SideChannels;
+using Unity.MLAgents.Sensors;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.SideChannels;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     internal class TestPolicy : IPolicy
     {

--- a/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
@@ -2,12 +2,12 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEditor;
 using Barracuda;
-using MLAgents.Inference;
-using MLAgents.Sensors;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Sensors;
 using System.Linq;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class ModelRunnerTest

--- a/com.unity.ml-agents/Tests/Editor/MultinomialTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MultinomialTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference.Utils;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class MultinomialTest
     {

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -2,12 +2,12 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEditor;
 using Barracuda;
-using MLAgents.Inference;
-using MLAgents.Sensors;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Sensors;
 using System.Linq;
-using MLAgents.Policies;
+using Unity.MLAgents.Policies;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class Test3DSensorComponent : SensorComponent
     {

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
-using MLAgents;
-using MLAgents.Policies;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.Sensors;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace MLAgentsExamples
+namespace Unity.MLAgentsExamples
 {
     /// <summary>
     /// The purpose of these tests is to make sure that we can do basic operations like creating

--- a/com.unity.ml-agents/Tests/Editor/RandomNormalTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/RandomNormalTest.cs
@@ -1,8 +1,8 @@
 using System;
 using NUnit.Framework;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference.Utils;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class RandomNormalTest
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorComponentTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorComponentTest.cs
@@ -1,9 +1,9 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
 
     [TestFixture]

--- a/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorTest.cs
@@ -1,9 +1,9 @@
  using System;
  using NUnit.Framework;
  using UnityEngine;
- using MLAgents.Sensors;
+ using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
 
     [TestFixture]

--- a/com.unity.ml-agents/Tests/Editor/Sensor/FloatVisualSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/FloatVisualSensorTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class Float2DSensor : ISensor
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class RayPerceptionSensorTests
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
@@ -1,9 +1,9 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class RenderTextureSensorComponentTest

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorTests.cs
@@ -1,9 +1,9 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     [TestFixture]
     public class RenderTextureSensorTests

--- a/com.unity.ml-agents/Tests/Editor/Sensor/SensorShapeValidatorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/SensorShapeValidatorTests.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class DummySensor : ISensor
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/StackingSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/StackingSensorTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class StackingSensorTests
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/VectorSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/VectorSensorTests.cs
@@ -1,8 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class SensorTestHelper
     {

--- a/com.unity.ml-agents/Tests/Editor/Sensor/WriterAdapterTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/WriterAdapterTests.cs
@@ -1,10 +1,10 @@
 using NUnit.Framework;
-using MLAgents.Sensors;
+using Unity.MLAgents.Sensors;
 using Barracuda;
-using MLAgents.Inference;
+using Unity.MLAgents.Inference;
 
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class WriteAdapterTests
     {

--- a/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
@@ -2,9 +2,9 @@ using System;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Text;
-using MLAgents.SideChannels;
+using Unity.MLAgents.SideChannels;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class SideChannelTests
     {

--- a/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
@@ -1,10 +1,10 @@
 using System;
 using Barracuda;
-using MLAgents.Inference;
-using MLAgents.Inference.Utils;
+using Unity.MLAgents.Inference;
+using Unity.MLAgents.Inference.Utils;
 using NUnit.Framework;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class TensorUtilsTest
     {

--- a/com.unity.ml-agents/Tests/Editor/TimerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TimerTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class TimerTests
     {

--- a/com.unity.ml-agents/Tests/Editor/UtilitiesTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/UtilitiesTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace MLAgents.Tests
+namespace Unity.MLAgents.Tests
 {
     public class UtilitiesTests
     {

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -1,9 +1,9 @@
 ﻿#if UNITY_INCLUDE_TESTS
 using System.Collections;
 using System.Collections.Generic;
-using MLAgents;
-using MLAgents.Policies;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
+using Unity.MLAgents.Sensors;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;

--- a/docs/Custom-SideChannels.md
+++ b/docs/Custom-SideChannels.md
@@ -63,8 +63,8 @@ from Unity to python.
 
 ```csharp
 using UnityEngine;
-using MLAgents;
-using MLAgents.SideChannels;
+using Unity.MLAgents;
+using Unity.MLAgents.SideChannels;
 using System.Text;
 using System;
 
@@ -107,7 +107,7 @@ be live in your Unity scene.
 
 ```csharp
 using UnityEngine;
-using MLAgents;
+using Unity.MLAgents;
 
 
 public class RegisterStringLogSideChannel : MonoBehaviour

--- a/docs/Feature-Monitor.md
+++ b/docs/Feature-Monitor.md
@@ -12,7 +12,7 @@ by calling `SetActive(boolean)`. For example to also show the monitor during
 training, you can call it in the `Awake()` method of your `MonoBehaviour`:
 
 ```csharp
-using MLAgents;
+using Unity.MLAgents;
 
 public class MyBehaviour : MonoBehaviour {
     public void Awake()

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -114,7 +114,7 @@ Then, edit the new `RollerAgent` script:
 
 1. In the Unity Project window, double-click the `RollerAgent` script to open it
    in your code editor.
-2. In the editor, add the `using MLAgents;` and `using MLAgents.Sensors` statements and then change the base
+2. In the editor, add the `using Unity.MLAgents;` and `using Unity.MLAgents.Sensors` statements and then change the base
     class from `MonoBehaviour` to `Agent`.
 3. Delete the `Update()` method, but we will use the `Start()` function, so
     leave it alone for now.
@@ -151,8 +151,8 @@ So far, our RollerAgent script looks like:
 ```csharp
 using System.Collections.Generic;
 using UnityEngine;
-using MLAgents;
-using MLAgents.Sensors;
+using Unity.MLAgents;
+using Unity.MLAgents.Sensors;
 
 public class RollerAgent : Agent
 {

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -10,6 +10,7 @@ The versions can be found in
 ## Migrating from 0.15 to latest
 
 ### Important changes
+* The `MLAgents` C# namespace was renamed to `Unity.MLAgents`, and other nested namespaces were similarly renamed.
 * The `--load` and `--train` command-line flags have been deprecated and replaced with `--resume` and `--inference`.
 * Running with the same `--run-id` twice will now throw an error.
 * The `play_against_current_self_ratio` self-play trainer hyperparameter has been renamed to `play_against_latest_model_ratio`
@@ -19,6 +20,7 @@ The versions can be found in
 * The signature of `Agent.Heuristic()` was changed to take a `float[]` as a parameter, instead of returning the array. This was done to prevent a common source of error where users would return arrays of the wrong size.
 
 ### Steps to Migrate
+* In C# code, replace `using MLAgents` with `using Unity.MLAgents`. Replace other nested namespaces such as `using MLAgents.Sensors` with `using Unity.MLAgents.Sensors`
 * Replace the `--load` flag with `--resume` when calling `mlagents-learn`, and don't use the `--train` flag as training
  will happen by default. To run without training, use `--inference`.
 * To force-overwrite files from a pre-existing run, add the `--force` command-line flag.

--- a/ml-agents-envs/mlagents_envs/communicator_objects/agent_action_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/agent_action_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/agent_action.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n5mlagents_envs/communicator_objects/agent_action.proto\x12\x14\x63ommunicator_objects\"K\n\x10\x41gentActionProto\x12\x16\n\x0evector_actions\x18\x01 \x03(\x02\x12\r\n\x05value\x18\x04 \x01(\x02J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04J\x04\x08\x05\x10\x06\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n5mlagents_envs/communicator_objects/agent_action.proto\x12\x14\x63ommunicator_objects\"K\n\x10\x41gentActionProto\x12\x16\n\x0evector_actions\x18\x01 \x03(\x02\x12\r\n\x05value\x18\x04 \x01(\x02J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04J\x04\x08\x05\x10\x06\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -74,5 +74,5 @@ _sym_db.RegisterMessage(AgentActionProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/agent_info_action_pair_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/agent_info_action_pair_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/agent_info_action_pair.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n?mlagents_envs/communicator_objects/agent_info_action_pair.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/agent_info.proto\x1a\x35mlagents_envs/communicator_objects/agent_action.proto\"\x91\x01\n\x18\x41gentInfoActionPairProto\x12\x38\n\nagent_info\x18\x01 \x01(\x0b\x32$.communicator_objects.AgentInfoProto\x12;\n\x0b\x61\x63tion_info\x18\x02 \x01(\x0b\x32&.communicator_objects.AgentActionProtoB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n?mlagents_envs/communicator_objects/agent_info_action_pair.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/agent_info.proto\x1a\x35mlagents_envs/communicator_objects/agent_action.proto\"\x91\x01\n\x18\x41gentInfoActionPairProto\x12\x38\n\nagent_info\x18\x01 \x01(\x0b\x32$.communicator_objects.AgentInfoProto\x12;\n\x0b\x61\x63tion_info\x18\x02 \x01(\x0b\x32&.communicator_objects.AgentActionProtoB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_agent__info__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_agent__action__pb2.DESCRIPTOR,])
 
@@ -79,5 +79,5 @@ _sym_db.RegisterMessage(AgentInfoActionPairProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/agent_info_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/agent_info_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/agent_info.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n3mlagents_envs/communicator_objects/agent_info.proto\x12\x14\x63ommunicator_objects\x1a\x34mlagents_envs/communicator_objects/observation.proto\"\xd1\x01\n\x0e\x41gentInfoProto\x12\x0e\n\x06reward\x18\x07 \x01(\x02\x12\x0c\n\x04\x64one\x18\x08 \x01(\x08\x12\x18\n\x10max_step_reached\x18\t \x01(\x08\x12\n\n\x02id\x18\n \x01(\x05\x12\x13\n\x0b\x61\x63tion_mask\x18\x0b \x03(\x08\x12<\n\x0cobservations\x18\r \x03(\x0b\x32&.communicator_objects.ObservationProtoJ\x04\x08\x01\x10\x02J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04J\x04\x08\x04\x10\x05J\x04\x08\x05\x10\x06J\x04\x08\x06\x10\x07J\x04\x08\x0c\x10\rB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n3mlagents_envs/communicator_objects/agent_info.proto\x12\x14\x63ommunicator_objects\x1a\x34mlagents_envs/communicator_objects/observation.proto\"\xd1\x01\n\x0e\x41gentInfoProto\x12\x0e\n\x06reward\x18\x07 \x01(\x02\x12\x0c\n\x04\x64one\x18\x08 \x01(\x08\x12\x18\n\x10max_step_reached\x18\t \x01(\x08\x12\n\n\x02id\x18\n \x01(\x05\x12\x13\n\x0b\x61\x63tion_mask\x18\x0b \x03(\x08\x12<\n\x0cobservations\x18\r \x03(\x0b\x32&.communicator_objects.ObservationProtoJ\x04\x08\x01\x10\x02J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04J\x04\x08\x04\x10\x05J\x04\x08\x05\x10\x06J\x04\x08\x06\x10\x07J\x04\x08\x0c\x10\rB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_observation__pb2.DESCRIPTOR,])
 
@@ -105,5 +105,5 @@ _sym_db.RegisterMessage(AgentInfoProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/brain_parameters_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/brain_parameters_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/brain_parameters.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n9mlagents_envs/communicator_objects/brain_parameters.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/space_type.proto\"\xd9\x01\n\x14\x42rainParametersProto\x12\x1a\n\x12vector_action_size\x18\x03 \x03(\x05\x12\"\n\x1avector_action_descriptions\x18\x05 \x03(\t\x12\x46\n\x18vector_action_space_type\x18\x06 \x01(\x0e\x32$.communicator_objects.SpaceTypeProto\x12\x12\n\nbrain_name\x18\x07 \x01(\t\x12\x13\n\x0bis_training\x18\x08 \x01(\x08J\x04\x08\x01\x10\x02J\x04\x08\x02\x10\x03J\x04\x08\x04\x10\x05\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n9mlagents_envs/communicator_objects/brain_parameters.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/space_type.proto\"\xd9\x01\n\x14\x42rainParametersProto\x12\x1a\n\x12vector_action_size\x18\x03 \x03(\x05\x12\"\n\x1avector_action_descriptions\x18\x05 \x03(\t\x12\x46\n\x18vector_action_space_type\x18\x06 \x01(\x0e\x32$.communicator_objects.SpaceTypeProto\x12\x12\n\nbrain_name\x18\x07 \x01(\t\x12\x13\n\x0bis_training\x18\x08 \x01(\x08J\x04\x08\x01\x10\x02J\x04\x08\x02\x10\x03J\x04\x08\x04\x10\x05\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_space__type__pb2.DESCRIPTOR,])
 
@@ -98,5 +98,5 @@ _sym_db.RegisterMessage(BrainParametersProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/command_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/command_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/command.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n0mlagents_envs/communicator_objects/command.proto\x12\x14\x63ommunicator_objects*-\n\x0c\x43ommandProto\x12\x08\n\x04STEP\x10\x00\x12\t\n\x05RESET\x10\x01\x12\x08\n\x04QUIT\x10\x02\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n0mlagents_envs/communicator_objects/command.proto\x12\x14\x63ommunicator_objects*-\n\x0c\x43ommandProto\x12\x08\n\x04STEP\x10\x00\x12\t\n\x05RESET\x10\x01\x12\x08\n\x04QUIT\x10\x02\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 _COMMANDPROTO = _descriptor.EnumDescriptor(
@@ -60,5 +60,5 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/custom_reset_parameters_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/custom_reset_parameters_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/custom_reset_parameters.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n@mlagents_envs/communicator_objects/custom_reset_parameters.proto\x12\x14\x63ommunicator_objects\"\x1c\n\x1a\x43ustomResetParametersProtoB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n@mlagents_envs/communicator_objects/custom_reset_parameters.proto\x12\x14\x63ommunicator_objects\"\x1c\n\x1a\x43ustomResetParametersProtoB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -60,5 +60,5 @@ _sym_db.RegisterMessage(CustomResetParametersProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/demonstration_meta_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/demonstration_meta_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/demonstration_meta.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n;mlagents_envs/communicator_objects/demonstration_meta.proto\x12\x14\x63ommunicator_objects\"\x8d\x01\n\x16\x44\x65monstrationMetaProto\x12\x13\n\x0b\x61pi_version\x18\x01 \x01(\x05\x12\x1a\n\x12\x64\x65monstration_name\x18\x02 \x01(\t\x12\x14\n\x0cnumber_steps\x18\x03 \x01(\x05\x12\x17\n\x0fnumber_episodes\x18\x04 \x01(\x05\x12\x13\n\x0bmean_reward\x18\x05 \x01(\x02\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n;mlagents_envs/communicator_objects/demonstration_meta.proto\x12\x14\x63ommunicator_objects\"\x8d\x01\n\x16\x44\x65monstrationMetaProto\x12\x13\n\x0b\x61pi_version\x18\x01 \x01(\x05\x12\x1a\n\x12\x64\x65monstration_name\x18\x02 \x01(\t\x12\x14\n\x0cnumber_steps\x18\x03 \x01(\x05\x12\x17\n\x0fnumber_episodes\x18\x04 \x01(\x05\x12\x13\n\x0bmean_reward\x18\x05 \x01(\x02\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -95,5 +95,5 @@ _sym_db.RegisterMessage(DemonstrationMetaProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/engine_configuration_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/engine_configuration_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/engine_configuration.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n=mlagents_envs/communicator_objects/engine_configuration.proto\x12\x14\x63ommunicator_objects\"\x95\x01\n\x18\x45ngineConfigurationProto\x12\r\n\x05width\x18\x01 \x01(\x05\x12\x0e\n\x06height\x18\x02 \x01(\x05\x12\x15\n\rquality_level\x18\x03 \x01(\x05\x12\x12\n\ntime_scale\x18\x04 \x01(\x02\x12\x19\n\x11target_frame_rate\x18\x05 \x01(\x05\x12\x14\n\x0cshow_monitor\x18\x06 \x01(\x08\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n=mlagents_envs/communicator_objects/engine_configuration.proto\x12\x14\x63ommunicator_objects\"\x95\x01\n\x18\x45ngineConfigurationProto\x12\r\n\x05width\x18\x01 \x01(\x05\x12\x0e\n\x06height\x18\x02 \x01(\x05\x12\x15\n\rquality_level\x18\x03 \x01(\x05\x12\x12\n\ntime_scale\x18\x04 \x01(\x02\x12\x19\n\x11target_frame_rate\x18\x05 \x01(\x05\x12\x14\n\x0cshow_monitor\x18\x06 \x01(\x08\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -102,5 +102,5 @@ _sym_db.RegisterMessage(EngineConfigurationProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/header_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/header_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/header.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n/mlagents_envs/communicator_objects/header.proto\x12\x14\x63ommunicator_objects\".\n\x0bHeaderProto\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x0f\n\x07message\x18\x02 \x01(\tB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n/mlagents_envs/communicator_objects/header.proto\x12\x14\x63ommunicator_objects\".\n\x0bHeaderProto\x12\x0e\n\x06status\x18\x01 \x01(\x05\x12\x0f\n\x07message\x18\x02 \x01(\tB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -74,5 +74,5 @@ _sym_db.RegisterMessage(HeaderProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/observation.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n4mlagents_envs/communicator_objects/observation.proto\x12\x14\x63ommunicator_objects\"\xf9\x01\n\x10ObservationProto\x12\r\n\x05shape\x18\x01 \x03(\x05\x12\x44\n\x10\x63ompression_type\x18\x02 \x01(\x0e\x32*.communicator_objects.CompressionTypeProto\x12\x19\n\x0f\x63ompressed_data\x18\x03 \x01(\x0cH\x00\x12\x46\n\nfloat_data\x18\x04 \x01(\x0b\x32\x30.communicator_objects.ObservationProto.FloatDataH\x00\x1a\x19\n\tFloatData\x12\x0c\n\x04\x64\x61ta\x18\x01 \x03(\x02\x42\x12\n\x10observation_data*)\n\x14\x43ompressionTypeProto\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03PNG\x10\x01\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n4mlagents_envs/communicator_objects/observation.proto\x12\x14\x63ommunicator_objects\"\xf9\x01\n\x10ObservationProto\x12\r\n\x05shape\x18\x01 \x03(\x05\x12\x44\n\x10\x63ompression_type\x18\x02 \x01(\x0e\x32*.communicator_objects.CompressionTypeProto\x12\x19\n\x0f\x63ompressed_data\x18\x03 \x01(\x0cH\x00\x12\x46\n\nfloat_data\x18\x04 \x01(\x0b\x32\x30.communicator_objects.ObservationProto.FloatDataH\x00\x1a\x19\n\tFloatData\x12\x0c\n\x04\x64\x61ta\x18\x01 \x03(\x02\x42\x12\n\x10observation_data*)\n\x14\x43ompressionTypeProto\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03PNG\x10\x01\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 _COMPRESSIONTYPEPROTO = _descriptor.EnumDescriptor(
@@ -165,5 +165,5 @@ _sym_db.RegisterMessage(ObservationProto.FloatData)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/space_type_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/space_type_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/space_type.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n3mlagents_envs/communicator_objects/space_type.proto\x12\x14\x63ommunicator_objects*.\n\x0eSpaceTypeProto\x12\x0c\n\x08\x64iscrete\x10\x00\x12\x0e\n\ncontinuous\x10\x01\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n3mlagents_envs/communicator_objects/space_type.proto\x12\x14\x63ommunicator_objects*.\n\x0eSpaceTypeProto\x12\x0c\n\x08\x64iscrete\x10\x00\x12\x0e\n\ncontinuous\x10\x01\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 _SPACETYPEPROTO = _descriptor.EnumDescriptor(
@@ -55,5 +55,5 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_input_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_input_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_input.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n4mlagents_envs/communicator_objects/unity_input.proto\x12\x14\x63ommunicator_objects\x1a\x37mlagents_envs/communicator_objects/unity_rl_input.proto\x1a\x46mlagents_envs/communicator_objects/unity_rl_initialization_input.proto\"\xa4\x01\n\x0fUnityInputProto\x12\x39\n\x08rl_input\x18\x01 \x01(\x0b\x32\'.communicator_objects.UnityRLInputProto\x12V\n\x17rl_initialization_input\x18\x02 \x01(\x0b\x32\x35.communicator_objects.UnityRLInitializationInputProtoB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n4mlagents_envs/communicator_objects/unity_input.proto\x12\x14\x63ommunicator_objects\x1a\x37mlagents_envs/communicator_objects/unity_rl_input.proto\x1a\x46mlagents_envs/communicator_objects/unity_rl_initialization_input.proto\"\xa4\x01\n\x0fUnityInputProto\x12\x39\n\x08rl_input\x18\x01 \x01(\x0b\x32\'.communicator_objects.UnityRLInputProto\x12V\n\x17rl_initialization_input\x18\x02 \x01(\x0b\x32\x35.communicator_objects.UnityRLInitializationInputProtoB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_unity__rl__input__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_unity__rl__initialization__input__pb2.DESCRIPTOR,])
 
@@ -79,5 +79,5 @@ _sym_db.RegisterMessage(UnityInputProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_message_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_message_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_message.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n6mlagents_envs/communicator_objects/unity_message.proto\x12\x14\x63ommunicator_objects\x1a\x35mlagents_envs/communicator_objects/unity_output.proto\x1a\x34mlagents_envs/communicator_objects/unity_input.proto\x1a/mlagents_envs/communicator_objects/header.proto\"\xc0\x01\n\x11UnityMessageProto\x12\x31\n\x06header\x18\x01 \x01(\x0b\x32!.communicator_objects.HeaderProto\x12<\n\x0cunity_output\x18\x02 \x01(\x0b\x32&.communicator_objects.UnityOutputProto\x12:\n\x0bunity_input\x18\x03 \x01(\x0b\x32%.communicator_objects.UnityInputProtoB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n6mlagents_envs/communicator_objects/unity_message.proto\x12\x14\x63ommunicator_objects\x1a\x35mlagents_envs/communicator_objects/unity_output.proto\x1a\x34mlagents_envs/communicator_objects/unity_input.proto\x1a/mlagents_envs/communicator_objects/header.proto\"\xc0\x01\n\x11UnityMessageProto\x12\x31\n\x06header\x18\x01 \x01(\x0b\x32!.communicator_objects.HeaderProto\x12<\n\x0cunity_output\x18\x02 \x01(\x0b\x32&.communicator_objects.UnityOutputProto\x12:\n\x0bunity_input\x18\x03 \x01(\x0b\x32%.communicator_objects.UnityInputProtoB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_unity__output__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_unity__input__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_header__pb2.DESCRIPTOR,])
 
@@ -88,5 +88,5 @@ _sym_db.RegisterMessage(UnityMessageProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_output_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_output_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_output.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n5mlagents_envs/communicator_objects/unity_output.proto\x12\x14\x63ommunicator_objects\x1a\x38mlagents_envs/communicator_objects/unity_rl_output.proto\x1aGmlagents_envs/communicator_objects/unity_rl_initialization_output.proto\"\xa9\x01\n\x10UnityOutputProto\x12;\n\trl_output\x18\x01 \x01(\x0b\x32(.communicator_objects.UnityRLOutputProto\x12X\n\x18rl_initialization_output\x18\x02 \x01(\x0b\x32\x36.communicator_objects.UnityRLInitializationOutputProtoB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n5mlagents_envs/communicator_objects/unity_output.proto\x12\x14\x63ommunicator_objects\x1a\x38mlagents_envs/communicator_objects/unity_rl_output.proto\x1aGmlagents_envs/communicator_objects/unity_rl_initialization_output.proto\"\xa9\x01\n\x10UnityOutputProto\x12;\n\trl_output\x18\x01 \x01(\x0b\x32(.communicator_objects.UnityRLOutputProto\x12X\n\x18rl_initialization_output\x18\x02 \x01(\x0b\x32\x36.communicator_objects.UnityRLInitializationOutputProtoB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_unity__rl__output__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_unity__rl__initialization__output__pb2.DESCRIPTOR,])
 
@@ -79,5 +79,5 @@ _sym_db.RegisterMessage(UnityOutputProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_initialization_input_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_initialization_input_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_rl_initialization_input.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\nFmlagents_envs/communicator_objects/unity_rl_initialization_input.proto\x12\x14\x63ommunicator_objects\"g\n\x1fUnityRLInitializationInputProto\x12\x0c\n\x04seed\x18\x01 \x01(\x05\x12\x1d\n\x15\x63ommunication_version\x18\x02 \x01(\t\x12\x17\n\x0fpackage_version\x18\x03 \x01(\tB\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\nFmlagents_envs/communicator_objects/unity_rl_initialization_input.proto\x12\x14\x63ommunicator_objects\"g\n\x1fUnityRLInitializationInputProto\x12\x0c\n\x04seed\x18\x01 \x01(\x05\x12\x1d\n\x15\x63ommunication_version\x18\x02 \x01(\t\x12\x17\n\x0fpackage_version\x18\x03 \x01(\tB%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 
@@ -81,5 +81,5 @@ _sym_db.RegisterMessage(UnityRLInitializationInputProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_initialization_output_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_initialization_output_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_rl_initialization_output.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\nGmlagents_envs/communicator_objects/unity_rl_initialization_output.proto\x12\x14\x63ommunicator_objects\x1a\x39mlagents_envs/communicator_objects/brain_parameters.proto\"\xc6\x01\n UnityRLInitializationOutputProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1d\n\x15\x63ommunication_version\x18\x02 \x01(\t\x12\x10\n\x08log_path\x18\x03 \x01(\t\x12\x44\n\x10\x62rain_parameters\x18\x05 \x03(\x0b\x32*.communicator_objects.BrainParametersProto\x12\x17\n\x0fpackage_version\x18\x07 \x01(\tJ\x04\x08\x06\x10\x07\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\nGmlagents_envs/communicator_objects/unity_rl_initialization_output.proto\x12\x14\x63ommunicator_objects\x1a\x39mlagents_envs/communicator_objects/brain_parameters.proto\"\xc6\x01\n UnityRLInitializationOutputProto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1d\n\x15\x63ommunication_version\x18\x02 \x01(\t\x12\x10\n\x08log_path\x18\x03 \x01(\t\x12\x44\n\x10\x62rain_parameters\x18\x05 \x03(\x0b\x32*.communicator_objects.BrainParametersProto\x12\x17\n\x0fpackage_version\x18\x07 \x01(\tJ\x04\x08\x06\x10\x07\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_brain__parameters__pb2.DESCRIPTOR,])
 
@@ -98,5 +98,5 @@ _sym_db.RegisterMessage(UnityRLInitializationOutputProto)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_input_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_input_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_rl_input.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n7mlagents_envs/communicator_objects/unity_rl_input.proto\x12\x14\x63ommunicator_objects\x1a\x35mlagents_envs/communicator_objects/agent_action.proto\x1a\x30mlagents_envs/communicator_objects/command.proto\"\xfe\x02\n\x11UnityRLInputProto\x12P\n\ragent_actions\x18\x01 \x03(\x0b\x32\x39.communicator_objects.UnityRLInputProto.AgentActionsEntry\x12\x33\n\x07\x63ommand\x18\x04 \x01(\x0e\x32\".communicator_objects.CommandProto\x12\x14\n\x0cside_channel\x18\x05 \x01(\x0c\x1aM\n\x14ListAgentActionProto\x12\x35\n\x05value\x18\x01 \x03(\x0b\x32&.communicator_objects.AgentActionProto\x1aq\n\x11\x41gentActionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12K\n\x05value\x18\x02 \x01(\x0b\x32<.communicator_objects.UnityRLInputProto.ListAgentActionProto:\x02\x38\x01J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n7mlagents_envs/communicator_objects/unity_rl_input.proto\x12\x14\x63ommunicator_objects\x1a\x35mlagents_envs/communicator_objects/agent_action.proto\x1a\x30mlagents_envs/communicator_objects/command.proto\"\xfe\x02\n\x11UnityRLInputProto\x12P\n\ragent_actions\x18\x01 \x03(\x0b\x32\x39.communicator_objects.UnityRLInputProto.AgentActionsEntry\x12\x33\n\x07\x63ommand\x18\x04 \x01(\x0e\x32\".communicator_objects.CommandProto\x12\x14\n\x0cside_channel\x18\x05 \x01(\x0c\x1aM\n\x14ListAgentActionProto\x12\x35\n\x05value\x18\x01 \x03(\x0b\x32&.communicator_objects.AgentActionProto\x1aq\n\x11\x41gentActionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12K\n\x05value\x18\x02 \x01(\x0b\x32<.communicator_objects.UnityRLInputProto.ListAgentActionProto:\x02\x38\x01J\x04\x08\x02\x10\x03J\x04\x08\x03\x10\x04\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_agent__action__pb2.DESCRIPTOR,mlagents__envs_dot_communicator__objects_dot_command__pb2.DESCRIPTOR,])
 
@@ -173,7 +173,7 @@ _sym_db.RegisterMessage(UnityRLInputProto.AgentActionsEntry)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 _UNITYRLINPUTPROTO_AGENTACTIONSENTRY.has_options = True
 _UNITYRLINPUTPROTO_AGENTACTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_output_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_rl_output_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_rl_output.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n8mlagents_envs/communicator_objects/unity_rl_output.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/agent_info.proto\"\xb9\x02\n\x12UnityRLOutputProto\x12L\n\nagentInfos\x18\x02 \x03(\x0b\x32\x38.communicator_objects.UnityRLOutputProto.AgentInfosEntry\x12\x14\n\x0cside_channel\x18\x03 \x01(\x0c\x1aI\n\x12ListAgentInfoProto\x12\x33\n\x05value\x18\x01 \x03(\x0b\x32$.communicator_objects.AgentInfoProto\x1an\n\x0f\x41gentInfosEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12J\n\x05value\x18\x02 \x01(\x0b\x32;.communicator_objects.UnityRLOutputProto.ListAgentInfoProto:\x02\x38\x01J\x04\x08\x01\x10\x02\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n8mlagents_envs/communicator_objects/unity_rl_output.proto\x12\x14\x63ommunicator_objects\x1a\x33mlagents_envs/communicator_objects/agent_info.proto\"\xb9\x02\n\x12UnityRLOutputProto\x12L\n\nagentInfos\x18\x02 \x03(\x0b\x32\x38.communicator_objects.UnityRLOutputProto.AgentInfosEntry\x12\x14\n\x0cside_channel\x18\x03 \x01(\x0c\x1aI\n\x12ListAgentInfoProto\x12\x33\n\x05value\x18\x01 \x03(\x0b\x32$.communicator_objects.AgentInfoProto\x1an\n\x0f\x41gentInfosEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12J\n\x05value\x18\x02 \x01(\x0b\x32;.communicator_objects.UnityRLOutputProto.ListAgentInfoProto:\x02\x38\x01J\x04\x08\x01\x10\x02\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_agent__info__pb2.DESCRIPTOR,])
 
@@ -164,7 +164,7 @@ _sym_db.RegisterMessage(UnityRLOutputProto.AgentInfosEntry)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 _UNITYRLOUTPUTPROTO_AGENTINFOSENTRY.has_options = True
 _UNITYRLOUTPUTPROTO_AGENTINFOSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 # @@protoc_insertion_point(module_scope)

--- a/ml-agents-envs/mlagents_envs/communicator_objects/unity_to_external_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/unity_to_external_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/unity_to_external.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n:mlagents_envs/communicator_objects/unity_to_external.proto\x12\x14\x63ommunicator_objects\x1a\x36mlagents_envs/communicator_objects/unity_message.proto2v\n\x14UnityToExternalProto\x12^\n\x08\x45xchange\x12\'.communicator_objects.UnityMessageProto\x1a\'.communicator_objects.UnityMessageProto\"\x00\x42\x1f\xaa\x02\x1cMLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n:mlagents_envs/communicator_objects/unity_to_external.proto\x12\x14\x63ommunicator_objects\x1a\x36mlagents_envs/communicator_objects/unity_message.proto2v\n\x14UnityToExternalProto\x12^\n\x08\x45xchange\x12\'.communicator_objects.UnityMessageProto\x1a\'.communicator_objects.UnityMessageProto\"\x00\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
   ,
   dependencies=[mlagents__envs_dot_communicator__objects_dot_unity__message__pb2.DESCRIPTOR,])
 
@@ -30,7 +30,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\034MLAgents.CommunicatorObjects'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\252\002\"Unity.MLAgents.CommunicatorObjects'))
 
 _UNITYTOEXTERNALPROTO = _descriptor.ServiceDescriptor(
   name='UnityToExternalProto',

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -52,7 +52,7 @@ def run_standalone_build(
         f"{base_path}/Project",
         "-batchmode",
         "-executeMethod",
-        "MLAgents.StandaloneBuildTest.BuildStandalonePlayerOSX",
+        "Unity.MLAgents.StandaloneBuildTest.BuildStandalonePlayerOSX",
     ]
 
     os.makedirs(os.path.dirname(log_output_path), exist_ok=True)

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_action.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_action.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message AgentActionProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_info.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_info.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "mlagents_envs/communicator_objects/observation.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message AgentInfoProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_info_action_pair.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/agent_info_action_pair.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "mlagents_envs/communicator_objects/agent_info.proto";
 import "mlagents_envs/communicator_objects/agent_action.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message AgentInfoActionPairProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/brain_parameters.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/brain_parameters.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "mlagents_envs/communicator_objects/space_type.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message BrainParametersProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/command.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/command.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 enum CommandProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/custom_reset_parameters.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/custom_reset_parameters.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message CustomResetParametersProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/demonstration_meta.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/demonstration_meta.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message DemonstrationMetaProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/engine_configuration.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/engine_configuration.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message EngineConfigurationProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/header.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/header.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message HeaderProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/observation.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/observation.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 enum CompressionTypeProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/space_type.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/space_type.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 enum SpaceTypeProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_input.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_input.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "mlagents_envs/communicator_objects/unity_rl_input.proto";
 import "mlagents_envs/communicator_objects/unity_rl_initialization_input.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message UnityInputProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_message.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_message.proto
@@ -4,7 +4,7 @@ import "mlagents_envs/communicator_objects/unity_output.proto";
 import "mlagents_envs/communicator_objects/unity_input.proto";
 import "mlagents_envs/communicator_objects/header.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message UnityMessageProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_output.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_output.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "mlagents_envs/communicator_objects/unity_rl_output.proto";
 import "mlagents_envs/communicator_objects/unity_rl_initialization_output.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message UnityOutputProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_initialization_input.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_initialization_input.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 // The initializaiton message - this is typically sent from the Python trainer to the C# environment.

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_initialization_output.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_initialization_output.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "mlagents_envs/communicator_objects/brain_parameters.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 // The request message containing the academy's parameters.

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_input.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_input.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "mlagents_envs/communicator_objects/agent_action.proto";
 import "mlagents_envs/communicator_objects/command.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message UnityRLInputProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_output.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_rl_output.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "mlagents_envs/communicator_objects/agent_info.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 message UnityRLOutputProto {

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_to_external.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/unity_to_external.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "mlagents_envs/communicator_objects/unity_message.proto";
 
-option csharp_namespace = "MLAgents.CommunicatorObjects";
+option csharp_namespace = "Unity.MLAgents.CommunicatorObjects";
 package communicator_objects;
 
 service UnityToExternalProto {


### PR DESCRIPTION
### Proposed change(s)
Change all namespaces from `MLAgents*` to `Unity.MLAgents*`. This brings us in line with package guidelines.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-850


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
