### PR TITLE
Clean up and fix save and load in ghost

### DIFF
--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -326,6 +326,7 @@ class GhostTrainer(Trainer):
         """
         policy = self.trainer.create_policy(parsed_behavior_id, brain_parameters)
         policy.create_tf_graph()
+        policy.initialize_or_load()
         policy.init_load_weights()
         team_id = parsed_behavior_id.team_id
         self.controller.subscribe_team_id(team_id, self)
@@ -335,7 +336,7 @@ class GhostTrainer(Trainer):
             internal_trainer_policy = self.trainer.create_policy(
                 parsed_behavior_id, brain_parameters
             )
-            internal_trainer_policy.create_tf_graph()
+            self.trainer.add_policy(parsed_behavior_id, internal_trainer_policy)
             internal_trainer_policy.init_load_weights()
             self.current_policy_snapshot[
                 parsed_behavior_id.brain_name
@@ -343,7 +344,6 @@ class GhostTrainer(Trainer):
 
             policy.load_weights(internal_trainer_policy.get_weights())
             self._save_snapshot()  # Need to save after trainer initializes policy
-            self.trainer.add_policy(parsed_behavior_id, internal_trainer_policy)
             self._learning_team = self.controller.get_learning_team
             self.wrapped_trainer_team = team_id
         return policy


### PR DESCRIPTION
### Proposed change(s)

A recent change [#3735 ](https://github.com/Unity-Technologies/ml-agents/pull/3735) created a bug in the save/load feature.  The wrapped trainer was correctly loading the policy but the initial ghosted policies were not receiving the loaded model due to the ordering of the function calls.  Specifically, the wrapped trainer must add_policy so that the optimizer can load the weights of the checkpoint before the ghosted policies can receive those weights.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
