### PR TITLE
access to observations in Heuristic

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -70,8 +70,10 @@ and this project adheres to
 - Academy.InferenceSeed property was added. This is used to initialize the
   random number generator in ModelRunner, and is incremented for each ModelRunner. (#3823)
 - Updated Barracuda to 0.6.3-preview.
- - Model updates can now happen asynchronously with environment steps for better performance. (#3690)
- - `num_updates` and `train_interval` for SAC were replaced with `steps_per_update`. (#3690)
+- Added `Agent.GetObservations(), which returns a read-only view of the observations
+  added in `CollectObservations()`. (#3825)
+- Model updates can now happen asynchronously with environment steps for better performance. (#3690)
+- `num_updates` and `train_interval` for SAC were replaced with `steps_per_update`. (#3690)
 
 ### Bug Fixes
 

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEngine;
 using Barracuda;
 using MLAgents.Sensors;
@@ -689,6 +690,17 @@ namespace MLAgents
         /// </remarks>
         public virtual void CollectObservations(VectorSensor sensor)
         {
+        }
+
+        /// <summary>
+        /// Returns a read-only view of the observations that were generated in
+        /// <see cref="CollectObservations(VectorSensor)"/>. This is mainly useful inside of a
+        /// <see cref="Heuristic(float[])"/> method to avoid recomputing the observations.
+        /// </summary>
+        /// <returns>A read-only view of the observations list.</returns>
+        public ReadOnlyCollection<float> GetObservations()
+        {
+            return collectObservationsSensor.GetObservations();
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace MLAgents.Sensors
@@ -58,6 +59,15 @@ namespace MLAgents.Sensors
             }
             adapter.AddRange(m_Observations);
             return expectedObservations;
+        }
+
+        /// <summary>
+        /// Returns a read-only view of the observations that added.
+        /// </summary>
+        /// <returns>A read-only view of the observations list.</returns>
+        internal ReadOnlyCollection<float> GetObservations()
+        {
+            return m_Observations.AsReadOnly();
         }
 
         /// <inheritdoc/>

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -96,6 +96,8 @@ namespace MLAgents.Tests
 
         public override void Heuristic(float[] actionsOut)
         {
+            var obs = GetObservations();
+            actionsOut[0] = obs[0];
             heuristicCalls++;
         }
     }
@@ -667,6 +669,9 @@ namespace MLAgents.Tests
             Assert.AreEqual(numSteps, agent1.heuristicCalls);
             Assert.AreEqual(numSteps, agent1.sensor1.numWriteCalls);
             Assert.AreEqual(numSteps, agent1.sensor2.numCompressedCalls);
+
+            // Make sure the Heuristic method read the observation and set the action
+            Assert.AreEqual(agent1.collectObservationsCallsForEpisode, agent1.GetAction()[0]);
         }
     }
 


### PR DESCRIPTION
### Proposed change(s)

Before some of the refactoring on Agent, it was possible to view the vector observations in the Heuristic method. This adds a new method to re-enable that.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://forum.unity.com/threads/ml-agents-v1-0-and-roadmap-update-mar-19-2020-discussion-thread.850099/#post-5617669


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
