### PR TITLE
inference seed, increment seed for ModelRunner

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to
 - Running `mlagents-learn` with the same `--run-id` twice will no longer
   overwrite the existing files. (#3705)
 - `StackingSensor` was changed from `internal` visibility to `public`
+- Academy.InferenceSeed property was added. This is used to initialize the
+  random number generator in ModelRunner, and is incremented for each ModelRunner. (#3823)
 - Updated Barracuda to 0.6.3-preview.
  - Model updates can now happen asynchronously with environment steps for better performance. (#3690)
  - `num_updates` and `train_interval` for SAC were replaced with `steps_per_update`. (#3690)

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -121,6 +121,19 @@ namespace MLAgents
         // Flag used to keep track of the first time the Academy is reset.
         bool m_HadFirstReset;
 
+        // Random seed used for inference.
+        int m_InferenceSeed;
+
+        /// <summary>
+        /// Set the random seed used for inference. This should be set before any Agents are added
+        /// to the scene. The seed is passed to the ModelRunner constructor, and incremented each
+        /// time a new ModelRunner is created.
+        /// </summary>
+        public int InferenceSeed
+        {
+            set { m_InferenceSeed = value; }
+        }
+
         // The Academy uses a series of events to communicate with agents
         // to facilitate synchronization. More specifically, it ensure
         // that all the agents performs their steps in a consistent order (i.e. no
@@ -331,6 +344,8 @@ namespace MLAgents
                             name = "AcademySingleton",
                         });
                     UnityEngine.Random.InitState(unityRlInitParameters.seed);
+                    // We might have inference-only Agents, so set the seed for them too.
+                    m_InferenceSeed = unityRlInitParameters.seed;
                 }
                 catch
                 {
@@ -489,9 +504,9 @@ namespace MLAgents
             var modelRunner = m_ModelRunners.Find(x => x.HasModel(model, inferenceDevice));
             if (modelRunner == null)
             {
-                modelRunner = new ModelRunner(
-                    model, brainParameters, inferenceDevice);
+                modelRunner = new ModelRunner(model, brainParameters, inferenceDevice, m_InferenceSeed);
                 m_ModelRunners.Add(modelRunner);
+                m_InferenceSeed++;
             }
             return modelRunner;
         }

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -57,6 +57,7 @@ namespace Tests
         [UnityTest]
         public IEnumerator RuntimeApiTestWithEnumeratorPasses()
         {
+            Academy.Instance.InferenceSeed = 1337;
             var gameObject = new GameObject();
 
             var behaviorParams = gameObject.AddComponent<BehaviorParameters>();


### PR DESCRIPTION
### Proposed change(s)

* Give users the ability to set the random seed for ModelRunner (currently it's always 0)
* Offset the random seed for each ModelRunner, just to potentially avoid synced behavior between duplicated models
* Set the inference seed from the trainer's seed.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-880

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
