### PR TITLE
Python side changes to the SideChannel redesign

### DIFF
--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -11,7 +11,7 @@ namespace MLAgents.SideChannels
     {
         private enum ConfigurationType : int
         {
-            Screen = 0,
+            ScreenResolution = 0,
             QualityLevel = 1,
             TimeScale = 2,
             TargetFrameRate = 3,
@@ -35,7 +35,7 @@ namespace MLAgents.SideChannels
             var messageType = (ConfigurationType)msg.ReadInt32();
             switch (messageType)
             {
-                case ConfigurationType.Screen:
+                case ConfigurationType.ScreenResolution:
                     var width = msg.ReadInt32();
                     var height = msg.ReadInt32();
                     Screen.SetResolution(width, height, false);
@@ -56,6 +56,11 @@ namespace MLAgents.SideChannels
                 case ConfigurationType.CaptureFrameRate:
                     var captureFrameRate = msg.ReadInt32();
                     Time.captureFramerate = captureFrameRate;
+                    break;
+                default:
+                    Debug.LogWarning(
+                        "Unknown engine configuration received from Python. Make sure" +
+                        " your Unity and Python versions are compatible.");
                     break;
             }
         }

--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -30,7 +30,7 @@ namespace MLAgents.SideChannels
         }
 
         /// <inheritdoc/>
-        public override void OnMessageReceived(IncomingMessage msg)
+        protected override void OnMessageReceived(IncomingMessage msg)
         {
             var messageType = (ConfigurationType)msg.ReadInt32();
             switch (messageType)

--- a/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EngineConfigurationChannel.cs
@@ -3,11 +3,21 @@ using UnityEngine;
 
 namespace MLAgents.SideChannels
 {
+
     /// <summary>
     /// Side channel that supports modifying attributes specific to the Unity Engine.
     /// </summary>
     internal class EngineConfigurationChannel : SideChannel
     {
+        private enum ConfigurationType : int
+        {
+            Screen = 0,
+            QualityLevel = 1,
+            TimeScale = 2,
+            TargetFrameRate = 3,
+            CaptureFrameRate = 4
+        }
+
         const string k_EngineConfigId = "e951342c-4f7e-11ea-b238-784f4387d1f7";
 
         /// <summary>
@@ -22,20 +32,32 @@ namespace MLAgents.SideChannels
         /// <inheritdoc/>
         public override void OnMessageReceived(IncomingMessage msg)
         {
-            var width = msg.ReadInt32();
-            var height = msg.ReadInt32();
-            var qualityLevel = msg.ReadInt32();
-            var timeScale = msg.ReadFloat32();
-            var targetFrameRate = msg.ReadInt32();
-            var captureFrameRate = msg.ReadInt32();
-
-            timeScale = Mathf.Clamp(timeScale, 1, 100);
-
-            Screen.SetResolution(width, height, false);
-            QualitySettings.SetQualityLevel(qualityLevel, true);
-            Time.timeScale = timeScale;
-            Time.captureFramerate = captureFrameRate;
-            Application.targetFrameRate = targetFrameRate;
+            var messageType = (ConfigurationType)msg.ReadInt32();
+            switch (messageType)
+            {
+                case ConfigurationType.Screen:
+                    var width = msg.ReadInt32();
+                    var height = msg.ReadInt32();
+                    Screen.SetResolution(width, height, false);
+                    break;
+                case ConfigurationType.QualityLevel:
+                    var qualityLevel = msg.ReadInt32();
+                    QualitySettings.SetQualityLevel(qualityLevel, true);
+                    break;
+                case ConfigurationType.TimeScale:
+                    var timeScale = msg.ReadFloat32();
+                    timeScale = Mathf.Clamp(timeScale, 1, 100);
+                    Time.timeScale = timeScale;
+                    break;
+                case ConfigurationType.TargetFrameRate:
+                    var targetFrameRate = msg.ReadInt32();
+                    Application.targetFrameRate = targetFrameRate;
+                    break;
+                case ConfigurationType.CaptureFrameRate:
+                    var captureFrameRate = msg.ReadInt32();
+                    Time.captureFramerate = captureFrameRate;
+                    break;
+            }
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/SideChannels/EnvironmentParametersChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/EnvironmentParametersChannel.cs
@@ -33,7 +33,7 @@ namespace MLAgents.SideChannels
         }
 
         /// <inheritdoc/>
-        public override void OnMessageReceived(IncomingMessage msg)
+        protected override void OnMessageReceived(IncomingMessage msg)
         {
             var key = msg.ReadString();
             var type = msg.ReadInt32();

--- a/com.unity.ml-agents/Runtime/SideChannels/FloatPropertiesChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/FloatPropertiesChannel.cs
@@ -30,7 +30,7 @@ namespace MLAgents.SideChannels
         }
 
         /// <inheritdoc/>
-        public override void OnMessageReceived(IncomingMessage msg)
+        protected override void OnMessageReceived(IncomingMessage msg)
         {
             var key = msg.ReadString();
             var value = msg.ReadFloat32();

--- a/com.unity.ml-agents/Runtime/SideChannels/RawBytesChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/RawBytesChannel.cs
@@ -22,7 +22,7 @@ namespace MLAgents.SideChannels
         }
 
         /// <inheritdoc/>
-        public override void OnMessageReceived(IncomingMessage msg)
+        protected override void OnMessageReceived(IncomingMessage msg)
         {
             m_MessagesReceived.Add(msg.GetRawBytes());
         }

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannel.cs
@@ -32,12 +32,20 @@ namespace MLAgents.SideChannels
             protected set;
         }
 
+        internal void ProcessMessage(byte[] msg)
+        {
+            using (var incomingMsg = new IncomingMessage(msg))
+            {
+                OnMessageReceived(incomingMsg);
+            }
+        }
+
         /// <summary>
         /// Is called by the communicator every time a message is received from Python by the SideChannel.
         /// Can be called multiple times per simulation step if multiple messages were sent.
         /// </summary>
         /// <param name="msg">The incoming message.</param>
-        public abstract void OnMessageReceived(IncomingMessage msg);
+        protected abstract void OnMessageReceived(IncomingMessage msg);
 
         /// <summary>
         /// Queues a message to be sent to Python during the next simulation step.

--- a/com.unity.ml-agents/Runtime/SideChannels/SideChannelsManager.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/SideChannelsManager.cs
@@ -42,10 +42,7 @@ namespace MLAgents.SideChannels
                 var cachedMessage = m_CachedMessages.Dequeue();
                 if (channelId == cachedMessage.ChannelId)
                 {
-                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
-                    {
-                        sideChannel.OnMessageReceived(incomingMsg);
-                    }
+                    sideChannel.ProcessMessage(cachedMessage.Message);
                 }
                 else
                 {
@@ -160,10 +157,7 @@ namespace MLAgents.SideChannels
                 var cachedMessage = m_CachedMessages.Dequeue();
                 if (sideChannels.ContainsKey(cachedMessage.ChannelId))
                 {
-                    using (var incomingMsg = new IncomingMessage(cachedMessage.Message))
-                    {
-                        sideChannels[cachedMessage.ChannelId].OnMessageReceived(incomingMsg);
-                    }
+                    sideChannels[cachedMessage.ChannelId].ProcessMessage(cachedMessage.Message);
                 }
                 else
                 {
@@ -200,10 +194,7 @@ namespace MLAgents.SideChannels
                         }
                         if (sideChannels.ContainsKey(channelId))
                         {
-                            using (var incomingMsg = new IncomingMessage(message))
-                            {
-                                sideChannels[channelId].OnMessageReceived(incomingMsg);
-                            }
+                            sideChannels[channelId].ProcessMessage(message);
                         }
                         else
                         {

--- a/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/StatsSideChannel.cs
@@ -35,7 +35,7 @@ namespace MLAgents.SideChannels
         }
 
         /// <inheritdoc/>
-        public override void OnMessageReceived(IncomingMessage msg)
+        protected override void OnMessageReceived(IncomingMessage msg)
         {
             throw new UnityAgentsException("StatsSideChannel should never receive messages.");
         }

--- a/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/SideChannelTests.cs
@@ -18,7 +18,7 @@ namespace MLAgents.Tests
                 ChannelId = new Guid("6afa2c06-4f82-11ea-b238-784f4387d1f7");
             }
 
-            public override void OnMessageReceived(IncomingMessage msg)
+            protected override void OnMessageReceived(IncomingMessage msg)
             {
                 messagesReceived.Add(msg.ReadInt32());
             }

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -281,11 +281,11 @@ The `EngineConfiguration` side channel allows you to modify the time-scale, reso
 `EngineConfigurationChannel` has two methods :
 
  * `set_configuration_parameters` which takes the following arguments:
-   * `width`: Defines the width of the display. Default 80.
-   * `height`: Defines the height of the display. Default 80.
-   * `quality_level`: Defines the quality level of the simulation. Default 1.
-   * `time_scale`: Defines the multiplier for the deltatime in the simulation. If set to a higher value, time will pass faster in the simulation but the physics may perform unpredictably. Default 20.
-   *  `target_frame_rate`: Instructs simulation to try to render at a specified frame rate. Default -1.
+   * `width`: Defines the width of the display. (Must be set alongside height)
+   * `height`: Defines the height of the display. (Must be set alongside width)
+   * `quality_level`: Defines the quality level of the simulation.
+   * `time_scale`: Defines the multiplier for the deltatime in the simulation. If set to a higher value, time will pass faster in the simulation but the physics may perform unpredictably.
+   *  `target_frame_rate`: Instructs simulation to try to render at a specified frame rate.
  * `set_configuration` with argument config which is an `EngineConfig`
  NamedTuple object.
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -286,6 +286,7 @@ The `EngineConfiguration` side channel allows you to modify the time-scale, reso
    * `quality_level`: Defines the quality level of the simulation.
    * `time_scale`: Defines the multiplier for the deltatime in the simulation. If set to a higher value, time will pass faster in the simulation but the physics may perform unpredictably.
    *  `target_frame_rate`: Instructs simulation to try to render at a specified frame rate.
+   *  `capture_frame_rate` Instructs the simulation to consider time between updates to always be constant, regardless of the actual frame rate.
  * `set_configuration` with argument config which is an `EngineConfig`
  NamedTuple object.
 

--- a/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
@@ -1,7 +1,8 @@
 from mlagents_envs.side_channel import SideChannel, OutgoingMessage, IncomingMessage
 from mlagents_envs.exception import UnityCommunicationException
 import uuid
-from typing import NamedTuple
+from typing import NamedTuple, Optional
+from enum import IntEnum
 
 
 class EngineConfig(NamedTuple):
@@ -10,6 +11,7 @@ class EngineConfig(NamedTuple):
     quality_level: int
     time_scale: float
     target_frame_rate: int
+    capture_frame_rate: int
 
     @staticmethod
     def default_config():
@@ -25,7 +27,15 @@ class EngineConfigurationChannel(SideChannel):
      - int qualityLevel;
      - float timeScale;
      - int targetFrameRate;
+     - int captureFrameRate;
     """
+
+    class ConfigurationType(IntEnum):
+        SCREEN = (0,)
+        QUALITY_LEVEL = (1,)
+        TIME_SCALE = (2,)
+        TARGET_FRAME_RATE = (3,)
+        CAPTURE_FRAME_RATE = 4
 
     def __init__(self) -> None:
         super().__init__(uuid.UUID("e951342c-4f7e-11ea-b238-784f4387d1f7"))
@@ -45,32 +55,59 @@ class EngineConfigurationChannel(SideChannel):
 
     def set_configuration_parameters(
         self,
-        width: int = 80,
-        height: int = 80,
-        quality_level: int = 1,
-        time_scale: float = 20.0,
-        target_frame_rate: int = -1,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        quality_level: Optional[int] = None,
+        time_scale: Optional[float] = None,
+        target_frame_rate: Optional[int] = None,
+        capture_frame_rate: Optional[int] = None,
     ) -> None:
         """
         Sets the engine configuration. Takes as input the configurations of the
         engine.
-        :param width: Defines the width of the display. Default 80.
-        :param height: Defines the height of the display. Default 80.
+        :param width: Defines the width of the display. (Must be set alongside height)
+        :param height: Defines the height of the display. (Must be set alongside width)
         :param quality_level: Defines the quality level of the simulation.
-        Default 1.
         :param time_scale: Defines the multiplier for the deltatime in the
         simulation. If set to a higher value, time will pass faster in the
-        simulation but the physics might break. Default 20.
+        simulation but the physics might break.
         :param target_frame_rate: Instructs simulation to try to render at a
-        specified frame rate. Default -1.
+        specified frame rate.
+        :param capture_frame_rate: Instructs the simulation to consider time between
+        updates to always be constant, regardless of the actual frame rate.
         """
-        msg = OutgoingMessage()
-        msg.write_int32(width)
-        msg.write_int32(height)
-        msg.write_int32(quality_level)
-        msg.write_float32(time_scale)
-        msg.write_int32(target_frame_rate)
-        super().queue_message_to_send(msg)
+        if width is not None and height is not None:
+            screen_msg = OutgoingMessage()
+            screen_msg.write_int32(self.ConfigurationType.SCREEN)
+            screen_msg.write_int32(width)
+            screen_msg.write_int32(height)
+            super().queue_message_to_send(screen_msg)
+
+        if quality_level is not None:
+            quality_level_msg = OutgoingMessage()
+            quality_level_msg.write_int32(self.ConfigurationType.QUALITY_LEVEL)
+            quality_level_msg.write_int32(quality_level)
+            super().queue_message_to_send(quality_level_msg)
+
+        if time_scale is not None:
+            time_scale_msg = OutgoingMessage()
+            time_scale_msg.write_int32(self.ConfigurationType.TIME_SCALE)
+            time_scale_msg.write_float32(time_scale)
+            super().queue_message_to_send(time_scale_msg)
+
+        if target_frame_rate is not None:
+            target_frame_rate_msg = OutgoingMessage()
+            target_frame_rate_msg.write_int32(self.ConfigurationType.TARGET_FRAME_RATE)
+            target_frame_rate_msg.write_int32(target_frame_rate)
+            super().queue_message_to_send(target_frame_rate_msg)
+
+        if capture_frame_rate is not None:
+            capture_frame_rate_msg = OutgoingMessage()
+            capture_frame_rate_msg.write_int32(
+                self.ConfigurationType.CAPTURE_FRAME_RATE
+            )
+            capture_frame_rate_msg.write_int32(capture_frame_rate)
+            super().queue_message_to_send(capture_frame_rate_msg)
 
     def set_configuration(self, config: EngineConfig) -> None:
         """

--- a/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
@@ -15,7 +15,7 @@ class EngineConfig(NamedTuple):
 
     @staticmethod
     def default_config():
-        return EngineConfig(80, 80, 1, 20.0, -1)
+        return EngineConfig(80, 80, 1, 20.0, -1, 60)
 
 
 class EngineConfigurationChannel(SideChannel):

--- a/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
@@ -1,5 +1,8 @@
 from mlagents_envs.side_channel import SideChannel, OutgoingMessage, IncomingMessage
-from mlagents_envs.exception import UnityCommunicationException
+from mlagents_envs.exception import (
+    UnityCommunicationException,
+    UnitySideChannelException,
+)
 import uuid
 from typing import NamedTuple, Optional
 from enum import IntEnum
@@ -31,10 +34,10 @@ class EngineConfigurationChannel(SideChannel):
     """
 
     class ConfigurationType(IntEnum):
-        SCREEN = (0,)
-        QUALITY_LEVEL = (1,)
-        TIME_SCALE = (2,)
-        TARGET_FRAME_RATE = (3,)
+        SCREEN_RESOLUTION = 0
+        QUALITY_LEVEL = 1
+        TIME_SCALE = 2
+        TARGET_FRAME_RATE = 3
         CAPTURE_FRAME_RATE = 4
 
     def __init__(self) -> None:
@@ -76,9 +79,17 @@ class EngineConfigurationChannel(SideChannel):
         :param capture_frame_rate: Instructs the simulation to consider time between
         updates to always be constant, regardless of the actual frame rate.
         """
+
+        if (width is None and height is not None) or (
+            width is not None and height is None
+        ):
+            raise UnitySideChannelException(
+                "You cannot set the width/height of the screen resolution without also setting the height/width"
+            )
+
         if width is not None and height is not None:
             screen_msg = OutgoingMessage()
-            screen_msg.write_int32(self.ConfigurationType.SCREEN)
+            screen_msg.write_int32(self.ConfigurationType.SCREEN_RESOLUTION)
             screen_msg.write_int32(width)
             screen_msg.write_int32(height)
             super().queue_message_to_send(screen_msg)

--- a/ml-agents-envs/mlagents_envs/side_channel/environment_parameters_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/environment_parameters_channel.py
@@ -1,0 +1,37 @@
+from mlagents_envs.side_channel import SideChannel, IncomingMessage, OutgoingMessage
+from mlagents_envs.exception import UnityCommunicationException
+import uuid
+from enum import IntEnum
+
+
+class EnvironmentParametersChannel(SideChannel):
+    """
+    This is the SideChannel for sending environment parameters to Unity.
+    You can send parameters to an environment with the command
+    set_float_property.
+    """
+
+    class EnvironmentDataTypes(IntEnum):
+        FLOAT = 0
+
+    def __init__(self) -> None:
+        channel_id = uuid.UUID(("534c891e-810f-11ea-a9d0-822485860400"))
+        super().__init__(channel_id)
+
+    def on_message_received(self, msg: IncomingMessage) -> None:
+        raise UnityCommunicationException(
+            "The EnvironmentParametersChannel received a message from Unity, "
+            + "this should not have happend."
+        )
+
+    def set_float_property(self, key: str, value: float) -> None:
+        """
+        Sets a float environment parameter in the Unity Environment.
+        :param key: The string identifier of the parameter.
+        :param value: The float value of the parameter.
+        """
+        msg = OutgoingMessage()
+        msg.write_string(key)
+        msg.write_int32(self.EnvironmentDataTypes.FLOAT)
+        msg.write_float32(value)
+        super().queue_message_to_send(msg)

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -72,11 +72,6 @@ class EnvManager(ABC):
     def external_brains(self) -> Dict[BehaviorName, BrainParameters]:
         pass
 
-    @property
-    @abstractmethod
-    def get_properties(self) -> Dict[BehaviorName, float]:
-        pass
-
     @abstractmethod
     def close(self):
         pass

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -234,6 +234,13 @@ def _create_parser():
         help="The target frame rate of the Unity environment(s). Equivalent to setting "
         "Application.targetFrameRate in Unity.",
     )
+    eng_conf.add_argument(
+        "--capture-frame-rate",
+        default=60,
+        type=int,
+        help="The capture frame rate of the Unity environment(s). Equivalent to setting "
+        "Time.captureFramerate in Unity.",
+    )
     return argparser
 
 
@@ -268,6 +275,7 @@ class RunOptions(NamedTuple):
     quality_level: int = parser.get_default("quality_level")
     time_scale: float = parser.get_default("time_scale")
     target_frame_rate: int = parser.get_default("target_frame_rate")
+    capture_frame_rate: int = parser.get_default("capture_frame_rate")
 
     @staticmethod
     def from_argparse(args: argparse.Namespace) -> "RunOptions":
@@ -353,11 +361,12 @@ def run_training(run_seed: int, options: RunOptions) -> None:
             options.env_path, options.no_graphics, run_seed, port, options.env_args
         )
         engine_config = EngineConfig(
-            options.width,
-            options.height,
-            options.quality_level,
-            options.time_scale,
-            options.target_frame_rate,
+            width=options.width,
+            height=options.height,
+            quality_level=options.quality_level,
+            time_scale=options.time_scale,
+            target_frame_rate=options.target_frame_rate,
+            capture_frame_rate=options.capture_frame_rate,
         )
         env_manager = SubprocessEnvManager(env_factory, engine_config, options.num_envs)
         maybe_meta_curriculum = try_create_meta_curriculum(

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -16,7 +16,9 @@ from mlagents.trainers.simple_env_manager import SimpleEnvManager
 from mlagents.trainers.sampler_class import SamplerManager
 from mlagents.trainers.demo_loader import write_demo
 from mlagents.trainers.stats import StatsReporter, StatsWriter, StatsSummary
-from mlagents_envs.side_channel.float_properties_channel import FloatPropertiesChannel
+from mlagents_envs.side_channel.environment_parameters_channel import (
+    EnvironmentParametersChannel,
+)
 from mlagents_envs.communicator_objects.demonstration_meta_pb2 import (
     DemonstrationMetaProto,
 )
@@ -139,7 +141,7 @@ def _check_environment_trains(
         debug_writer = DebugWriter()
         StatsReporter.add_writer(debug_writer)
         if env_manager is None:
-            env_manager = SimpleEnvManager(env, FloatPropertiesChannel())
+            env_manager = SimpleEnvManager(env, EnvironmentParametersChannel())
         trainer_factory = TrainerFactory(
             trainer_config=trainer_config,
             summaries_dir=dir,


### PR DESCRIPTION
### Proposed change(s)

 - Updating the engine config side channel to include capture framerate as the last field. This will require adding a new CLI option that has a default value of 60.
 - Creating EnvironmentParameters side channel that is uni-directional Python to Unity with the message format of: string, int, block. The int represents an enum value that is equivalent to the 
 - EnvironmentDataTypes enum in EnvironmentParametersChannel.cs
Switch from using floatproperties to the new environment parameters side channel
 - Make OnMessageReceived protected
 - Make the engine config send one message per config field 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
