### PR TITLE
allow SideChannel list in UnityEnv init

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to
 - `StackingSensor` was changed from `internal` visibility to `public`
 - Updated Barracuda to 0.6.3-preview.
 - The `gym` wrapper now takes optional parameters for SideChannels and command
-  line arguments for the environment.
+  line arguments for the environment. (#3801)
 
 ### Bug Fixes
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to
   communication between Unity and the Python process.
 - The obsolete `Agent` methods `GiveModel`, `Done`, `InitializeAgent`,
   `AgentAction` and `AgentReset` have been removed.
-- The GhostTrainer has been extended to support asymmetric games and the asymmetric example environment Strikers Vs. Goalie has been added.
+- The GhostTrainer has been extended to support asymmetric games and the
+  asymmetric example environment Strikers Vs. Goalie has been added.
 
 ### Minor Changes
 
@@ -61,6 +62,8 @@ and this project adheres to
   overwrite the existing files. (#3705)
 - `StackingSensor` was changed from `internal` visibility to `public`
 - Updated Barracuda to 0.6.3-preview.
+- The `gym` wrapper now takes optional parameters for SideChannels and command
+  line arguments for the environment.
 
 ### Bug Fixes
 

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -7,6 +7,7 @@ from gym import error, spaces
 
 from mlagents_envs.environment import UnityEnvironment
 from mlagents_envs.base_env import DecisionSteps, TerminalSteps
+from mlagents_envs.side_channel.side_channel import SideChannel
 from mlagents_envs import logging_util
 
 
@@ -38,6 +39,7 @@ class UnityEnv(gym.Env):
         flatten_branched: bool = False,
         no_graphics: bool = False,
         allow_multiple_visual_obs: bool = False,
+        side_channels: Optional[List[SideChannel]] = None,
     ):
         """
         Environment initialization
@@ -49,6 +51,7 @@ class UnityEnv(gym.Env):
             MultiDiscrete.
         :param no_graphics: Whether to run the Unity simulator in no-graphics mode
         :param allow_multiple_visual_obs: If True, return a list of visual observations instead of only one.
+        :param side_channels: Optional list of side channels for no-rl communication with Unity
         """
         base_port = UnityEnvironment.BASE_ENVIRONMENT_PORT
         if environment_filename is None:
@@ -59,6 +62,7 @@ class UnityEnv(gym.Env):
             worker_id,
             base_port=base_port,
             no_graphics=no_graphics,
+            side_channels=side_channels,
         )
 
         # Take a single step so that the brain information will be sent over

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -39,6 +39,7 @@ class UnityEnv(gym.Env):
         flatten_branched: bool = False,
         no_graphics: bool = False,
         allow_multiple_visual_obs: bool = False,
+        env_args: Optional[List[str]] = None,
         side_channels: Optional[List[SideChannel]] = None,
     ):
         """
@@ -51,6 +52,7 @@ class UnityEnv(gym.Env):
             MultiDiscrete.
         :param no_graphics: Whether to run the Unity simulator in no-graphics mode
         :param allow_multiple_visual_obs: If True, return a list of visual observations instead of only one.
+        :param env_args: Optional list of additional arguments that are passed on the command line to the environment.
         :param side_channels: Optional list of side channels for no-rl communication with Unity
         """
         base_port = UnityEnvironment.BASE_ENVIRONMENT_PORT
@@ -62,6 +64,7 @@ class UnityEnv(gym.Env):
             worker_id,
             base_port=base_port,
             no_graphics=no_graphics,
+            args=env_args,
             side_channels=side_channels,
         )
 

--- a/ml-agents/tests/yamato/scripts/run_gym.py
+++ b/ml-agents/tests/yamato/scripts/run_gym.py
@@ -8,7 +8,13 @@ def test_run_environment(env_name):
     Run the gym test using the specified environment
     :param env_name: Name of the Unity environment binary to launch
     """
-    env = UnityEnv(env_name, worker_id=1, use_visual=False, no_graphics=True)
+    env = UnityEnv(
+        env_name,
+        worker_id=1,
+        use_visual=False,
+        no_graphics=True,
+        env_args=["-logFile", "-"],
+    )
 
     try:
         # Examine environment parameters


### PR DESCRIPTION
### Proposed change(s)

Feature request from the forums - we don't provide any interface for passing SideChannels to the BaseEnv. We also don't allow environment args being passed, so add that too.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://forum.unity.com/threads/sidechannel-in-gym-environment.863938/

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
