### PR TITLE
[bug-fix] Bugfixes for Threaded Trainers

### DIFF
--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -152,7 +152,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
                     except AgentManagerQueue.Empty:
                         break
                 if self.threaded and not _queried:
-                    # Avoid busy-waiting
+                    # Yield thread to avoid busy-waiting
                     time.sleep(0.0001)
         if self.should_still_train:
             if self._is_ready_update():

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -153,7 +153,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
                         break
                 if self.threaded and not _queried:
                     # Avoid busy-waiting
-                    time.sleep(0.05)
+                    time.sleep(0.0001)
         if self.should_still_train:
             if self._is_ready_update():
                 with hierarchical_timer("_update_policy"):


### PR DESCRIPTION
### Proposed change(s)

This PR fixes two issues with the threaded trainer. 

- When ghost-training, two threads are created for the same trainer causing a race condition on the buffer. We now only create one thread for a ghost-trainer. 
- If there is more than one trainer but no samples are produced by the environment for that trainer (e.g. WallJump's swappable brains) the idle trainer busy-waits polling the trajectory queue. Now we yield the thread. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)