### PR TITLE
Code Style - apply PascalCase

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
@@ -30,7 +30,7 @@ public class HallwayAgent : Agent
     {
         if (useVectorObs)
         {
-            sensor.AddObservation(StepCount / (float)maxStep);
+            sensor.AddObservation(StepCount / (float)MaxStep);
         }
     }
 
@@ -68,7 +68,7 @@ public class HallwayAgent : Agent
 
     public override void OnActionReceived(float[] vectorAction)
     {
-        AddReward(-1f / maxStep);
+        AddReward(-1f / MaxStep);
         MoveAgent(vectorAction);
     }
 

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -167,7 +167,7 @@ public class PushAgentBasic : Agent
         MoveAgent(vectorAction);
 
         // Penalty given each step to encourage agent to finish task quickly.
-        AddReward(-1f / maxStep);
+        AddReward(-1f / MaxStep);
     }
 
     public override void Heuristic(float[] actionsOut)

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
@@ -57,7 +57,7 @@ public class PyramidAgent : Agent
 
     public override void OnActionReceived(float[] vectorAction)
     {
-        AddReward(-1f / maxStep);
+        AddReward(-1f / MaxStep);
         MoveAgent(vectorAction);
     }
 

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -87,10 +87,10 @@ namespace MLAgentsExamples
             if (m_MaxEpisodes > 0)
             {
                 // For Agents without maxSteps, exit as soon as we've hit the target number of episodes.
-                // For Agents that specify maxStep, also make sure we've gone at least that many steps.
+                // For Agents that specify MaxStep, also make sure we've gone at least that many steps.
                 // Since we exit as soon as *any* Agent hits its target, the maxSteps condition keeps us running
                 // a bit longer in case there's an early failure.
-                if (m_Agent.CompletedEpisodes >= m_MaxEpisodes && m_NumSteps > m_MaxEpisodes * m_Agent.maxStep)
+                if (m_Agent.CompletedEpisodes >= m_MaxEpisodes && m_NumSteps > m_MaxEpisodes * m_Agent.MaxStep)
                 {
                     Application.Quit(0);
                 }
@@ -107,7 +107,7 @@ namespace MLAgentsExamples
 
             if (!m_BehaviorNameOverrides.ContainsKey(behaviorName))
             {
-                Debug.Log($"No override for behaviorName {behaviorName}");
+                Debug.Log($"No override for BehaviorName {behaviorName}");
                 return null;
             }
 
@@ -142,7 +142,7 @@ namespace MLAgentsExamples
         {
             m_Agent.LazyInitialize();
             var bp = m_Agent.GetComponent<BehaviorParameters>();
-            var name = bp.behaviorName;
+            var name = bp.BehaviorName;
 
             var nnModel = GetModelForBehaviorName(name);
             Debug.Log($"Overriding behavior {name} for agent with model {nnModel?.name}");

--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
@@ -51,7 +51,7 @@ public class AgentSoccer : Agent
 
     public override void Initialize()
     {
-        m_Existential = 1f / maxStep;
+        m_Existential = 1f / MaxStep;
         m_BehaviorParameters = gameObject.GetComponent<BehaviorParameters>();
         if (m_BehaviorParameters.TeamId == (int)Team.Blue)
         {

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to
   `UnityToGymWrapper` and no longer creates the `UnityEnvironment`.
   Instead, the `UnityEnvironment` must be passed as input to the
   constructor of `UnityToGymWrapper`
+- Public fields and properties on several classes were renamed to follow Unity's
+  C# style conventions. All public fields and properties now use "PascalCase"
+  instead of "camelCase"; for example, `Agent.maxStep` was renamed to
+  `Agent.MaxStep`. For a full list of changes, see the pull request. (#3828)
 
 ### Minor Changes
 

--- a/com.unity.ml-agents/Editor/AgentEditor.cs
+++ b/com.unity.ml-agents/Editor/AgentEditor.cs
@@ -15,13 +15,12 @@ namespace MLAgents.Editor
             var serializedAgent = serializedObject;
             serializedAgent.Update();
 
-            var maxSteps = serializedAgent.FindProperty(
-                "maxStep");
+            var maxSteps = serializedAgent.FindProperty("MaxStep");
 
             EditorGUILayout.PropertyField(
                 maxSteps,
-                new GUIContent(
-                    "Max Step", "The per-agent maximum number of steps."));
+                new GUIContent("Max Step", "The per-agent maximum number of steps.")
+            );
 
             serializedAgent.ApplyModifiedProperties();
 

--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -90,7 +90,7 @@ namespace MLAgents.Editor
             var model = (NNModel)serializedObject.FindProperty("m_Model").objectReferenceValue;
             var behaviorParameters = (BehaviorParameters)target;
             SensorComponent[] sensorComponents;
-            if (behaviorParameters.useChildSensors)
+            if (behaviorParameters.UseChildSensors)
             {
                 sensorComponents = behaviorParameters.GetComponentsInChildren<SensorComponent>();
             }
@@ -98,7 +98,7 @@ namespace MLAgents.Editor
             {
                 sensorComponents = behaviorParameters.GetComponents<SensorComponent>();
             }
-            var brainParameters = behaviorParameters.brainParameters;
+            var brainParameters = behaviorParameters.BrainParameters;
             if (model != null)
             {
                 barracudaModel = ModelLoader.Load(model);
@@ -106,7 +106,7 @@ namespace MLAgents.Editor
             if (brainParameters != null)
             {
                 var failedChecks = Inference.BarracudaModelParamLoader.CheckModel(
-                    barracudaModel, brainParameters, sensorComponents, behaviorParameters.behaviorType
+                    barracudaModel, brainParameters, sensorComponents, behaviorParameters.BehaviorType
                 );
                 foreach (var check in failedChecks)
                 {

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -14,11 +14,11 @@ namespace MLAgents.Editor
         // The height of a line in the Unity Inspectors
         const float k_LineHeight = 17f;
         const int k_VecObsNumLine = 3;
-        const string k_ActionSizePropName = "vectorActionSize";
-        const string k_ActionTypePropName = "vectorActionSpaceType";
-        const string k_ActionDescriptionPropName = "vectorActionDescriptions";
-        const string k_VecObsPropName = "vectorObservationSize";
-        const string k_NumVecObsPropName = "numStackedVectorObservations";
+        const string k_ActionSizePropName = "VectorActionSize";
+        const string k_ActionTypePropName = "VectorActionSpaceType";
+        const string k_ActionDescriptionPropName = "VectorActionDescriptions";
+        const string k_VecObsPropName = "VectorObservationSize";
+        const string k_NumVecObsPropName = "NumStackedVectorObservations";
 
         /// <inheritdoc />
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)

--- a/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
@@ -72,8 +72,8 @@ namespace MLAgents.Editor
         /// </summary>
         void MakeActionsProperty(SerializedProperty property)
         {
-            var actSizeProperty = property.FindPropertyRelative("vectorActionSize");
-            var actSpaceTypeProp = property.FindPropertyRelative("vectorActionSpaceType");
+            var actSizeProperty = property.FindPropertyRelative("VectorActionSize");
+            var actSpaceTypeProp = property.FindPropertyRelative("VectorActionSpaceType");
 
             var vecActSizeLabel =
                 actSizeProperty.displayName + ": " + BuildIntArrayLabel(actSizeProperty);

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -478,7 +478,7 @@ namespace MLAgents
         /// NNModel and the InferenceDevice as provided.
         /// </summary>
         /// <param name="model">The NNModel the ModelRunner must use.</param>
-        /// <param name="brainParameters">The brainParameters used to create the ModelRunner.</param>
+        /// <param name="brainParameters">The BrainParameters used to create the ModelRunner.</param>
         /// <param name="inferenceDevice">
         /// The inference device (CPU or GPU) the ModelRunner will use.
         /// </param>

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -5,6 +5,7 @@ using Barracuda;
 using MLAgents.Sensors;
 using MLAgents.Demonstrations;
 using MLAgents.Policies;
+using UnityEngine.Serialization;
 
 namespace MLAgents
 {
@@ -110,7 +111,7 @@ namespace MLAgents
         IPolicy m_Brain;
         BehaviorParameters m_PolicyFactory;
 
-        /// This code is here to make the upgrade path for users using maxStep
+        /// This code is here to make the upgrade path for users using MaxStep
         /// easier. We will hook into the Serialization code and make sure that
         /// agentParameters.maxStep and this.maxStep are in sync.
         [Serializable]
@@ -134,7 +135,8 @@ namespace MLAgents
         /// that many steps. Note that setting the max step to a value greater
         /// than the academy max step value renders it useless.
         /// </remarks>
-        [HideInInspector] public int maxStep;
+        [FormerlySerializedAs("maxStep")]
+        [HideInInspector] public int MaxStep;
 
         /// Current Agent information (message sent to Brain).
         AgentInfo m_Info;
@@ -211,11 +213,11 @@ namespace MLAgents
         /// </summary>
         public void OnBeforeSerialize()
         {
-            // Manages a serialization upgrade issue from v0.13 to v0.14 where maxStep moved
+            // Manages a serialization upgrade issue from v0.13 to v0.14 where MaxStep moved
             // from AgentParameters (since removed) to Agent
-            if (maxStep == 0 && maxStep != agentParameters.maxStep && !hasUpgradedFromAgentParameters)
+            if (MaxStep == 0 && MaxStep != agentParameters.maxStep && !hasUpgradedFromAgentParameters)
             {
-                maxStep = agentParameters.maxStep;
+                MaxStep = agentParameters.maxStep;
             }
             hasUpgradedFromAgentParameters = true;
         }
@@ -225,11 +227,11 @@ namespace MLAgents
         /// </summary>
         public void OnAfterDeserialize()
         {
-            // Manages a serialization upgrade issue from v0.13 to v0.14 where maxStep moved
+            // Manages a serialization upgrade issue from v0.13 to v0.14 where MaxStep moved
             // from AgentParameters (since removed) to Agent
-            if (maxStep == 0 && maxStep != agentParameters.maxStep && !hasUpgradedFromAgentParameters)
+            if (MaxStep == 0 && MaxStep != agentParameters.maxStep && !hasUpgradedFromAgentParameters)
             {
-                maxStep = agentParameters.maxStep;
+                MaxStep = agentParameters.maxStep;
             }
             hasUpgradedFromAgentParameters = true;
         }
@@ -376,17 +378,17 @@ namespace MLAgents
             NNModel model,
             InferenceDevice inferenceDevice = InferenceDevice.CPU)
         {
-            if (behaviorName == m_PolicyFactory.behaviorName &&
-                model == m_PolicyFactory.model &&
-                inferenceDevice == m_PolicyFactory.inferenceDevice)
+            if (behaviorName == m_PolicyFactory.BehaviorName &&
+                model == m_PolicyFactory.Model &&
+                inferenceDevice == m_PolicyFactory.InferenceDevice)
             {
                 // If everything is the same, don't make any changes.
                 return;
             }
             NotifyAgentDone(DoneReason.Disabled);
-            m_PolicyFactory.model = model;
-            m_PolicyFactory.inferenceDevice = inferenceDevice;
-            m_PolicyFactory.behaviorName = behaviorName;
+            m_PolicyFactory.Model = model;
+            m_PolicyFactory.InferenceDevice = inferenceDevice;
+            m_PolicyFactory.BehaviorName = behaviorName;
             ReloadPolicy();
         }
 
@@ -463,7 +465,7 @@ namespace MLAgents
 
         void UpdateRewardStats()
         {
-            var gaugeName = $"{m_PolicyFactory.behaviorName}.CumulativeReward";
+            var gaugeName = $"{m_PolicyFactory.BehaviorName}.CumulativeReward";
             TimerStack.Instance.SetGauge(gaugeName, GetCumulativeReward());
         }
 
@@ -498,7 +500,7 @@ namespace MLAgents
         /// at the end of an episode.
         void ResetData()
         {
-            var param = m_PolicyFactory.brainParameters;
+            var param = m_PolicyFactory.BrainParameters;
             m_ActionMasker = new DiscreteActionMasker(param);
             // If we haven't initialized vectorActions, initialize to 0. This should only
             // happen during the creation of the Agent. In subsequent episodes, vectorAction
@@ -541,7 +543,7 @@ namespace MLAgents
         {
             // Get all attached sensor components
             SensorComponent[] attachedSensorComponents;
-            if (m_PolicyFactory.useChildSensors)
+            if (m_PolicyFactory.UseChildSensors)
             {
                 attachedSensorComponents = GetComponentsInChildren<SensorComponent>();
             }
@@ -557,7 +559,7 @@ namespace MLAgents
             }
 
             // Support legacy CollectObservations
-            var param = m_PolicyFactory.brainParameters;
+            var param = m_PolicyFactory.BrainParameters;
             if (param.vectorObservationSize > 0)
             {
                 collectObservationsSensor = new VectorSensor(param.vectorObservationSize);
@@ -619,7 +621,7 @@ namespace MLAgents
             }
             using (TimerStack.Instance.Scoped("CollectDiscreteActionMasks"))
             {
-                if (m_PolicyFactory.brainParameters.vectorActionSpaceType == SpaceType.Discrete)
+                if (m_PolicyFactory.BrainParameters.vectorActionSpaceType == SpaceType.Discrete)
                 {
                     CollectDiscreteActionMasks(m_ActionMasker);
                 }
@@ -787,7 +789,7 @@ namespace MLAgents
                 OnActionReceived(m_Action.vectorActions);
             }
 
-            if ((m_StepCount >= maxStep) && (maxStep > 0))
+            if ((m_StepCount >= MaxStep) && (MaxStep > 0))
             {
                 NotifyAgentDone(DoneReason.MaxStepReached);
                 _AgentReset();

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -507,8 +507,8 @@ namespace MLAgents
             // should stay the previous action before the Done(), so that it is properly recorded.
             if (m_Action.vectorActions == null)
             {
-                m_Action.vectorActions = new float[param.numActions];
-                m_Info.storedVectorActions = new float[param.numActions];
+                m_Action.vectorActions = new float[param.NumActions];
+                m_Info.storedVectorActions = new float[param.NumActions];
             }
         }
 
@@ -560,13 +560,13 @@ namespace MLAgents
 
             // Support legacy CollectObservations
             var param = m_PolicyFactory.BrainParameters;
-            if (param.vectorObservationSize > 0)
+            if (param.VectorObservationSize > 0)
             {
-                collectObservationsSensor = new VectorSensor(param.vectorObservationSize);
-                if (param.numStackedVectorObservations > 1)
+                collectObservationsSensor = new VectorSensor(param.VectorObservationSize);
+                if (param.NumStackedVectorObservations > 1)
                 {
                     var stackingSensor = new StackingSensor(
-                        collectObservationsSensor, param.numStackedVectorObservations);
+                        collectObservationsSensor, param.NumStackedVectorObservations);
                     sensors.Add(stackingSensor);
                 }
                 else
@@ -621,7 +621,7 @@ namespace MLAgents
             }
             using (TimerStack.Instance.Scoped("CollectDiscreteActionMasks"))
             {
-                if (m_PolicyFactory.BrainParameters.vectorActionSpaceType == SpaceType.Discrete)
+                if (m_PolicyFactory.BrainParameters.VectorActionSpaceType == SpaceType.Discrete)
                 {
                     CollectDiscreteActionMasks(m_ActionMasker);
                 }
@@ -685,7 +685,7 @@ namespace MLAgents
         /// Depending on your environment, any combination of these helpers can
         /// be used. They just need to be used in the exact same order each time
         /// this method is called and the resulting size of the vector observation
-        /// needs to match the vectorObservationSize attribute of the linked Brain.
+        /// needs to match the VectorObservationSize attribute of the linked Brain.
         /// Visual observations are implicitly added from the cameras attached to
         /// the Agent.
         /// </remarks>

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -748,7 +748,7 @@ namespace MLAgents
         ///
         /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
         /// </remarks>
-        public virtual void Initialize(){}
+        public virtual void Initialize() {}
 
         /// <summary>
         /// Implement `Heuristic()` to choose an action for this agent using a custom heuristic.
@@ -800,6 +800,7 @@ namespace MLAgents
         /// [Input Manager]: https://docs.unity3d.com/Manual/class-InputManager.html
         /// [Input System package]: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/manual/index.html
         /// </example>
+        /// <param name="actionsOut">Array for the output actions.</param>
         /// <seealso cref="OnActionReceived(float[])"/>
         public virtual void Heuristic(float[] actionsOut)
         {
@@ -1078,7 +1079,7 @@ namespace MLAgents
         /// by the <see cref="BrainParameters"/> of the agent's associated
         /// <see cref="BehaviorParameters"/> component.
         /// </param>
-        public virtual void OnActionReceived(float[] vectorAction){}
+        public virtual void OnActionReceived(float[] vectorAction) {}
 
         /// <summary>
         /// Implement `OnEpisodeBegin()` to set up an Agent instance at the beginning

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -94,13 +94,13 @@ namespace MLAgents
         {
             var brainParametersProto = new BrainParametersProto
             {
-                VectorActionSize = { bp.vectorActionSize },
+                VectorActionSize = { bp.VectorActionSize },
                 VectorActionSpaceType =
-                    (SpaceTypeProto)bp.vectorActionSpaceType,
+                    (SpaceTypeProto)bp.VectorActionSpaceType,
                 BrainName = name,
                 IsTraining = isTraining
             };
-            brainParametersProto.VectorActionDescriptions.AddRange(bp.vectorActionDescriptions);
+            brainParametersProto.VectorActionDescriptions.AddRange(bp.VectorActionDescriptions);
             return brainParametersProto;
         }
 
@@ -113,9 +113,9 @@ namespace MLAgents
         {
             var bp = new BrainParameters
             {
-                vectorActionSize = bpp.VectorActionSize.ToArray(),
-                vectorActionDescriptions = bpp.VectorActionDescriptions.ToArray(),
-                vectorActionSpaceType = (SpaceType)bpp.VectorActionSpaceType
+                VectorActionSize = bpp.VectorActionSize.ToArray(),
+                VectorActionDescriptions = bpp.VectorActionDescriptions.ToArray(),
+                VectorActionSpaceType = (SpaceType)bpp.VectorActionSpaceType
             };
             return bp;
         }

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -81,7 +81,7 @@ namespace MLAgents.Demonstrations
             var behaviorParams = GetComponent<BehaviorParameters>();
             if (string.IsNullOrEmpty(DemonstrationName))
             {
-                DemonstrationName = behaviorParams.behaviorName;
+                DemonstrationName = behaviorParams.BehaviorName;
             }
             if (string.IsNullOrEmpty(DemonstrationDirectory))
             {
@@ -179,8 +179,8 @@ namespace MLAgents.Demonstrations
             var behaviorParams = GetComponent<BehaviorParameters>();
             demoWriter.Initialize(
                 DemonstrationName,
-                behaviorParams.brainParameters,
-                behaviorParams.fullyQualifiedBehaviorName
+                behaviorParams.BrainParameters,
+                behaviorParams.FullyQualifiedBehaviorName
             );
             m_Agent.DemonstrationWriters.Add(demoWriter);
         }

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using UnityEngine;
 using System.IO;
 using MLAgents.Policies;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Demonstrations
 {
@@ -16,24 +17,27 @@ namespace MLAgents.Demonstrations
         /// <summary>
         /// Whether or not to record demonstrations.
         /// </summary>
+        [FormerlySerializedAs("record")]
         [Tooltip("Whether or not to record demonstrations.")]
-        public bool record;
+        public bool Record;
 
         /// <summary>
         /// Base demonstration file name. If multiple files are saved, the additional filenames
         /// will have a sequence of unique numbers appended.
         /// </summary>
+        [FormerlySerializedAs("demonstrationName")]
         [Tooltip("Base demonstration file name. If multiple files are saved, the additional " +
                  "filenames will have a unique number appended.")]
-        public string demonstrationName;
+        public string DemonstrationName;
 
         /// <summary>
         /// Directory to save the demo files. Will default to a "Demonstrations/" folder in the
         /// Application data path if not specified.
         /// </summary>
+        [FormerlySerializedAs("demonstrationDirectory")]
         [Tooltip("Directory to save the demo files. Will default to " +
                  "{Application.dataPath}/Demonstrations if not specified.")]
-        public string demonstrationDirectory;
+        public string DemonstrationDirectory;
 
         DemonstrationWriter m_DemoWriter;
         internal const int MaxNameLength = 16;
@@ -51,7 +55,7 @@ namespace MLAgents.Demonstrations
 
         void Update()
         {
-            if (record)
+            if (Record)
             {
                 LazyInitialize();
             }
@@ -75,17 +79,17 @@ namespace MLAgents.Demonstrations
 
             m_FileSystem = fileSystem ?? new FileSystem();
             var behaviorParams = GetComponent<BehaviorParameters>();
-            if (string.IsNullOrEmpty(demonstrationName))
+            if (string.IsNullOrEmpty(DemonstrationName))
             {
-                demonstrationName = behaviorParams.behaviorName;
+                DemonstrationName = behaviorParams.behaviorName;
             }
-            if (string.IsNullOrEmpty(demonstrationDirectory))
+            if (string.IsNullOrEmpty(DemonstrationDirectory))
             {
-                demonstrationDirectory = Path.Combine(Application.dataPath, k_DefaultDirectoryName);
+                DemonstrationDirectory = Path.Combine(Application.dataPath, k_DefaultDirectoryName);
             }
 
-            demonstrationName = SanitizeName(demonstrationName, MaxNameLength);
-            var filePath = MakeDemonstrationFilePath(m_FileSystem, demonstrationDirectory, demonstrationName);
+            DemonstrationName = SanitizeName(DemonstrationName, MaxNameLength);
+            var filePath = MakeDemonstrationFilePath(m_FileSystem, DemonstrationDirectory, DemonstrationName);
             var stream = m_FileSystem.File.Create(filePath);
             m_DemoWriter = new DemonstrationWriter(stream);
 
@@ -111,7 +115,7 @@ namespace MLAgents.Demonstrations
         }
 
         /// <summary>
-        /// Gets a unique path for the demonstrationName in the demonstrationDirectory.
+        /// Gets a unique path for the DemonstrationName in the DemonstrationDirectory.
         /// </summary>
         /// <param name="fileSystem"></param>
         /// <param name="demonstrationDirectory"></param>
@@ -174,7 +178,7 @@ namespace MLAgents.Demonstrations
         {
             var behaviorParams = GetComponent<BehaviorParameters>();
             demoWriter.Initialize(
-                demonstrationName,
+                DemonstrationName,
                 behaviorParams.brainParameters,
                 behaviorParams.fullyQualifiedBehaviorName
             );

--- a/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
+++ b/com.unity.ml-agents/Runtime/DiscreteActionMasker.cs
@@ -38,11 +38,11 @@ namespace MLAgents
         public void SetMask(int branch, IEnumerable<int> actionIndices)
         {
             // If the branch does not exist, raise an error
-            if (branch >= m_BrainParameters.vectorActionSize.Length)
+            if (branch >= m_BrainParameters.VectorActionSize.Length)
                 throw new UnityAgentsException(
                     "Invalid Action Masking : Branch " + branch + " does not exist.");
 
-            var totalNumberActions = m_BrainParameters.vectorActionSize.Sum();
+            var totalNumberActions = m_BrainParameters.VectorActionSize.Sum();
 
             // By default, the masks are null. If we want to specify a new mask, we initialize
             // the actionMasks with trues.
@@ -55,13 +55,13 @@ namespace MLAgents
             // indices for each branch.
             if (m_StartingActionIndices == null)
             {
-                m_StartingActionIndices = Utilities.CumSum(m_BrainParameters.vectorActionSize);
+                m_StartingActionIndices = Utilities.CumSum(m_BrainParameters.VectorActionSize);
             }
 
             // Perform the masking
             foreach (var actionIndex in actionIndices)
             {
-                if (actionIndex >= m_BrainParameters.vectorActionSize[branch])
+                if (actionIndex >= m_BrainParameters.VectorActionSize[branch])
                 {
                     throw new UnityAgentsException(
                         "Invalid Action Masking: Action Mask is too large for specified branch.");
@@ -90,13 +90,13 @@ namespace MLAgents
         void AssertMask()
         {
             // Action Masks can only be used in Discrete Control.
-            if (m_BrainParameters.vectorActionSpaceType != SpaceType.Discrete)
+            if (m_BrainParameters.VectorActionSpaceType != SpaceType.Discrete)
             {
                 throw new UnityAgentsException(
                     "Invalid Action Masking : Can only set action mask for Discrete Control.");
             }
 
-            var numBranches = m_BrainParameters.vectorActionSize.Length;
+            var numBranches = m_BrainParameters.VectorActionSize.Length;
             for (var branchIndex = 0; branchIndex < numBranches; branchIndex++)
             {
                 if (AreAllActionsMasked(branchIndex))

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -267,7 +267,7 @@ namespace MLAgents.Inference
             var tensorsNames = GetInputTensors(model).Select(x => x.name).ToList();
 
             // If there is no Vector Observation Input but the Brain Parameters expect one.
-            if ((brainParameters.vectorObservationSize != 0) &&
+            if ((brainParameters.VectorObservationSize != 0) &&
                 (!tensorsNames.Contains(TensorNames.VectorObservationPlaceholder)))
             {
                 failedModelChecks.Add(
@@ -477,8 +477,8 @@ namespace MLAgents.Inference
         static string CheckVectorObsShape(
             BrainParameters brainParameters, TensorProxy tensorProxy, SensorComponent[] sensorComponents)
         {
-            var vecObsSizeBp = brainParameters.vectorObservationSize;
-            var numStackedVector = brainParameters.numStackedVectorObservations;
+            var vecObsSizeBp = brainParameters.VectorObservationSize;
+            var numStackedVector = brainParameters.NumStackedVectorObservations;
             var totalVecObsSizeT = tensorProxy.shape[tensorProxy.shape.Length - 1];
 
             var totalVectorSensorSize = 0;
@@ -531,7 +531,7 @@ namespace MLAgents.Inference
         static string CheckPreviousActionShape(
             BrainParameters brainParameters, TensorProxy tensorProxy, SensorComponent[] sensorComponents)
         {
-            var numberActionsBp = brainParameters.vectorActionSize.Length;
+            var numberActionsBp = brainParameters.VectorActionSize.Length;
             var numberActionsT = tensorProxy.shape[tensorProxy.shape.Length - 1];
             if (numberActionsBp != numberActionsT)
             {
@@ -574,7 +574,7 @@ namespace MLAgents.Inference
                 return failedModelChecks;
             }
             if (isContinuous == ModelActionType.Continuous &&
-                brainParameters.vectorActionSpaceType != SpaceType.Continuous)
+                brainParameters.VectorActionSpaceType != SpaceType.Continuous)
             {
                 failedModelChecks.Add(
                     "Model has been trained using Continuous Control but the Brain Parameters " +
@@ -582,7 +582,7 @@ namespace MLAgents.Inference
                 return failedModelChecks;
             }
             if (isContinuous == ModelActionType.Discrete &&
-                brainParameters.vectorActionSpaceType != SpaceType.Discrete)
+                brainParameters.VectorActionSpaceType != SpaceType.Discrete)
             {
                 failedModelChecks.Add(
                     "Model has been trained using Discrete Control but the Brain Parameters " +
@@ -590,7 +590,7 @@ namespace MLAgents.Inference
                 return failedModelChecks;
             }
             var tensorTester = new Dictionary<string, Func<BrainParameters, TensorShape, int, string>>();
-            if (brainParameters.vectorActionSpaceType == SpaceType.Continuous)
+            if (brainParameters.VectorActionSpaceType == SpaceType.Continuous)
             {
                 tensorTester[TensorNames.ActionOutput] = CheckContinuousActionOutputShape;
             }
@@ -632,7 +632,7 @@ namespace MLAgents.Inference
         static string CheckDiscreteActionOutputShape(
             BrainParameters brainParameters, TensorShape shape, int modelActionSize)
         {
-            var bpActionSize = brainParameters.vectorActionSize.Sum();
+            var bpActionSize = brainParameters.VectorActionSize.Sum();
             if (modelActionSize != bpActionSize)
             {
                 return "Action Size of the model does not match. The BrainParameters expect " +
@@ -657,7 +657,7 @@ namespace MLAgents.Inference
         static string CheckContinuousActionOutputShape(
             BrainParameters brainParameters, TensorShape shape, int modelActionSize)
         {
-            var bpActionSize = brainParameters.vectorActionSize[0];
+            var bpActionSize = brainParameters.VectorActionSize[0];
             if (modelActionSize != bpActionSize)
             {
                 return "Action Size of the model does not match. The BrainParameters expect " +

--- a/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
@@ -51,14 +51,14 @@ namespace MLAgents.Inference
             Dictionary<int, List<float>> memories,
             object barracudaModel = null)
         {
-            if (bp.vectorActionSpaceType == SpaceType.Continuous)
+            if (bp.VectorActionSpaceType == SpaceType.Continuous)
             {
                 m_Dict[TensorNames.ActionOutput] = new ContinuousActionOutputApplier();
             }
             else
             {
                 m_Dict[TensorNames.ActionOutput] =
-                    new DiscreteActionOutputApplier(bp.vectorActionSize, seed, allocator);
+                    new DiscreteActionOutputApplier(bp.VectorActionSize, seed, allocator);
             }
             m_Dict[TensorNames.RecurrentOutput] = new MemoryOutputApplier(memories);
 

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -139,7 +139,7 @@ namespace MLAgents.Policies
             switch (m_BehaviorType)
             {
                 case BehaviorType.HeuristicOnly:
-                    return new HeuristicPolicy(heuristic, m_BrainParameters.numActions);
+                    return new HeuristicPolicy(heuristic, m_BrainParameters.NumActions);
                 case BehaviorType.InferenceOnly:
                 {
                     if (m_Model == null)
@@ -163,10 +163,10 @@ namespace MLAgents.Policies
                     }
                     else
                     {
-                        return new HeuristicPolicy(heuristic, m_BrainParameters.numActions);
+                        return new HeuristicPolicy(heuristic, m_BrainParameters.NumActions);
                     }
                 default:
-                    return new HeuristicPolicy(heuristic, m_BrainParameters.numActions);
+                    return new HeuristicPolicy(heuristic, m_BrainParameters.NumActions);
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -30,7 +30,6 @@ namespace MLAgents.Policies
         InferenceOnly
     }
 
-
     /// <summary>
     /// The Factory to generate policies.
     /// </summary>
@@ -41,9 +40,9 @@ namespace MLAgents.Policies
         BrainParameters m_BrainParameters = new BrainParameters();
 
         /// <summary>
-        /// The associated <see cref="BrainParameters"/> for this behavior.
+        /// The associated <see cref="Policies.BrainParameters"/> for this behavior.
         /// </summary>
-        public BrainParameters brainParameters
+        public BrainParameters BrainParameters
         {
             get { return m_BrainParameters; }
             internal set { m_BrainParameters = value; }
@@ -54,10 +53,10 @@ namespace MLAgents.Policies
 
         /// <summary>
         /// The neural network model used when in inference mode.
-        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,InferenceDevice)"/>
+        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,Policies.InferenceDevice)"/>
         /// to set it instead.
         /// </summary>
-        public NNModel model
+        public NNModel Model
         {
             get { return m_Model; }
             set { m_Model = value; UpdateAgentPolicy(); }
@@ -68,10 +67,10 @@ namespace MLAgents.Policies
 
         /// <summary>
         /// How inference is performed for this Agent's model.
-        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,InferenceDevice)"/>
+        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,Policies.InferenceDevice)"/>
         /// to set it instead.
         /// </summary>
-        public InferenceDevice inferenceDevice
+        public InferenceDevice InferenceDevice
         {
             get { return m_InferenceDevice; }
             set { m_InferenceDevice = value; UpdateAgentPolicy();}
@@ -83,7 +82,7 @@ namespace MLAgents.Policies
         /// <summary>
         /// The BehaviorType for the Agent.
         /// </summary>
-        public BehaviorType behaviorType
+        public BehaviorType BehaviorType
         {
             get { return m_BehaviorType; }
             set { m_BehaviorType = value; UpdateAgentPolicy(); }
@@ -94,11 +93,11 @@ namespace MLAgents.Policies
 
         /// <summary>
         /// The name of this behavior, which is used as a base name. See
-        /// <see cref="fullyQualifiedBehaviorName"/> for the full name.
-        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,InferenceDevice)"/>
+        /// <see cref="FullyQualifiedBehaviorName"/> for the full name.
+        /// This should not be set at runtime; use <see cref="Agent.SetModel(string,NNModel,Policies.InferenceDevice)"/>
         /// to set it instead.
         /// </summary>
-        public string behaviorName
+        public string BehaviorName
         {
             get { return m_BehaviorName; }
             set { m_BehaviorName = value; UpdateAgentPolicy(); }
@@ -121,7 +120,7 @@ namespace MLAgents.Policies
         /// Whether or not to use all the sensor components attached to child GameObjects of the agent.
         /// Note that changing this after the Agent has been initialized will not have any effect.
         /// </summary>
-        public bool useChildSensors
+        public bool UseChildSensors
         {
             get { return m_UseChildSensors; }
             set { m_UseChildSensors = value; }
@@ -130,7 +129,7 @@ namespace MLAgents.Policies
         /// <summary>
         /// Returns the behavior name, concatenated with any other metadata (i.e. team id).
         /// </summary>
-        public string fullyQualifiedBehaviorName
+        public string FullyQualifiedBehaviorName
         {
             get { return m_BehaviorName + "?team=" + TeamId; }
         }
@@ -156,7 +155,7 @@ namespace MLAgents.Policies
                 case BehaviorType.Default:
                     if (Academy.Instance.IsCommunicatorOn)
                     {
-                        return new RemotePolicy(m_BrainParameters, fullyQualifiedBehaviorName);
+                        return new RemotePolicy(m_BrainParameters, FullyQualifiedBehaviorName);
                     }
                     if (m_Model != null)
                     {

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace MLAgents.Policies
 {
@@ -30,43 +31,48 @@ namespace MLAgents.Policies
         /// If continuous : The length of the float vector that represents the state.
         /// If discrete : The number of possible values the state can take.
         /// </summary>
-        public int vectorObservationSize = 1;
+        [FormerlySerializedAs("vectorObservationSize")]
+        public int VectorObservationSize = 1;
 
         /// <summary>
         /// Stacking refers to concatenating the observations across multiple frames. This field
         /// indicates the number of frames to concatenate across.
         /// </summary>
-        [Range(1, 50)] public int numStackedVectorObservations = 1;
+        [FormerlySerializedAs("numStackedVectorObservations")]
+        [Range(1, 50)] public int NumStackedVectorObservations = 1;
 
         /// <summary>
         /// If continuous : The length of the float vector that represents the action.
         /// If discrete : The number of possible values the action can take.
         /// </summary>
-        public int[] vectorActionSize = new[] {1};
+        [FormerlySerializedAs("vectorActionSize")]
+        public int[] VectorActionSize = new[] {1};
 
         /// <summary>
         /// The list of strings describing what the actions correspond to.
         /// </summary>
-        public string[] vectorActionDescriptions;
+        [FormerlySerializedAs("vectorActionDescriptions")]
+        public string[] VectorActionDescriptions;
 
         /// <summary>
         /// Defines if the action is discrete or continuous.
         /// </summary>
-        public SpaceType vectorActionSpaceType = SpaceType.Discrete;
+        [FormerlySerializedAs("vectorActionSpaceType")]
+        public SpaceType VectorActionSpaceType = SpaceType.Discrete;
 
         /// <summary>
         /// The number of actions specified by this Brain.
         /// </summary>
-        public int numActions
+        public int NumActions
         {
             get
             {
-                switch (vectorActionSpaceType)
+                switch (VectorActionSpaceType)
                 {
                     case SpaceType.Discrete:
-                        return vectorActionSize.Length;
+                        return VectorActionSize.Length;
                     case SpaceType.Continuous:
-                        return vectorActionSize[0];
+                        return VectorActionSize[0];
                     default:
                         return 0;
                 }
@@ -81,11 +87,11 @@ namespace MLAgents.Policies
         {
             return new BrainParameters
             {
-                vectorObservationSize = vectorObservationSize,
-                numStackedVectorObservations = numStackedVectorObservations,
-                vectorActionSize = (int[])vectorActionSize.Clone(),
-                vectorActionDescriptions = (string[])vectorActionDescriptions.Clone(),
-                vectorActionSpaceType = vectorActionSpaceType
+                VectorObservationSize = VectorObservationSize,
+                NumStackedVectorObservations = NumStackedVectorObservations,
+                VectorActionSize = (int[])VectorActionSize.Clone(),
+                VectorActionDescriptions = (string[])VectorActionDescriptions.Clone(),
+                VectorActionSpaceType = VectorActionSpaceType
             };
         }
     }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -18,7 +18,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// The Camera used for rendering the sensor observations.
         /// </summary>
-        public Camera camera
+        public Camera Camera
         {
             get { return m_Camera; }
             set { m_Camera = value; }
@@ -27,7 +27,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// The compression type used by the sensor.
         /// </summary>
-        public SensorCompressionType compressionType
+        public SensorCompressionType CompressionType
         {
             get { return m_CompressionType;  }
             set { m_CompressionType = value; }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -17,7 +17,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Camera object that provides the data to the sensor.
         /// </summary>
-        public new Camera camera
+        public new Camera Camera
         {
             get { return m_Camera;  }
             set { m_Camera = value; UpdateSensor(); }
@@ -30,7 +30,7 @@ namespace MLAgents.Sensors
         /// Name of the generated <see cref="CameraSensor"/> object.
         /// Note that changing this at runtime does not affect how the Agent sorts the sensors.
         /// </summary>
-        public string sensorName
+        public string SensorName
         {
             get { return m_SensorName;  }
             set { m_SensorName = value; }
@@ -43,7 +43,7 @@ namespace MLAgents.Sensors
         /// Width of the generated observation.
         /// Note that changing this after the sensor is created has no effect.
         /// </summary>
-        public int width
+        public int Width
         {
             get { return m_Width;  }
             set { m_Width = value; }
@@ -56,7 +56,7 @@ namespace MLAgents.Sensors
         /// Height of the generated observation.
         /// Note that changing this after the sensor is created has no effect.
         /// </summary>
-        public int height
+        public int Height
         {
             get { return m_Height;  }
             set { m_Height = value;  }
@@ -69,7 +69,7 @@ namespace MLAgents.Sensors
         /// Whether to generate grayscale images or color.
         /// Note that changing this after the sensor is created has no effect.
         /// </summary>
-        public bool grayscale
+        public bool Grayscale
         {
             get { return m_Grayscale;  }
             set { m_Grayscale = value; }
@@ -81,7 +81,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// The compression type to use for the sensor.
         /// </summary>
-        public SensorCompressionType compression
+        public SensorCompressionType CompressionType
         {
             get { return m_Compression;  }
             set { m_Compression = value; UpdateSensor(); }
@@ -93,7 +93,7 @@ namespace MLAgents.Sensors
         /// <returns>The created <see cref="CameraSensor"/> object for this component.</returns>
         public override ISensor CreateSensor()
         {
-            m_Sensor = new CameraSensor(m_Camera, m_Width, m_Height, grayscale, m_SensorName, compression);
+            m_Sensor = new CameraSensor(m_Camera, m_Width, m_Height, Grayscale, m_SensorName, m_Compression);
             return m_Sensor;
         }
 
@@ -103,7 +103,7 @@ namespace MLAgents.Sensors
         /// <returns>The observation shape of the associated <see cref="CameraSensor"/> object.</returns>
         public override int[] GetObservationShape()
         {
-            return CameraSensor.GenerateShape(m_Width, m_Height, grayscale);
+            return CameraSensor.GenerateShape(m_Width, m_Height, Grayscale);
         }
 
         /// <summary>
@@ -113,8 +113,8 @@ namespace MLAgents.Sensors
         {
             if (m_Sensor != null)
             {
-                m_Sensor.camera = m_Camera;
-                m_Sensor.compressionType = m_Compression;
+                m_Sensor.Camera = m_Camera;
+                m_Sensor.CompressionType = m_Compression;
             }
         }
     }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -17,7 +17,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Camera object that provides the data to the sensor.
         /// </summary>
-        public new Camera Camera
+        public Camera Camera
         {
             get { return m_Camera;  }
             set { m_Camera = value; UpdateSensor(); }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -28,49 +28,49 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Length of the rays to cast. This will be scaled up or down based on the scale of the transform.
         /// </summary>
-        public float rayLength;
+        public float RayLength;
 
         /// <summary>
         /// List of tags which correspond to object types agent can see.
         /// </summary>
-        public IReadOnlyList<string> detectableTags;
+        public IReadOnlyList<string> DetectableTags;
 
         /// <summary>
         /// List of angles (in degrees) used to define the rays.
         /// 90 degrees is considered "forward" relative to the game object.
         /// </summary>
-        public IReadOnlyList<float> angles;
+        public IReadOnlyList<float> Angles;
 
         /// <summary>
         /// Starting height offset of ray from center of agent
         /// </summary>
-        public float startOffset;
+        public float StartOffset;
 
         /// <summary>
         /// Ending height offset of ray from center of agent.
         /// </summary>
-        public float endOffset;
+        public float EndOffset;
 
         /// <summary>
         /// Radius of the sphere to use for spherecasting.
         /// If 0 or less, rays are used instead - this may be faster, especially for complex environments.
         /// </summary>
-        public float castRadius;
+        public float CastRadius;
 
         /// <summary>
         /// Transform of the GameObject.
         /// </summary>
-        public Transform transform;
+        public Transform Transform;
 
         /// <summary>
         /// Whether to perform the casts in 2D or 3D.
         /// </summary>
-        public RayPerceptionCastType castType;
+        public RayPerceptionCastType CastType;
 
         /// <summary>
         /// Filtering options for the casts.
         /// </summary>
-        public int layerMask;
+        public int LayerMask;
 
         /// <summary>
         /// Returns the expected number of floats in the output.
@@ -78,7 +78,7 @@ namespace MLAgents.Sensors
         /// <returns></returns>
         public int OutputSize()
         {
-            return (detectableTags.Count + 2) * angles.Count;
+            return (DetectableTags.Count + 2) * Angles.Count;
         }
 
         /// <summary>
@@ -88,23 +88,23 @@ namespace MLAgents.Sensors
         /// <returns>A tuple of the start and end positions in world space.</returns>
         public (Vector3 StartPositionWorld, Vector3 EndPositionWorld) RayExtents(int rayIndex)
         {
-            var angle = angles[rayIndex];
+            var angle = Angles[rayIndex];
             Vector3 startPositionLocal, endPositionLocal;
-            if (castType == RayPerceptionCastType.Cast3D)
+            if (CastType == RayPerceptionCastType.Cast3D)
             {
-                startPositionLocal = new Vector3(0, startOffset, 0);
-                endPositionLocal = PolarToCartesian3D(rayLength, angle);
-                endPositionLocal.y += endOffset;
+                startPositionLocal = new Vector3(0, StartOffset, 0);
+                endPositionLocal = PolarToCartesian3D(RayLength, angle);
+                endPositionLocal.y += EndOffset;
             }
             else
             {
                 // Vector2s here get converted to Vector3s (and back to Vector2s for casting)
                 startPositionLocal = new Vector2();
-                endPositionLocal = PolarToCartesian2D(rayLength, angle);
+                endPositionLocal = PolarToCartesian2D(RayLength, angle);
             }
 
-            var startPositionWorld = transform.TransformPoint(startPositionLocal);
-            var endPositionWorld = transform.TransformPoint(endPositionLocal);
+            var startPositionWorld = Transform.TransformPoint(startPositionLocal);
+            var endPositionWorld = Transform.TransformPoint(endPositionLocal);
 
             return (StartPositionWorld : startPositionWorld, EndPositionWorld : endPositionWorld);
         }
@@ -143,29 +143,29 @@ namespace MLAgents.Sensors
             /// <summary>
             /// Whether or not the ray hit anything.
             /// </summary>
-            public bool hasHit;
+            public bool HasHit;
 
             /// <summary>
-            /// Whether or not the ray hit an object whose tag is in the input's detectableTags list.
+            /// Whether or not the ray hit an object whose tag is in the input's DetectableTags list.
             /// </summary>
-            public bool hitTaggedObject;
+            public bool HitTaggedObject;
 
             /// <summary>
-            /// The index of the hit object's tag in the detectableTags list, or -1 if there was no hit, or the
+            /// The index of the hit object's tag in the DetectableTags list, or -1 if there was no hit, or the
             /// hit object has a different tag.
             /// </summary>
-            public int hitTagIndex;
+            public int HitTagIndex;
 
             /// <summary>
             /// Normalized distance to the hit object.
             /// </summary>
-            public float hitFraction;
+            public float HitFraction;
 
             /// <summary>
             /// Writes the ray output information to a subset of the float array.  Each element in the rayAngles array
             /// determines a sublist of data to the observation. The sublist contains the observation data for a single cast.
             /// The list is composed of the following:
-            /// 1. A one-hot encoding for detectable tags. For example, if detectableTags.Length = n, the
+            /// 1. A one-hot encoding for detectable tags. For example, if DetectableTags.Length = n, the
             ///    first n elements of the sublist will be a one-hot encoding of the detectableTag that was hit, or
             ///    all zeroes otherwise.
             /// 2. The 'numDetectableTags' element of the sublist will be 1 if the ray missed everything, or 0 if it hit
@@ -175,23 +175,23 @@ namespace MLAgents.Sensors
             /// </summary>
             /// <param name="numDetectableTags"></param>
             /// <param name="rayIndex"></param>
-            /// <param name="buffer">Output buffer. The size must be equal to (numDetectableTags+2) * rayOutputs.Length</param>
+            /// <param name="buffer">Output buffer. The size must be equal to (numDetectableTags+2) * RayOutputs.Length</param>
             public void ToFloatArray(int numDetectableTags, int rayIndex, float[] buffer)
             {
                 var bufferOffset = (numDetectableTags + 2) * rayIndex;
-                if (hitTaggedObject)
+                if (HitTaggedObject)
                 {
-                    buffer[bufferOffset + hitTagIndex] = 1f;
+                    buffer[bufferOffset + HitTagIndex] = 1f;
                 }
-                buffer[bufferOffset + numDetectableTags] = hasHit ? 0f : 1f;
-                buffer[bufferOffset + numDetectableTags + 1] = hitFraction;
+                buffer[bufferOffset + numDetectableTags] = HasHit ? 0f : 1f;
+                buffer[bufferOffset + numDetectableTags + 1] = HitFraction;
             }
         }
 
         /// <summary>
         /// RayOutput for each ray that was cast.
         /// </summary>
-        public RayOutput[] rayOutputs;
+        public RayOutput[] RayOutputs;
     }
 
     /// <summary>
@@ -296,8 +296,8 @@ namespace MLAgents.Sensors
             {
                 Array.Clear(m_Observations, 0, m_Observations.Length);
 
-                var numRays = m_RayPerceptionInput.angles.Count;
-                var numDetectableTags = m_RayPerceptionInput.detectableTags.Count;
+                var numRays = m_RayPerceptionInput.Angles.Count;
+                var numDetectableTags = m_RayPerceptionInput.DetectableTags.Count;
 
                 if (m_DebugDisplayInfo != null)
                 {
@@ -368,12 +368,12 @@ namespace MLAgents.Sensors
         public static RayPerceptionOutput Perceive(RayPerceptionInput input)
         {
             RayPerceptionOutput output = new RayPerceptionOutput();
-            output.rayOutputs = new RayPerceptionOutput.RayOutput[input.angles.Count];
+            output.RayOutputs = new RayPerceptionOutput.RayOutput[input.Angles.Count];
 
-            for (var rayIndex = 0; rayIndex < input.angles.Count; rayIndex++)
+            for (var rayIndex = 0; rayIndex < input.Angles.Count; rayIndex++)
             {
                 DebugDisplayInfo.RayInfo debugRay;
-                output.rayOutputs[rayIndex] = PerceiveSingleRay(input, rayIndex, out debugRay);
+                output.RayOutputs[rayIndex] = PerceiveSingleRay(input, rayIndex, out debugRay);
             }
 
             return output;
@@ -392,8 +392,8 @@ namespace MLAgents.Sensors
             out DebugDisplayInfo.RayInfo debugRayOut
         )
         {
-            var unscaledRayLength = input.rayLength;
-            var unscaledCastRadius = input.castRadius;
+            var unscaledRayLength = input.RayLength;
+            var unscaledCastRadius = input.CastRadius;
 
             var extents = input.RayExtents(rayIndex);
             var startPositionWorld = extents.StartPositionWorld;
@@ -414,18 +414,18 @@ namespace MLAgents.Sensors
             float hitFraction;
             GameObject hitObject;
 
-            if (input.castType == RayPerceptionCastType.Cast3D)
+            if (input.CastType == RayPerceptionCastType.Cast3D)
             {
                 RaycastHit rayHit;
                 if (scaledCastRadius > 0f)
                 {
                     castHit = Physics.SphereCast(startPositionWorld, scaledCastRadius, rayDirection, out rayHit,
-                        scaledRayLength, input.layerMask);
+                        scaledRayLength, input.LayerMask);
                 }
                 else
                 {
                     castHit = Physics.Raycast(startPositionWorld, rayDirection, out rayHit,
-                        scaledRayLength, input.layerMask);
+                        scaledRayLength, input.LayerMask);
                 }
 
                 // If scaledRayLength is 0, we still could have a hit with sphere casts (maybe?).
@@ -439,11 +439,11 @@ namespace MLAgents.Sensors
                 if (scaledCastRadius > 0f)
                 {
                     rayHit = Physics2D.CircleCast(startPositionWorld, scaledCastRadius, rayDirection,
-                        scaledRayLength, input.layerMask);
+                        scaledRayLength, input.LayerMask);
                 }
                 else
                 {
-                    rayHit = Physics2D.Raycast(startPositionWorld, rayDirection, scaledRayLength, input.layerMask);
+                    rayHit = Physics2D.Raycast(startPositionWorld, rayDirection, scaledRayLength, input.LayerMask);
                 }
 
                 castHit = rayHit;
@@ -453,21 +453,21 @@ namespace MLAgents.Sensors
 
             var rayOutput = new RayPerceptionOutput.RayOutput
             {
-                hasHit = castHit,
-                hitFraction = hitFraction,
-                hitTaggedObject = false,
-                hitTagIndex = -1
+                HasHit = castHit,
+                HitFraction = hitFraction,
+                HitTaggedObject = false,
+                HitTagIndex = -1
             };
 
             if (castHit)
             {
                 // Find the index of the tag of the object that was hit.
-                for (var i = 0; i < input.detectableTags.Count; i++)
+                for (var i = 0; i < input.DetectableTags.Count; i++)
                 {
-                    if (hitObject.CompareTag(input.detectableTags[i]))
+                    if (hitObject.CompareTag(input.DetectableTags[i]))
                     {
-                        rayOutput.hitTaggedObject = true;
-                        rayOutput.hitTagIndex = i;
+                        rayOutput.HitTaggedObject = true;
+                        rayOutput.HitTagIndex = i;
                         break;
                     }
                 }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
@@ -14,7 +14,7 @@ namespace MLAgents.Sensors
         public RayPerceptionSensorComponent2D()
         {
             // Set to the 2D defaults (just in case they ever diverge).
-            rayLayerMask = Physics2D.DefaultRaycastLayers;
+            RayLayerMask = Physics2D.DefaultRaycastLayers;
         }
 
         /// <inheritdoc/>

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent3D.cs
@@ -17,7 +17,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Ray start is offset up or down by this amount.
         /// </summary>
-        public float startVerticalOffset
+        public float StartVerticalOffset
         {
             get => m_StartVerticalOffset;
             set { m_StartVerticalOffset = value; UpdateSensor(); }
@@ -31,7 +31,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Ray end is offset up or down by this amount.
         /// </summary>
-        public float endVerticalOffset
+        public float EndVerticalOffset
         {
             get => m_EndVerticalOffset;
             set { m_EndVerticalOffset = value; UpdateSensor(); }
@@ -46,13 +46,13 @@ namespace MLAgents.Sensors
         /// <inheritdoc/>
         public override float GetStartVerticalOffset()
         {
-            return startVerticalOffset;
+            return StartVerticalOffset;
         }
 
         /// <inheritdoc/>
         public override float GetEndVerticalOffset()
         {
-            return endVerticalOffset;
+            return EndVerticalOffset;
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -242,15 +242,15 @@ namespace MLAgents.Sensors
             var rayAngles = GetRayAngles(raysPerDirection, maxRayDegrees);
 
             var rayPerceptionInput = new RayPerceptionInput();
-            rayPerceptionInput.rayLength = rayLength;
-            rayPerceptionInput.detectableTags = detectableTags;
-            rayPerceptionInput.angles = rayAngles;
-            rayPerceptionInput.startOffset = GetStartVerticalOffset();
-            rayPerceptionInput.endOffset = GetEndVerticalOffset();
-            rayPerceptionInput.castRadius = sphereCastRadius;
-            rayPerceptionInput.transform = transform;
-            rayPerceptionInput.castType = GetCastType();
-            rayPerceptionInput.layerMask = rayLayerMask;
+            rayPerceptionInput.RayLength = rayLength;
+            rayPerceptionInput.DetectableTags = detectableTags;
+            rayPerceptionInput.Angles = rayAngles;
+            rayPerceptionInput.StartOffset = GetStartVerticalOffset();
+            rayPerceptionInput.EndOffset = GetEndVerticalOffset();
+            rayPerceptionInput.CastRadius = sphereCastRadius;
+            rayPerceptionInput.Transform = transform;
+            rayPerceptionInput.CastType = GetCastType();
+            rayPerceptionInput.LayerMask = rayLayerMask;
 
             return rayPerceptionInput;
         }
@@ -281,7 +281,7 @@ namespace MLAgents.Sensors
             else
             {
                 var rayInput = GetRayPerceptionInput();
-                for (var rayIndex = 0; rayIndex < rayInput.angles.Count; rayIndex++)
+                for (var rayIndex = 0; rayIndex < rayInput.Angles.Count; rayIndex++)
                 {
                     DebugDisplayInfo.RayInfo debugRay;
                     RayPerceptionSensor.PerceiveSingleRay(rayInput, rayIndex, out debugRay);
@@ -298,17 +298,17 @@ namespace MLAgents.Sensors
             var startPositionWorld = rayInfo.worldStart;
             var endPositionWorld = rayInfo.worldEnd;
             var rayDirection = endPositionWorld - startPositionWorld;
-            rayDirection *= rayInfo.rayOutput.hitFraction;
+            rayDirection *= rayInfo.rayOutput.HitFraction;
 
             // hit fraction ^2 will shift "far" hits closer to the hit color
-            var lerpT = rayInfo.rayOutput.hitFraction * rayInfo.rayOutput.hitFraction;
+            var lerpT = rayInfo.rayOutput.HitFraction * rayInfo.rayOutput.HitFraction;
             var color = Color.Lerp(rayHitColor, rayMissColor, lerpT);
             color.a *= alpha;
             Gizmos.color = color;
             Gizmos.DrawRay(startPositionWorld, rayDirection);
 
             // Draw the hit point as a sphere. If using rays to cast (0 radius), use a small sphere.
-            if (rayInfo.rayOutput.hasHit)
+            if (rayInfo.rayOutput.HasHit)
             {
                 var hitRadius = Mathf.Max(rayInfo.castRadius, .05f);
                 Gizmos.DrawWireSphere(startPositionWorld + rayDirection, hitRadius);

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -17,7 +17,7 @@ namespace MLAgents.Sensors
         /// The name of the Sensor that this component wraps.
         /// Note that changing this at runtime does not affect how the Agent sorts the sensors.
         /// </summary>
-        public string sensorName
+        public string SensorName
         {
             get { return m_SensorName; }
             set { m_SensorName = value; }
@@ -31,7 +31,7 @@ namespace MLAgents.Sensors
         /// List of tags in the scene to compare against.
         /// Note that this should not be changed at runtime.
         /// </summary>
-        public List<string> detectableTags
+        public List<string> DetectableTags
         {
             get { return m_DetectableTags; }
             set { m_DetectableTags = value; }
@@ -46,7 +46,7 @@ namespace MLAgents.Sensors
         /// Number of rays to the left and right of center.
         /// Note that this should not be changed at runtime.
         /// </summary>
-        public int raysPerDirection
+        public int RaysPerDirection
         {
             get { return m_RaysPerDirection; }
             // Note: can't change at runtime
@@ -63,7 +63,7 @@ namespace MLAgents.Sensors
         /// Cone size for rays. Using 90 degrees will cast rays to the left and right.
         /// Greater than 90 degrees will go backwards.
         /// </summary>
-        public float maxRayDegrees
+        public float MaxRayDegrees
         {
             get => m_MaxRayDegrees;
             set { m_MaxRayDegrees = value; UpdateSensor(); }
@@ -77,7 +77,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Radius of sphere to cast. Set to zero for raycasts.
         /// </summary>
-        public float sphereCastRadius
+        public float SphereCastRadius
         {
             get => m_SphereCastRadius;
             set { m_SphereCastRadius = value; UpdateSensor(); }
@@ -91,7 +91,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Length of the rays to cast.
         /// </summary>
-        public float rayLength
+        public float RayLength
         {
             get => m_RayLength;
             set { m_RayLength = value; UpdateSensor(); }
@@ -104,7 +104,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Controls which layers the rays can hit.
         /// </summary>
-        public LayerMask rayLayerMask
+        public LayerMask RayLayerMask
         {
             get => m_RayLayerMask;
             set { m_RayLayerMask = value; UpdateSensor(); }
@@ -119,7 +119,7 @@ namespace MLAgents.Sensors
         /// Whether to stack previous observations. Using 1 means no previous observations.
         /// Note that changing this after the sensor is created has no effect.
         /// </summary>
-        public int observationStacks
+        public int ObservationStacks
         {
             get { return m_ObservationStacks; }
             set { m_ObservationStacks = value; }
@@ -146,7 +146,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Get the RayPerceptionSensor that was created.
         /// </summary>
-        public RayPerceptionSensor raySensor
+        public RayPerceptionSensor RaySensor
         {
             get => m_RaySensor;
         }
@@ -185,9 +185,9 @@ namespace MLAgents.Sensors
 
             m_RaySensor = new RayPerceptionSensor(m_SensorName, rayPerceptionInput);
 
-            if (observationStacks != 1)
+            if (ObservationStacks != 1)
             {
-                var stackingSensor = new StackingSensor(m_RaySensor, observationStacks);
+                var stackingSensor = new StackingSensor(m_RaySensor, ObservationStacks);
                 return stackingSensor;
             }
 
@@ -226,10 +226,10 @@ namespace MLAgents.Sensors
         /// <returns></returns>
         public override int[] GetObservationShape()
         {
-            var numRays = 2 * raysPerDirection + 1;
+            var numRays = 2 * RaysPerDirection + 1;
             var numTags = m_DetectableTags?.Count ?? 0;
             var obsSize = (numTags + 2) * numRays;
-            var stacks = observationStacks > 1 ? observationStacks : 1;
+            var stacks = ObservationStacks > 1 ? ObservationStacks : 1;
             return new[] { obsSize * stacks };
         }
 
@@ -239,18 +239,18 @@ namespace MLAgents.Sensors
         /// <returns></returns>
         public RayPerceptionInput GetRayPerceptionInput()
         {
-            var rayAngles = GetRayAngles(raysPerDirection, maxRayDegrees);
+            var rayAngles = GetRayAngles(RaysPerDirection, MaxRayDegrees);
 
             var rayPerceptionInput = new RayPerceptionInput();
-            rayPerceptionInput.RayLength = rayLength;
-            rayPerceptionInput.DetectableTags = detectableTags;
+            rayPerceptionInput.RayLength = RayLength;
+            rayPerceptionInput.DetectableTags = DetectableTags;
             rayPerceptionInput.Angles = rayAngles;
             rayPerceptionInput.StartOffset = GetStartVerticalOffset();
             rayPerceptionInput.EndOffset = GetEndVerticalOffset();
-            rayPerceptionInput.CastRadius = sphereCastRadius;
+            rayPerceptionInput.CastRadius = SphereCastRadius;
             rayPerceptionInput.Transform = transform;
             rayPerceptionInput.CastType = GetCastType();
-            rayPerceptionInput.LayerMask = rayLayerMask;
+            rayPerceptionInput.LayerMask = RayLayerMask;
 
             return rayPerceptionInput;
         }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -16,7 +16,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// The compression type used by the sensor.
         /// </summary>
-        public SensorCompressionType compressionType
+        public SensorCompressionType CompressionType
         {
             get { return m_CompressionType;  }
             set { m_CompressionType = value; }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -12,16 +12,16 @@ namespace MLAgents.Sensors
         RenderTextureSensor m_Sensor;
 
         /// <summary>
-        /// The <see cref="RenderTexture"/> instance that the associated
+        /// The <see cref="UnityEngine.RenderTexture"/> instance that the associated
         /// <see cref="RenderTextureSensor"/> wraps.
         /// </summary>
         [HideInInspector, SerializeField, FormerlySerializedAs("renderTexture")]
         RenderTexture m_RenderTexture;
 
         /// <summary>
-        /// Stores the <see cref="RenderTexture"/> associated with this sensor.
+        /// Stores the <see cref="UnityEngine.RenderTexture"/> associated with this sensor.
         /// </summary>
-        public RenderTexture renderTexture
+        public RenderTexture RenderTexture
         {
             get { return m_RenderTexture;  }
             set { m_RenderTexture = value;  }
@@ -34,7 +34,7 @@ namespace MLAgents.Sensors
         /// Name of the generated <see cref="RenderTextureSensor"/>.
         /// Note that changing this at runtime does not affect how the Agent sorts the sensors.
         /// </summary>
-        public string sensorName
+        public string SensorName
         {
             get { return m_SensorName;  }
             set { m_SensorName = value; }
@@ -47,7 +47,7 @@ namespace MLAgents.Sensors
         /// Whether the RenderTexture observation should be converted to grayscale or not.
         /// Note that changing this after the sensor is created has no effect.
         /// </summary>
-        public bool grayscale
+        public bool Grayscale
         {
             get { return m_Grayscale;  }
             set { m_Grayscale = value; }
@@ -59,7 +59,7 @@ namespace MLAgents.Sensors
         /// <summary>
         /// Compression type for the render texture observation.
         /// </summary>
-        public SensorCompressionType compression
+        public SensorCompressionType CompressionType
         {
             get { return m_Compression;  }
             set { m_Compression = value; UpdateSensor(); }
@@ -68,17 +68,17 @@ namespace MLAgents.Sensors
         /// <inheritdoc/>
         public override ISensor CreateSensor()
         {
-            m_Sensor = new RenderTextureSensor(renderTexture, grayscale, sensorName, compression);
+            m_Sensor = new RenderTextureSensor(RenderTexture, Grayscale, SensorName, m_Compression);
             return m_Sensor;
         }
 
         /// <inheritdoc/>
         public override int[] GetObservationShape()
         {
-            var width = renderTexture != null ? renderTexture.width : 0;
-            var height = renderTexture != null ? renderTexture.height : 0;
+            var width = RenderTexture != null ? RenderTexture.width : 0;
+            var height = RenderTexture != null ? RenderTexture.height : 0;
 
-            return new[] { height, width, grayscale ? 1 : 3 };
+            return new[] { height, width, Grayscale ? 1 : 3 };
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace MLAgents.Sensors
         {
             if (m_Sensor != null)
             {
-                m_Sensor.compressionType = m_Compression;
+                m_Sensor.CompressionType = m_Compression;
             }
         }
     }

--- a/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/BehaviorParameterTests.cs
@@ -18,7 +18,7 @@ namespace MLAgents.Tests
         {
             var gameObj = new GameObject();
             var bp = gameObj.AddComponent<BehaviorParameters>();
-            bp.behaviorType = BehaviorType.InferenceOnly;
+            bp.BehaviorType = BehaviorType.InferenceOnly;
 
             Assert.Throws<UnityAgentsException>(() =>
             {

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -43,11 +43,11 @@ namespace MLAgents.Tests
             var gameobj = new GameObject("gameObj");
 
             var bp = gameobj.AddComponent<BehaviorParameters>();
-            bp.brainParameters.vectorObservationSize = 3;
-            bp.brainParameters.numStackedVectorObservations = 2;
-            bp.brainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bp.brainParameters.vectorActionSize = new[] { 2, 2 };
-            bp.brainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            bp.BrainParameters.vectorObservationSize = 3;
+            bp.BrainParameters.numStackedVectorObservations = 2;
+            bp.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            bp.BrainParameters.vectorActionSize = new[] { 2, 2 };
+            bp.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
 
             var agent = gameobj.AddComponent<TestAgent>();
 
@@ -100,11 +100,11 @@ namespace MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bpA = agentGo1.AddComponent<BehaviorParameters>();
-            bpA.brainParameters.vectorObservationSize = 3;
-            bpA.brainParameters.numStackedVectorObservations = 1;
-            bpA.brainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bpA.brainParameters.vectorActionSize = new[] { 2, 2 };
-            bpA.brainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            bpA.BrainParameters.vectorObservationSize = 3;
+            bpA.BrainParameters.numStackedVectorObservations = 1;
+            bpA.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            bpA.BrainParameters.vectorActionSize = new[] { 2, 2 };
+            bpA.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
 
             agentGo1.AddComponent<ObservationAgent>();
             var agent1 = agentGo1.GetComponent<ObservationAgent>();
@@ -139,7 +139,7 @@ namespace MLAgents.Tests
             var obs = agentInfoProto.Observations[2]; // skip dummy sensors
             {
                 var vecObs = obs.FloatData.Data;
-                Assert.AreEqual(bpA.brainParameters.vectorObservationSize, vecObs.Count);
+                Assert.AreEqual(bpA.BrainParameters.vectorObservationSize, vecObs.Count);
                 for (var i = 0; i < vecObs.Count; i++)
                 {
                     Assert.AreEqual((float)i + 1, vecObs[i]);

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -43,11 +43,11 @@ namespace MLAgents.Tests
             var gameobj = new GameObject("gameObj");
 
             var bp = gameobj.AddComponent<BehaviorParameters>();
-            bp.BrainParameters.vectorObservationSize = 3;
-            bp.BrainParameters.numStackedVectorObservations = 2;
-            bp.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bp.BrainParameters.vectorActionSize = new[] { 2, 2 };
-            bp.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            bp.BrainParameters.VectorObservationSize = 3;
+            bp.BrainParameters.NumStackedVectorObservations = 2;
+            bp.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            bp.BrainParameters.VectorActionSize = new[] { 2, 2 };
+            bp.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
 
             var agent = gameobj.AddComponent<TestAgent>();
 
@@ -100,11 +100,11 @@ namespace MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bpA = agentGo1.AddComponent<BehaviorParameters>();
-            bpA.BrainParameters.vectorObservationSize = 3;
-            bpA.BrainParameters.numStackedVectorObservations = 1;
-            bpA.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bpA.BrainParameters.vectorActionSize = new[] { 2, 2 };
-            bpA.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            bpA.BrainParameters.VectorObservationSize = 3;
+            bpA.BrainParameters.NumStackedVectorObservations = 1;
+            bpA.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            bpA.BrainParameters.VectorActionSize = new[] { 2, 2 };
+            bpA.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
 
             agentGo1.AddComponent<ObservationAgent>();
             var agent1 = agentGo1.GetComponent<ObservationAgent>();
@@ -139,7 +139,7 @@ namespace MLAgents.Tests
             var obs = agentInfoProto.Observations[2]; // skip dummy sensors
             {
                 var vecObs = obs.FloatData.Data;
-                Assert.AreEqual(bpA.BrainParameters.vectorObservationSize, vecObs.Count);
+                Assert.AreEqual(bpA.BrainParameters.VectorObservationSize, vecObs.Count);
                 for (var i = 0; i < vecObs.Count; i++)
                 {
                     Assert.AreEqual((float)i + 1, vecObs[i]);

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -54,9 +54,9 @@ namespace MLAgents.Tests
             Assert.IsFalse(fileSystem.Directory.Exists(k_DemoDirectory));
 
             var demoRec = gameobj.AddComponent<DemonstrationRecorder>();
-            demoRec.record = true;
-            demoRec.demonstrationName = k_DemoName;
-            demoRec.demonstrationDirectory = k_DemoDirectory;
+            demoRec.Record = true;
+            demoRec.DemonstrationName = k_DemoName;
+            demoRec.DemonstrationDirectory = k_DemoDirectory;
             var demoWriter = demoRec.LazyInitialize(fileSystem);
 
             Assert.IsTrue(fileSystem.Directory.Exists(k_DemoDirectory));
@@ -112,9 +112,9 @@ namespace MLAgents.Tests
             agentGo1.AddComponent<DemonstrationRecorder>();
             var demoRecorder = agentGo1.GetComponent<DemonstrationRecorder>();
             var fileSystem = new MockFileSystem();
-            demoRecorder.demonstrationDirectory = k_DemoDirectory;
-            demoRecorder.demonstrationName = "TestBrain";
-            demoRecorder.record = true;
+            demoRecorder.DemonstrationDirectory = k_DemoDirectory;
+            demoRecorder.DemonstrationName = "TestBrain";
+            demoRecorder.Record = true;
             demoRecorder.LazyInitialize(fileSystem);
 
             var agentEnableMethod = typeof(Agent).GetMethod("OnEnable",

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestActionMasker.cs
@@ -17,8 +17,8 @@ namespace MLAgents.Tests
         public void FailsWithContinuous()
         {
             var bp = new BrainParameters();
-            bp.vectorActionSpaceType = SpaceType.Continuous;
-            bp.vectorActionSize = new[] {4};
+            bp.VectorActionSpaceType = SpaceType.Continuous;
+            bp.VectorActionSize = new[] {4};
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(0, new[] {0});
             Assert.Catch<UnityAgentsException>(() => masker.GetMask());
@@ -28,7 +28,7 @@ namespace MLAgents.Tests
         public void NullMask()
         {
             var bp = new BrainParameters();
-            bp.vectorActionSpaceType = SpaceType.Discrete;
+            bp.VectorActionSpaceType = SpaceType.Discrete;
             var masker = new DiscreteActionMasker(bp);
             var mask = masker.GetMask();
             Assert.IsNull(mask);
@@ -38,8 +38,8 @@ namespace MLAgents.Tests
         public void FirstBranchMask()
         {
             var bp = new BrainParameters();
-            bp.vectorActionSpaceType = SpaceType.Discrete;
-            bp.vectorActionSize = new[] {4, 5, 6};
+            bp.VectorActionSpaceType = SpaceType.Discrete;
+            bp.VectorActionSize = new[] {4, 5, 6};
             var masker = new DiscreteActionMasker(bp);
             var mask = masker.GetMask();
             Assert.IsNull(mask);
@@ -58,8 +58,8 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters
             {
-                vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                VectorActionSpaceType = SpaceType.Discrete,
+                VectorActionSize = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(1, new[] {1, 2, 3});
@@ -78,8 +78,8 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters
             {
-                vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                VectorActionSpaceType = SpaceType.Discrete,
+                VectorActionSize = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(1, new[] {1, 2, 3});
@@ -96,8 +96,8 @@ namespace MLAgents.Tests
         {
             var bp = new BrainParameters
             {
-                vectorActionSpaceType = SpaceType.Discrete,
-                vectorActionSize = new[] { 4, 5, 6 }
+                VectorActionSpaceType = SpaceType.Discrete,
+                VectorActionSize = new[] { 4, 5, 6 }
             };
             var masker = new DiscreteActionMasker(bp);
 
@@ -119,8 +119,8 @@ namespace MLAgents.Tests
         public void MultipleMaskEdit()
         {
             var bp = new BrainParameters();
-            bp.vectorActionSpaceType = SpaceType.Discrete;
-            bp.vectorActionSize = new[] {4, 5, 6};
+            bp.VectorActionSpaceType = SpaceType.Discrete;
+            bp.VectorActionSize = new[] {4, 5, 6};
             var masker = new DiscreteActionMasker(bp);
             masker.SetMask(0, new[] {0, 1});
             masker.SetMask(0, new[] {3});

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
@@ -23,14 +23,14 @@ namespace MLAgents.Tests
         {
             var goA = new GameObject("goA");
             var bpA = goA.AddComponent<BehaviorParameters>();
-            bpA.brainParameters.vectorObservationSize = 3;
-            bpA.brainParameters.numStackedVectorObservations = 1;
+            bpA.BrainParameters.vectorObservationSize = 3;
+            bpA.BrainParameters.numStackedVectorObservations = 1;
             var agentA = goA.AddComponent<TestAgent>();
 
             var goB = new GameObject("goB");
             var bpB = goB.AddComponent<BehaviorParameters>();
-            bpB.brainParameters.vectorObservationSize = 3;
-            bpB.brainParameters.numStackedVectorObservations = 1;
+            bpB.BrainParameters.vectorObservationSize = 3;
+            bpB.BrainParameters.numStackedVectorObservations = 1;
             var agentB = goB.AddComponent<TestAgent>();
 
             var agents = new List<TestAgent> { agentA, agentB };

--- a/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
+++ b/com.unity.ml-agents/Tests/Editor/EditModeTestInternalBrainTensorGenerator.cs
@@ -23,14 +23,14 @@ namespace MLAgents.Tests
         {
             var goA = new GameObject("goA");
             var bpA = goA.AddComponent<BehaviorParameters>();
-            bpA.BrainParameters.vectorObservationSize = 3;
-            bpA.BrainParameters.numStackedVectorObservations = 1;
+            bpA.BrainParameters.VectorObservationSize = 3;
+            bpA.BrainParameters.NumStackedVectorObservations = 1;
             var agentA = goA.AddComponent<TestAgent>();
 
             var goB = new GameObject("goB");
             var bpB = goB.AddComponent<BehaviorParameters>();
-            bpB.BrainParameters.vectorObservationSize = 3;
-            bpB.BrainParameters.numStackedVectorObservations = 1;
+            bpB.BrainParameters.VectorObservationSize = 3;
+            bpB.BrainParameters.NumStackedVectorObservations = 1;
             var agentB = goB.AddComponent<TestAgent>();
 
             var agents = new List<TestAgent> { agentA, agentB };

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -500,7 +500,7 @@ namespace MLAgents.Tests
             var agentGo1 = new GameObject("TestAgent");
             agentGo1.AddComponent<TestAgent>();
             var behaviorParameters = agentGo1.GetComponent<BehaviorParameters>();
-            behaviorParameters.brainParameters.numStackedVectorObservations = 3;
+            behaviorParameters.BrainParameters.numStackedVectorObservations = 3;
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var aca = Academy.Instance;
             agent1.LazyInitialize();
@@ -557,7 +557,7 @@ namespace MLAgents.Tests
             decisionRequester.Awake();
 
 
-            agent1.maxStep = 20;
+            agent1.MaxStep = 20;
 
             agent2.LazyInitialize();
             agent1.LazyInitialize();
@@ -568,7 +568,7 @@ namespace MLAgents.Tests
             for (var i = 0; i < 50; i++)
             {
                 expectedAgent1ActionForEpisode += 1;
-                if (expectedAgent1ActionForEpisode == agent1.maxStep || i == 0)
+                if (expectedAgent1ActionForEpisode == agent1.MaxStep || i == 0)
                 {
                     expectedAgent1ActionForEpisode = 0;
                 }
@@ -594,7 +594,7 @@ namespace MLAgents.Tests
             decisionRequester.Awake();
 
             const int maxStep = 6;
-            agent1.maxStep = maxStep;
+            agent1.MaxStep = maxStep;
             agent1.LazyInitialize();
 
             var expectedAgentStepCount = 0;

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -500,7 +500,7 @@ namespace MLAgents.Tests
             var agentGo1 = new GameObject("TestAgent");
             agentGo1.AddComponent<TestAgent>();
             var behaviorParameters = agentGo1.GetComponent<BehaviorParameters>();
-            behaviorParameters.BrainParameters.numStackedVectorObservations = 3;
+            behaviorParameters.BrainParameters.NumStackedVectorObservations = 3;
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var aca = Academy.Instance;
             agent1.LazyInitialize();

--- a/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ModelRunnerTest.cs
@@ -22,20 +22,20 @@ namespace MLAgents.Tests
         private BrainParameters GetContinuous2vis8vec2actionBrainParameters()
         {
             var validBrainParameters = new BrainParameters();
-            validBrainParameters.vectorObservationSize = 8;
-            validBrainParameters.vectorActionSize = new int[] { 2 };
-            validBrainParameters.numStackedVectorObservations = 1;
-            validBrainParameters.vectorActionSpaceType = SpaceType.Continuous;
+            validBrainParameters.VectorObservationSize = 8;
+            validBrainParameters.VectorActionSize = new int[] { 2 };
+            validBrainParameters.NumStackedVectorObservations = 1;
+            validBrainParameters.VectorActionSpaceType = SpaceType.Continuous;
             return validBrainParameters;
         }
 
         private BrainParameters GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters()
         {
             var validBrainParameters = new BrainParameters();
-            validBrainParameters.vectorObservationSize = 0;
-            validBrainParameters.vectorActionSize = new int[] { 2, 3 };
-            validBrainParameters.numStackedVectorObservations = 1;
-            validBrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            validBrainParameters.VectorObservationSize = 0;
+            validBrainParameters.VectorActionSize = new int[] { 2, 3 };
+            validBrainParameters.NumStackedVectorObservations = 1;
+            validBrainParameters.VectorActionSpaceType = SpaceType.Discrete;
             return validBrainParameters;
         }
 
@@ -94,7 +94,7 @@ namespace MLAgents.Tests
             Assert.IsNotNull(modelRunner.GetAction(1));
             Assert.IsNotNull(modelRunner.GetAction(2));
             Assert.IsNull(modelRunner.GetAction(3));
-            Assert.AreEqual(brainParameters.vectorActionSize.Count(), modelRunner.GetAction(1).Count());
+            Assert.AreEqual(brainParameters.VectorActionSize.Count(), modelRunner.GetAction(1).Count());
             modelRunner.Dispose();
         }
     }

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -84,20 +84,20 @@ namespace MLAgents.Tests
         private BrainParameters GetContinuous2vis8vec2actionBrainParameters()
         {
             var validBrainParameters = new BrainParameters();
-            validBrainParameters.vectorObservationSize = 8;
-            validBrainParameters.vectorActionSize = new int[] { 2 };
-            validBrainParameters.numStackedVectorObservations = 1;
-            validBrainParameters.vectorActionSpaceType = SpaceType.Continuous;
+            validBrainParameters.VectorObservationSize = 8;
+            validBrainParameters.VectorActionSize = new int[] { 2 };
+            validBrainParameters.NumStackedVectorObservations = 1;
+            validBrainParameters.VectorActionSpaceType = SpaceType.Continuous;
             return validBrainParameters;
         }
 
         private BrainParameters GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters()
         {
             var validBrainParameters = new BrainParameters();
-            validBrainParameters.vectorObservationSize = 0;
-            validBrainParameters.vectorActionSize = new int[] { 2, 3 };
-            validBrainParameters.numStackedVectorObservations = 1;
-            validBrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            validBrainParameters.VectorObservationSize = 0;
+            validBrainParameters.VectorActionSize = new int[] { 2, 3 };
+            validBrainParameters.NumStackedVectorObservations = 1;
+            validBrainParameters.VectorActionSpaceType = SpaceType.Discrete;
             return validBrainParameters;
         }
 
@@ -197,12 +197,12 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(continuous2vis8vec2actionModel);
 
             var brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.vectorObservationSize = 9; // Invalid observation
+            brainParameters.VectorObservationSize = 9; // Invalid observation
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 });
             Assert.Greater(errors.Count(), 0);
 
             brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.numStackedVectorObservations = 2;// Invalid stacking
+            brainParameters.NumStackedVectorObservations = 2;// Invalid stacking
             errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 });
             Assert.Greater(errors.Count(), 0);
         }
@@ -213,7 +213,7 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(discrete1vis0vec_2_3action_recurrModel);
 
             var brainParameters = GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters();
-            brainParameters.vectorObservationSize = 1; // Invalid observation
+            brainParameters.VectorObservationSize = 1; // Invalid observation
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 });
             Assert.Greater(errors.Count(), 0);
         }
@@ -224,12 +224,12 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(continuous2vis8vec2actionModel);
 
             var brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.vectorActionSize = new int[] { 3 }; // Invalid action
+            brainParameters.VectorActionSize = new int[] { 3 }; // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 });
             Assert.Greater(errors.Count(), 0);
 
             brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.vectorActionSpaceType = SpaceType.Discrete;// Invalid SpaceType
+            brainParameters.VectorActionSpaceType = SpaceType.Discrete;// Invalid SpaceType
             errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 });
             Assert.Greater(errors.Count(), 0);
         }
@@ -240,12 +240,12 @@ namespace MLAgents.Tests
             var model = ModelLoader.Load(discrete1vis0vec_2_3action_recurrModel);
 
             var brainParameters = GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters();
-            brainParameters.vectorActionSize = new int[] { 3, 3 }; // Invalid action
+            brainParameters.VectorActionSize = new int[] { 3, 3 }; // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 });
             Assert.Greater(errors.Count(), 0);
 
             brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.vectorActionSpaceType = SpaceType.Continuous;// Invalid SpaceType
+            brainParameters.VectorActionSpaceType = SpaceType.Continuous;// Invalid SpaceType
             errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 });
             Assert.Greater(errors.Count(), 0);
         }

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -47,13 +47,13 @@ namespace MLAgentsExamples
             var width = 24;
             var height = 16;
             var texture = new RenderTexture(width, height, 0);
-            sensorComponent.renderTexture = texture;
-            sensorComponent.sensorName = "rtx1";
-            sensorComponent.grayscale = true;
+            sensorComponent.RenderTexture = texture;
+            sensorComponent.SensorName = "rtx1";
+            sensorComponent.Grayscale = true;
 
             // Make sure the sets actually applied
-            Assert.AreEqual("rtx1", sensorComponent.sensorName);
-            Assert.IsTrue(sensorComponent.grayscale);
+            Assert.AreEqual("rtx1", sensorComponent.SensorName);
+            Assert.IsTrue(sensorComponent.Grayscale);
         }
 
         [Test]
@@ -62,13 +62,13 @@ namespace MLAgentsExamples
             var gameObject = new GameObject();
 
             var sensorComponent = gameObject.AddComponent<RayPerceptionSensorComponent3D>();
-            sensorComponent.sensorName = "ray3d";
-            sensorComponent.detectableTags = new List<string> { "Player", "Respawn" };
-            sensorComponent.raysPerDirection = 3;
-            sensorComponent.maxRayDegrees = 30;
-            sensorComponent.sphereCastRadius = .1f;
-            sensorComponent.rayLayerMask = 0;
-            sensorComponent.observationStacks = 2;
+            sensorComponent.SensorName = "ray3d";
+            sensorComponent.DetectableTags = new List<string> { "Player", "Respawn" };
+            sensorComponent.RaysPerDirection = 3;
+            sensorComponent.MaxRayDegrees = 30;
+            sensorComponent.SphereCastRadius = .1f;
+            sensorComponent.RayLayerMask = 0;
+            sensorComponent.ObservationStacks = 2;
 
             sensorComponent.CreateSensor();
         }

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -25,17 +25,17 @@ namespace MLAgentsExamples
             var height = 16;
 
             var sensorComponent = gameObject.AddComponent<CameraSensorComponent>();
-            sensorComponent.camera = Camera.main;
-            sensorComponent.sensorName = "camera1";
-            sensorComponent.width = width;
-            sensorComponent.height = height;
-            sensorComponent.grayscale = true;
+            sensorComponent.Camera = Camera.main;
+            sensorComponent.SensorName = "camera1";
+            sensorComponent.Width = width;
+            sensorComponent.Height = height;
+            sensorComponent.Grayscale = true;
 
             // Make sure the sets actually applied
-            Assert.AreEqual("camera1", sensorComponent.sensorName);
-            Assert.AreEqual(width, sensorComponent.width);
-            Assert.AreEqual(height, sensorComponent.height);
-            Assert.IsTrue(sensorComponent.grayscale);
+            Assert.AreEqual("camera1", sensorComponent.SensorName);
+            Assert.AreEqual(width, sensorComponent.Width);
+            Assert.AreEqual(height, sensorComponent.Height);
+            Assert.IsTrue(sensorComponent.Grayscale);
         }
 
         [Test]

--- a/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorComponentTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/CameraSensorComponentTest.cs
@@ -23,11 +23,11 @@ namespace MLAgents.Tests
                     var agentGameObj = new GameObject("agent");
 
                     var cameraComponent = agentGameObj.AddComponent<CameraSensorComponent>();
-                    cameraComponent.camera = camera;
-                    cameraComponent.height = height;
-                    cameraComponent.width = width;
-                    cameraComponent.grayscale = grayscale;
-                    cameraComponent.compression = compression;
+                    cameraComponent.Camera = camera;
+                    cameraComponent.Height = height;
+                    cameraComponent.Width = width;
+                    cameraComponent.Grayscale = grayscale;
+                    cameraComponent.CompressionType = compression;
 
                     var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
                     Assert.AreEqual(expectedShape, cameraComponent.GetObservationShape());

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -67,20 +67,20 @@ namespace MLAgents.Tests
             var obj = new GameObject("agent");
             var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
 
-            perception.raysPerDirection = 1;
-            perception.maxRayDegrees = 45;
-            perception.rayLength = 20;
-            perception.detectableTags = new List<string>();
-            perception.detectableTags.Add(k_CubeTag);
-            perception.detectableTags.Add(k_SphereTag);
+            perception.RaysPerDirection = 1;
+            perception.MaxRayDegrees = 45;
+            perception.RayLength = 20;
+            perception.DetectableTags = new List<string>();
+            perception.DetectableTags.Add(k_CubeTag);
+            perception.DetectableTags.Add(k_SphereTag);
 
             var radii = new[] { 0f, .5f };
             foreach (var castRadius in radii)
             {
-                perception.sphereCastRadius = castRadius;
+                perception.SphereCastRadius = castRadius;
                 var sensor = perception.CreateSensor();
 
-                var expectedObs = (2 * perception.raysPerDirection + 1) * (perception.detectableTags.Count + 2);
+                var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationShape()[0], expectedObs);
                 var outputBuffer = new float[expectedObs];
 
@@ -102,7 +102,7 @@ namespace MLAgents.Tests
 
                 // Hit is at z=9.0 in world space, ray length is 20
                 Assert.That(
-                    outputBuffer[3], Is.EqualTo((9.5f - castRadius) / perception.rayLength).Within(.0005f)
+                    outputBuffer[3], Is.EqualTo((9.5f - castRadius) / perception.RayLength).Within(.0005f)
                 );
 
                 // Spheres are at 5,0,5 and 5,0,-5, so 5*sqrt(2) units from origin
@@ -112,14 +112,14 @@ namespace MLAgents.Tests
                 Assert.AreEqual(0.0f, outputBuffer[5]); // missed sphere
                 Assert.AreEqual(0.0f, outputBuffer[6]); // hit unknown tag -> all 0
                 Assert.That(
-                    outputBuffer[7], Is.EqualTo(expectedHitLengthWorldSpace / perception.rayLength).Within(.0005f)
+                    outputBuffer[7], Is.EqualTo(expectedHitLengthWorldSpace / perception.RayLength).Within(.0005f)
                 );
 
                 Assert.AreEqual(0.0f, outputBuffer[8]); // missed cube
                 Assert.AreEqual(1.0f, outputBuffer[9]); // hit sphere
                 Assert.AreEqual(0.0f, outputBuffer[10]); // missed unknown tag
                 Assert.That(
-                    outputBuffer[11], Is.EqualTo(expectedHitLengthWorldSpace / perception.rayLength).Within(.0005f)
+                    outputBuffer[11], Is.EqualTo(expectedHitLengthWorldSpace / perception.RayLength).Within(.0005f)
                 );
             }
         }
@@ -130,15 +130,15 @@ namespace MLAgents.Tests
             var obj = new GameObject("agent");
             var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
 
-            perception.raysPerDirection = 0;
-            perception.maxRayDegrees = 45;
-            perception.rayLength = 20;
-            perception.detectableTags = new List<string>();
-            perception.detectableTags.Add(k_CubeTag);
-            perception.detectableTags.Add(k_SphereTag);
+            perception.RaysPerDirection = 0;
+            perception.MaxRayDegrees = 45;
+            perception.RayLength = 20;
+            perception.DetectableTags = new List<string>();
+            perception.DetectableTags.Add(k_CubeTag);
+            perception.DetectableTags.Add(k_SphereTag);
 
             var sensor = perception.CreateSensor();
-            var expectedObs = (2 * perception.raysPerDirection + 1) * (perception.detectableTags.Count + 2);
+            var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
             Assert.AreEqual(sensor.GetObservationShape()[0], expectedObs);
             var outputBuffer = new float[expectedObs];
 
@@ -170,9 +170,9 @@ namespace MLAgents.Tests
 
             var obj = new GameObject("agent");
             var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
-            perception.raysPerDirection = 0;
-            perception.rayLength = 20;
-            perception.detectableTags = new List<string>();
+            perception.RaysPerDirection = 0;
+            perception.RayLength = 20;
+            perception.DetectableTags = new List<string>();
 
             var filterCubeLayers = new[] { false, true };
             foreach (var filterCubeLayer in filterCubeLayers)
@@ -183,10 +183,10 @@ namespace MLAgents.Tests
                 {
                     layerMask &= ~(1 << cubeFiltered.layer);
                 }
-                perception.rayLayerMask = layerMask;
+                perception.RayLayerMask = layerMask;
 
                 var sensor = perception.CreateSensor();
-                var expectedObs = (2 * perception.raysPerDirection + 1) * (perception.detectableTags.Count + 2);
+                var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationShape()[0], expectedObs);
                 var outputBuffer = new float[expectedObs];
 
@@ -200,14 +200,14 @@ namespace MLAgents.Tests
                 {
                     // Hit the far cube because close was filtered.
                     Assert.That(outputBuffer[outputBuffer.Length - 1],
-                        Is.EqualTo((9.5f - perception.sphereCastRadius) / perception.rayLength).Within(.0005f)
+                        Is.EqualTo((9.5f - perception.SphereCastRadius) / perception.RayLength).Within(.0005f)
                     );
                 }
                 else
                 {
                     // Hit the close cube because not filtered.
                     Assert.That(outputBuffer[outputBuffer.Length - 1],
-                        Is.EqualTo((4.5f - perception.sphereCastRadius) / perception.rayLength).Within(.0005f)
+                        Is.EqualTo((4.5f - perception.SphereCastRadius) / perception.RayLength).Within(.0005f)
                     );
                 }
             }
@@ -221,19 +221,19 @@ namespace MLAgents.Tests
             var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
             obj.transform.localScale = new Vector3(2, 2, 2);
 
-            perception.raysPerDirection = 0;
-            perception.maxRayDegrees = 45;
-            perception.rayLength = 20;
-            perception.detectableTags = new List<string>();
-            perception.detectableTags.Add(k_CubeTag);
+            perception.RaysPerDirection = 0;
+            perception.MaxRayDegrees = 45;
+            perception.RayLength = 20;
+            perception.DetectableTags = new List<string>();
+            perception.DetectableTags.Add(k_CubeTag);
 
             var radii = new[] { 0f, .5f };
             foreach (var castRadius in radii)
             {
-                perception.sphereCastRadius = castRadius;
+                perception.SphereCastRadius = castRadius;
                 var sensor = perception.CreateSensor();
 
-                var expectedObs = (2 * perception.raysPerDirection + 1) * (perception.detectableTags.Count + 2);
+                var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationShape()[0], expectedObs);
                 var outputBuffer = new float[expectedObs];
 
@@ -251,7 +251,7 @@ namespace MLAgents.Tests
 
                 // Hit is at z=9.0 in world space, ray length was 20
                 // But scale increases the cast size and the ray length
-                var scaledRayLength = 2 * perception.rayLength;
+                var scaledRayLength = 2 * perception.RayLength;
                 var scaledCastRadius = 2 * castRadius;
                 Assert.That(
                     outputBuffer[2], Is.EqualTo((9.5f - scaledCastRadius) / scaledRayLength).Within(.0005f)
@@ -271,17 +271,17 @@ namespace MLAgents.Tests
 
             var obj = new GameObject("agent");
             var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
-            perception.raysPerDirection = 0;
-            perception.rayLength = 0.0f;
-            perception.sphereCastRadius = .5f;
-            perception.detectableTags = new List<string>();
-            perception.detectableTags.Add(k_CubeTag);
+            perception.RaysPerDirection = 0;
+            perception.RayLength = 0.0f;
+            perception.SphereCastRadius = .5f;
+            perception.DetectableTags = new List<string>();
+            perception.DetectableTags.Add(k_CubeTag);
 
             {
                 // Set the layer mask to either the default, or one that ignores the close cube's layer
 
                 var sensor = perception.CreateSensor();
-                var expectedObs = (2 * perception.raysPerDirection + 1) * (perception.detectableTags.Count + 2);
+                var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationShape()[0], expectedObs);
                 var outputBuffer = new float[expectedObs];
 

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RenderTextureSensorComponentTests.cs
@@ -22,9 +22,9 @@ namespace MLAgents.Tests
                     var agentGameObj = new GameObject("agent");
 
                     var renderTexComponent = agentGameObj.AddComponent<RenderTextureSensorComponent>();
-                    renderTexComponent.renderTexture = texture;
-                    renderTexComponent.grayscale = grayscale;
-                    renderTexComponent.compression = compression;
+                    renderTexComponent.RenderTexture = texture;
+                    renderTexComponent.Grayscale = grayscale;
+                    renderTexComponent.CompressionType = compression;
 
                     var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
                     Assert.AreEqual(expectedShape, renderTexComponent.GetObservationShape());

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -60,23 +60,23 @@ namespace Tests
             var gameObject = new GameObject();
 
             var behaviorParams = gameObject.AddComponent<BehaviorParameters>();
-            behaviorParams.brainParameters.vectorObservationSize = 3;
-            behaviorParams.brainParameters.numStackedVectorObservations = 2;
-            behaviorParams.brainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            behaviorParams.brainParameters.vectorActionSize = new[] { 2, 2 };
-            behaviorParams.brainParameters.vectorActionSpaceType = SpaceType.Discrete;
-            behaviorParams.behaviorName = "TestBehavior";
+            behaviorParams.BrainParameters.vectorObservationSize = 3;
+            behaviorParams.BrainParameters.numStackedVectorObservations = 2;
+            behaviorParams.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            behaviorParams.BrainParameters.vectorActionSize = new[] { 2, 2 };
+            behaviorParams.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            behaviorParams.BehaviorName = "TestBehavior";
             behaviorParams.TeamId = 42;
-            behaviorParams.useChildSensors = true;
+            behaviorParams.UseChildSensors = true;
 
 
             // Can't actually create an Agent with InferenceOnly and no model, so change back
-            behaviorParams.behaviorType = BehaviorType.Default;
+            behaviorParams.BehaviorType = BehaviorType.Default;
 
             var sensorComponent = gameObject.AddComponent<RayPerceptionSensorComponent3D>();
-            sensorComponent.sensorName = "ray3d";
-            sensorComponent.detectableTags = new List<string> { "Player", "Respawn" };
-            sensorComponent.raysPerDirection = 3;
+            sensorComponent.SensorName = "ray3d";
+            sensorComponent.DetectableTags = new List<string> { "Player", "Respawn" };
+            sensorComponent.RaysPerDirection = 3;
 
             // Make a StackingSensor that wraps the RayPerceptionSensorComponent3D
             // This isn't necessarily practical, just to ensure that it can be done
@@ -85,12 +85,12 @@ namespace Tests
             wrappingSensorComponent.numStacks = 3;
 
             // ISensor isn't set up yet.
-            Assert.IsNull(sensorComponent.raySensor);
+            Assert.IsNull(sensorComponent.RaySensor);
 
 
             // Make sure we can set the behavior type correctly after the agent is initialized
             // (this creates a new policy).
-            behaviorParams.behaviorType = BehaviorType.HeuristicOnly;
+            behaviorParams.BehaviorType = BehaviorType.HeuristicOnly;
 
             // Agent needs to be added after everything else is setup.
             var agent = gameObject.AddComponent<PublicApiAgent>();
@@ -102,11 +102,11 @@ namespace Tests
 
 
             // Initialization should set up the sensors
-            Assert.IsNotNull(sensorComponent.raySensor);
+            Assert.IsNotNull(sensorComponent.RaySensor);
 
             // Let's change the inference device
-            var otherDevice = behaviorParams.inferenceDevice == InferenceDevice.CPU ? InferenceDevice.GPU : InferenceDevice.CPU;
-            agent.SetModel(behaviorParams.behaviorName, behaviorParams.model, otherDevice);
+            var otherDevice = behaviorParams.InferenceDevice == InferenceDevice.CPU ? InferenceDevice.GPU : InferenceDevice.CPU;
+            agent.SetModel(behaviorParams.BehaviorName, behaviorParams.Model, otherDevice);
 
             agent.AddReward(1.0f);
 

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -60,11 +60,11 @@ namespace Tests
             var gameObject = new GameObject();
 
             var behaviorParams = gameObject.AddComponent<BehaviorParameters>();
-            behaviorParams.BrainParameters.vectorObservationSize = 3;
-            behaviorParams.BrainParameters.numStackedVectorObservations = 2;
-            behaviorParams.BrainParameters.vectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            behaviorParams.BrainParameters.vectorActionSize = new[] { 2, 2 };
-            behaviorParams.BrainParameters.vectorActionSpaceType = SpaceType.Discrete;
+            behaviorParams.BrainParameters.VectorObservationSize = 3;
+            behaviorParams.BrainParameters.NumStackedVectorObservations = 2;
+            behaviorParams.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
+            behaviorParams.BrainParameters.VectorActionSize = new[] { 2, 2 };
+            behaviorParams.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
             behaviorParams.BehaviorName = "TestBehavior";
             behaviorParams.TeamId = 42;
             behaviorParams.UseChildSensors = true;

--- a/docs/Learning-Environment-Examples.md
+++ b/docs/Learning-Environment-Examples.md
@@ -361,7 +361,7 @@ you would like to contribute environments, please see our
   Behavior Parameters : SoccerTwos.
 - Agent Reward Function (dependent):
     - (1 - `accumulated time penalty`) When ball enters opponent's goal `accumulated time penalty` is incremented by
-    (1 / `maxStep`) every fixed update and is reset to 0 at the beginning of an episode.
+    (1 / `MaxStep`) every fixed update and is reset to 0 at the beginning of an episode.
     - -1 When ball enters team's goal.
 - Behavior Parameters:
   - Vector Observation space: 336 corresponding to 11 ray-casts forward distributed over 120 degrees

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -38,6 +38,10 @@ double-check that the versions are in the same. The versions can be found in
   `UnityToGymWrapper` and no longer creates the `UnityEnvironment`. Instead,
   the `UnityEnvironment` must be passed as input to the
   constructor of `UnityToGymWrapper`
+- Public fields and properties on several classes were renamed to follow Unity's
+  C# style conventions. All public fields and properties now use "PascalCase"
+  instead of "camelCase"; for example, `Agent.maxStep` was renamed to
+  `Agent.MaxStep`. For a full list of changes, see the pull request. (#3828)
 
 ### Steps to Migrate
 
@@ -64,6 +68,7 @@ double-check that the versions are in the same. The versions can be found in
 - Replace `UnityEnv` with `UnityToGymWrapper` in your code. The constructor
   no longer takes a file name as input but a fully constructed
   `UnityEnvironment` instead.
+- Update uses of "camelCase" fields and properties to "PascalCase".
 
 ## Migrating from 0.14 to 0.15
 


### PR DESCRIPTION
### Proposed change(s)

Unity's C# style guide says
```
In the Unity namespace, public fields are PascalCase with no prefix
In the Unity namespace, public properties are PascalCase with no prefix
```
(as opposed to UnityEngine and UnityEditor namespaces, which have different conventions).

This PR updates all the public fields and properties that I could find (via API scraper) that were camelCase instead of PascalCase

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://ono.unity3d.com/unity-extra/unity-meta/files/@/ReferenceSource/CSharp/Assets/CSharpReference.cs


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
