### PR TITLE
[bug-fix] Increase buffer size for SAC tests

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -55,7 +55,7 @@ SAC_CONFIG = f"""
     {BRAIN_NAME}:
         trainer: sac
         batch_size: 8
-        buffer_size: 500
+        buffer_size: 5000
         buffer_init_steps: 100
         hidden_units: 16
         init_entcoef: 0.01


### PR DESCRIPTION
### Proposed change(s)

Previously we were using a buffer size of 500 for SAC end-to-end tests. This was much too small for 2D and memory tests, causing some instability if the seeding of the test ever changed. 

We increase the buffer size to 5000 to fix this. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)
