### PR TITLE
Master package publish

### DIFF
--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -1,9 +1,9 @@
 pack:
   name: Pack
   agent:
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.large
+    type: Unity::VM::osx
+    image: package-ci/mac:stable
+    flavor: b1.small
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path com.unity.ml-agents

--- a/.yamato/com.unity.ml-agents-promotion.yml
+++ b/.yamato/com.unity.ml-agents-promotion.yml
@@ -1,0 +1,90 @@
+test_editors:
+  - version: 2018.4
+    # 2018.4 doesn't support code-coverage
+    coverageOptions:
+    minCoveragePct: 0
+  - version: 2019.3
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: 2020.1
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: 2020.2
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: trunk
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+
+test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  - name: mac
+    type: Unity::VM::osx
+    image: package-ci/mac:stable
+    flavor: b1.small
+  - name: linux
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.medium
+---
+
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+promotion_test_{{ platform.name }}_{{ editor.version }}:
+  name : Promotion Test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.ml-agents
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+{% endfor %}
+{% endfor %}
+
+promotion_test_trigger:
+  name: Promotion Tests Trigger
+  dependencies:
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/com.unity.ml-agents-promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
+{% endfor %}
+{% endfor %}
+
+promote:
+  name: Promote to Production
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package promote --package-path com.unity.ml-agents --dry-run
+#  triggers:
+#    tags:
+#      only:
+#        - /^(r|R)elease-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/com.unity.ml-agents-promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
+{% endfor %}
+{% endfor %}

--- a/.yamato/com.unity.ml-agents-promotion.yml
+++ b/.yamato/com.unity.ml-agents-promotion.yml
@@ -20,28 +20,6 @@ test_platforms:
     flavor: b1.medium
 ---
 
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-promotion_test_{{ platform.name }}_{{ editor.version }}:
-  name : Promotion Test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  variables:
-    UPMCI_PROMOTION: 1
-  commands:
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.ml-agents
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-{% endfor %}
-{% endfor %}
-
 promotion_test_trigger:
   name: Promotion Tests Trigger
   dependencies:

--- a/.yamato/com.unity.ml-agents-promotion.yml
+++ b/.yamato/com.unity.ml-agents-promotion.yml
@@ -1,8 +1,3 @@
-promotion_test_trigger:
-  name: Promotion Tests Trigger
-  dependencies:
-    - .yamato/com.unity.ml-agents-test.yml#all_package_tests
-
 promote:
   name: Promote to Production
   agent:
@@ -24,3 +19,4 @@ promote:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/com.unity.ml-agents-pack.yml#pack
+    - .yamato/com.unity.ml-agents-test.yml#all_package_tests

--- a/.yamato/com.unity.ml-agents-promotion.yml
+++ b/.yamato/com.unity.ml-agents-promotion.yml
@@ -1,20 +1,9 @@
 test_editors:
   - version: 2018.4
-    # 2018.4 doesn't support code-coverage
-    coverageOptions:
-    minCoveragePct: 0
   - version: 2019.3
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: 2020.1
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: 2020.2
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: trunk
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
 
 test_platforms:
   - name: win
@@ -72,7 +61,7 @@ promote:
     UPMCI_PROMOTION: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package promote --package-path com.unity.ml-agents --dry-run
+    - upm-ci package promote --package-path com.unity.ml-agents
 #  triggers:
 #    tags:
 #      only:
@@ -83,8 +72,3 @@ promote:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/com.unity.ml-agents-pack.yml#pack
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-    - .yamato/com.unity.ml-agents-promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
-{% endfor %}
-{% endfor %}

--- a/.yamato/com.unity.ml-agents-promotion.yml
+++ b/.yamato/com.unity.ml-agents-promotion.yml
@@ -1,33 +1,7 @@
-test_editors:
-  - version: 2018.4
-  - version: 2019.3
-  - version: 2020.1
-  - version: 2020.2
-  - version: trunk
-
-test_platforms:
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: b1.small
-  - name: linux
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
----
-
 promotion_test_trigger:
   name: Promotion Tests Trigger
   dependencies:
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-    - .yamato/com.unity.ml-agents-promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
-{% endfor %}
-{% endfor %}
+    - .yamato/com.unity.ml-agents-test.yml#all_package_tests
 
 promote:
   name: Promote to Production

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -1,0 +1,58 @@
+test_editors:
+  - version: 2018.4
+    # 2018.4 doesn't support code-coverage
+    coverageOptions:
+    minCoveragePct: 0
+  - version: 2019.3
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: 2020.1
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: 2020.2
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: trunk
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+
+test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  - name: mac
+    type: Unity::VM::osx
+    image: package-ci/mac:stable
+    flavor: b1.small
+  - name: linux
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.medium
+---
+
+publish:
+  name: Publish ML-Agents to Internal Registry
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+# Please remove the dry-run option once your CI pipeline is in place ant that you're ready to publish for real
+    - upm-ci package publish --package-path com.unity.ml-agents --dry-run
+#  triggers:
+#    tags:
+#      only:
+#        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+    {% for editor in test_editors %}
+    {% for platform in test_platforms %}
+    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
+    {% endfor %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -29,6 +29,8 @@ test_platforms:
     image: package-ci/ubuntu:stable
     flavor: b1.medium
 ---
+{% for editor in trunk_editor %}
+{% for platform in test_platforms %}
 test_{{ platform.name }}_{{ editor.version }}:
   name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
   agent:
@@ -82,6 +84,3 @@ publish:
     {% endif %}
     {% endfor %}
     {% endfor %}
-
-  {% for editor in trunk_editor %}
-  {% for platform in test_platforms %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -39,8 +39,3 @@ publish:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/com.unity.ml-agents-pack.yml#pack
-    {% for editor in test_editors %}
-    {% for platform in test_platforms %}
-    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-    {% endfor %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -29,6 +29,28 @@ test_platforms:
     image: package-ci/ubuntu:stable
     flavor: b1.medium
 ---
+test_{{ platform.name }}_{{ editor.version }}:
+  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents  {{ editor.coverageOptions }}
+    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+  triggers:
+    cancel_old_ci: true
+  {% endfor %}
+  {% endfor %}
 
 publish:
   name: Publish ML-Agents to Internal Registry
@@ -54,34 +76,12 @@ publish:
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
     {% if test_editor.version == "trunk" %}
-    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% else %}
     - .yamato/com.unity.ml-agents-publish.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% else %}
+    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endif %}
     {% endfor %}
     {% endfor %}
 
   {% for editor in trunk_editor %}
   {% for platform in test_platforms %}
-test_{{ platform.name }}_{{ editor.version }}:
-  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents  {{ editor.coverageOptions }}
-    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-  {% endfor %}
-  {% endfor %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -20,7 +20,7 @@ test_platforms:
 ---
 {% for platform in test_platforms %}
 test_{{ platform.name }}_trunk:
-  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+  name : com.unity.ml-agents test trunk on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -53,7 +53,7 @@ publish:
     - .yamato/com.unity.ml-agents-pack.yml#pack
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
-    {% if test_editors.version == "trunk" %}
+    {% if test_editor.version == "trunk" %}
     - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
     {% else %}
     - .yamato/com.unity.ml-agents-publish.yml#test_{{ platform.name }}_{{ editor.version }}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -29,11 +29,9 @@ publish:
       paths:
         - "upm-ci~/packages/*.tgz"
   dependencies:
-  - .yamato/com.unity.ml-agents-pack.yml#pack
-  {% for editor in test_editors %}
-  {% for platform in test_platforms %}
-  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endfor %}
-  {% endfor %}
-  triggers:
-    cancel_old_ci: true
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+    {% for editor in test_editors %}
+    {% for platform in test_platforms %}
+    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
+    {% endfor %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -18,28 +18,6 @@ test_platforms:
     image: package-ci/ubuntu:stable
     flavor: b1.medium
 ---
-{% for platform in test_platforms %}
-test_{{ platform.name }}_trunk:
-  name : com.unity.ml-agents test trunk on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u trunk -c editor --wait --fast
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u trunk --package-path com.unity.ml-agents
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-  {% endfor %}
-
 publish:
   name: Publish ML-Agents to Internal Registry
   agent:
@@ -70,3 +48,26 @@ publish:
     {% endif %}
     {% endfor %}
     {% endfor %}
+
+{% for platform in test_platforms %}
+test_{{ platform.name }}_trunk:
+  name : com.unity.ml-agents test trunk on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u trunk -c editor --wait --fast
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u trunk --package-path com.unity.ml-agents
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+  triggers:
+    cancel_old_ci: true
+  {% endfor %}
+

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -6,7 +6,6 @@ publish:
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-# Please remove the dry-run option once your CI pipeline is in place ant that you're ready to publish for real
     - upm-ci package publish --package-path com.unity.ml-agents
   triggers:
     cancel_old_ci: true

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -42,6 +42,5 @@ publish:
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
     - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endif %}
     {% endfor %}
     {% endfor %}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -19,7 +19,7 @@ test_platforms:
     flavor: b1.medium
 ---
 {% for platform in test_platforms %}
-test_{{ platform.name }}_{{ editor.version }}:
+test_{{ platform.name }}_trunk:
   name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -1,20 +1,9 @@
 test_editors:
   - version: 2018.4
-    # 2018.4 doesn't support code-coverage
-    coverageOptions:
-    minCoveragePct: 0
   - version: 2019.3
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: 2020.1
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: 2020.2
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
   - version: trunk
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
 test_platforms:
   - name: win
     type: Unity::VM
@@ -29,7 +18,6 @@ test_platforms:
     image: package-ci/ubuntu:stable
     flavor: b1.medium
 ---
-{% for editor in trunk_editor %}
 {% for platform in test_platforms %}
 test_{{ platform.name }}_{{ editor.version }}:
   name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
@@ -39,10 +27,9 @@ test_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
+    - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents  {{ editor.coverageOptions }}
-    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+    - upm-ci package test -u trunk --package-path com.unity.ml-agents
   artifacts:
     logs:
       paths:
@@ -51,7 +38,6 @@ test_{{ platform.name }}_{{ editor.version }}:
     - .yamato/com.unity.ml-agents-pack.yml#pack
   triggers:
     cancel_old_ci: true
-  {% endfor %}
   {% endfor %}
 
 publish:

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -1,23 +1,3 @@
-test_editors:
-  - version: 2018.4
-  - version: 2019.3
-  - version: 2020.1
-  - version: 2020.2
-  - version: trunk
-test_platforms:
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: b1.small
-  - name: linux
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
----
 publish:
   name: Publish ML-Agents to Internal Registry
   agent:

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -1,3 +1,14 @@
+test_editors:
+  - version: 2018.4
+  - version: 2019.3
+  - version: 2020.1
+  - version: 2020.2
+  - version: trunk
+test_platforms:
+  - name: win
+  - name: mac
+  - name: linux
+---
 publish:
   name: Publish ML-Agents to Internal Registry
   agent:
@@ -18,4 +29,11 @@ publish:
       paths:
         - "upm-ci~/packages/*.tgz"
   dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
+  - .yamato/com.unity.ml-agents-pack.yml#pack
+  {% for editor in test_editors %}
+  {% for platform in test_platforms %}
+  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
+  {% endfor %}
+  triggers:
+    cancel_old_ci: true

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -1,14 +1,3 @@
-test_editors:
-  - version: 2018.4
-  - version: 2019.3
-  - version: 2020.1
-  - version: 2020.2
-  - version: trunk
-test_platforms:
-  - name: win
-  - name: mac
-  - name: linux
----
 publish:
   name: Publish ML-Agents to Internal Registry
   agent:
@@ -30,8 +19,4 @@ publish:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/com.unity.ml-agents-pack.yml#pack
-    {% for editor in test_editors %}
-    {% for platform in test_platforms %}
-    - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-    {% endfor %}
+    - .yamato/com.unity.ml-agents-test.yml#all_package_tests

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -27,7 +27,7 @@ publish:
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 # Please remove the dry-run option once your CI pipeline is in place ant that you're ready to publish for real
-    - upm-ci package publish --package-path com.unity.ml-agents --dry-run
+    - upm-ci package publish --package-path com.unity.ml-agents
   triggers:
     cancel_old_ci: true
 #    tags:

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -41,33 +41,7 @@ publish:
     - .yamato/com.unity.ml-agents-pack.yml#pack
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
-    {% if test_editor.version == "trunk" %}
-    - .yamato/com.unity.ml-agents-publish.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% else %}
     - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endif %}
     {% endfor %}
     {% endfor %}
-
-{% for platform in test_platforms %}
-test_{{ platform.name }}_trunk:
-  name : com.unity.ml-agents test trunk on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u trunk -c editor --wait --fast
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u trunk --package-path com.unity.ml-agents
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-  {% endfor %}
-

--- a/.yamato/com.unity.ml-agents-publish.yml
+++ b/.yamato/com.unity.ml-agents-publish.yml
@@ -15,7 +15,6 @@ test_editors:
   - version: trunk
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
-
 test_platforms:
   - name: win
     type: Unity::VM
@@ -41,7 +40,8 @@ publish:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 # Please remove the dry-run option once your CI pipeline is in place ant that you're ready to publish for real
     - upm-ci package publish --package-path com.unity.ml-agents --dry-run
-#  triggers:
+  triggers:
+    cancel_old_ci: true
 #    tags:
 #      only:
 #        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
@@ -53,6 +53,35 @@ publish:
     - .yamato/com.unity.ml-agents-pack.yml#pack
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
+    {% if test_editors.version == "trunk" %}
     - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% else %}
+    - .yamato/com.unity.ml-agents-publish.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endif %}
     {% endfor %}
     {% endfor %}
+
+  {% for editor in trunk_editor %}
+  {% for platform in test_platforms %}
+test_{{ platform.name }}_{{ editor.version }}:
+  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents  {{ editor.coverageOptions }}
+    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+  triggers:
+    cancel_old_ci: true
+  {% endfor %}
+  {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -9,6 +9,12 @@ test_editors:
   - version: 2020.1
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
+  - version: 2020.2
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
+  - version: trunk
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
 test_platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -35,14 +35,15 @@ all_package_tests:
   name: Run All Combinations of Editors/Platforms Tests
   dependencies:
   {% for editor in test_editors %}
-  {% for platform in test_platforms %}
+    {% for platform in test_platforms %}
   - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
   {% endfor %}
-  {% endfor %}
+
   {% for editor in trunk_editor %}
-  {% for platform in test_platforms %}
+    {% for platform in test_platforms %}
   - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endfor %}
+    {% endfor %}
   {% endfor %}
   triggers:
     cancel_old_ci: true
@@ -73,9 +74,9 @@ test_{{ platform.name }}_{{ editor.version }}:
         - "ml-agents/tests/yamato/**"
         - ".yamato/com.unity.ml-agents-test.yml"
   {% endfor %}
-  {% endfor %}
+{% endfor %}
 
-  {% for editor in trunk_editor %}
+{% for editor in trunk_editor %}
   {% for platform in test_platforms %}
 test_{{ platform.name }}_trunk:
   name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
@@ -97,5 +98,5 @@ test_{{ platform.name }}_trunk:
     - .yamato/com.unity.ml-agents-pack.yml#pack
   triggers:
     cancel_old_ci: true
-  {% endfor %}
+    {% endfor %}
   {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -56,10 +56,6 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    {% if editor.version != "trunk" %}
-    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u trunk -c editor --wait --fast
-    {% endif %}
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -12,6 +12,7 @@ test_editors:
   - version: 2020.2
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
+trunk_editor:
   - version: trunk
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
@@ -38,6 +39,11 @@ all_package_tests:
   - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
   {% endfor %}
   {% endfor %}
+  {% for editor in trunk_editor %}
+  {% for platform in test_platforms %}
+  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
+  {% endfor %}
   triggers:
     cancel_old_ci: true
 
@@ -50,7 +56,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    {% if editor.version == "trunk" %}
+    {% if editor.version != "trunk" %}
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     {% endif %}
@@ -73,3 +79,27 @@ test_{{ platform.name }}_{{ editor.version }}:
   {% endfor %}
   {% endfor %}
 
+  {% for editor in trunk_editor %}
+  {% for platform in test_platforms %}
+test_{{ platform.name }}_trunk:
+  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u trunk -c editor --wait --fast
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
+    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+  triggers:
+    cancel_old_ci: true
+  {% endfor %}
+  {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -12,6 +12,9 @@ test_editors:
   - version: 2020.2
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
+  - version: trunk
+    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
+    minCoveragePct: 72
 test_platforms:
   - name: win
     type: Unity::VM
@@ -36,6 +39,10 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
+    {% if editor.version == "trunk" %}
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u trunk -c editor --wait --fast
+    {% endif %}
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
@@ -56,3 +63,24 @@ test_{{ platform.name }}_{{ editor.version }}:
   {% endfor %}
   {% endfor %}
 
+{% for platform in test_platforms %}
+test_{{ platform.name }}_trunk:
+  name : com.unity.ml-agents test trunk on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u trunk -c editor --wait --fast
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u trunk --package-path com.unity.ml-agents
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#pack
+  triggers:
+    cancel_old_ci: true
+  {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -59,28 +59,6 @@ test_{{ platform.name }}_{{ editor.version }}:
         - "com.unity.ml-agents/**"
         - "ml-agents/tests/yamato/**"
         - ".yamato/com.unity.ml-agents-test.yml"
-
   {% endfor %}
   {% endfor %}
 
-{% for platform in test_platforms %}
-test_{{ platform.name }}_trunk:
-  name : com.unity.ml-agents test trunk on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
-    - unity-downloader-cli -u trunk -c editor --wait --fast
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u trunk --package-path com.unity.ml-agents
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-  {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -56,6 +56,10 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
+    {% if editor.version != "trunk" %}
+    - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - unity-downloader-cli -u trunk -c editor --wait --fast
+    {% endif %}
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -12,9 +12,6 @@ test_editors:
   - version: 2020.2
     coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
     minCoveragePct: 72
-  - version: trunk
-    coverageOptions: --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.ML-Agents'
-    minCoveragePct: 72
 test_platforms:
   - name: win
     type: Unity::VM
@@ -58,3 +55,4 @@ test_{{ platform.name }}_{{ editor.version }}:
 
   {% endfor %}
   {% endfor %}
+

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -30,6 +30,17 @@ test_platforms:
     flavor: b1.medium
 ---
 
+all_package_tests:
+  name: Run All Combinations of Editors/Platforms Tests
+  dependencies:
+  {% for editor in test_editors %}
+  {% for platform in test_platforms %}
+  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
+  {% endfor %}
+  triggers:
+    cancel_old_ci: true
+
 {% for editor in test_editors %}
   {% for platform in test_platforms %}
 test_{{ platform.name }}_{{ editor.version }}:


### PR DESCRIPTION
### Proposed change(s)
Create publish and promotion configs for com.unity.ml-agents.
You can now trigger a publish job in the Yamato UI to publish new versions of ML-Agents to the internal package registry.  We have not added any automatic triggers yet as we are still figuring out the tagging situation for python/c#/github in our repo. 

I also moved our pack job to MacOS in order to get better distribution times (on average).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) - Package publish/promotion yamato configs

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
