### PR TITLE
support newer versions of tensorflow (2.1+)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ executors:
   python373:
     docker:
       - image: circleci/python:3.7.3
+  python382:
+    docker:
+      - image: circleci/python:3.8.2
 
 jobs:
   build_python:
@@ -228,10 +231,10 @@ workflows:
           # Make sure ONNX conversion passes here (recent version of tensorflow 1.x)
           enforce_onnx_conversion: 1
       - build_python:
-          name: python_3.7.3+tf2
-          executor: python373
-          pyversion: 3.7.3
-          # Test python 3.7 with the newest supported versions
+          name: python_3.8.2+tf2
+          executor: python382
+          pyversion: 3.8.2
+          # Test python 3.8 with the newest supported versions
           pip_constraints: test_constraints_max_tf2_version.txt
       - markdown_link_check
       - pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,10 +231,10 @@ workflows:
           # Make sure ONNX conversion passes here (recent version of tensorflow 1.x)
           enforce_onnx_conversion: 1
       - build_python:
-          name: python_3.8.2+tf2
-          executor: python382
-          pyversion: 3.8.2
-          # Test python 3.8 with the newest supported versions
+          name: python_3.7.3+tf2
+          executor: python373
+          pyversion: 3.7.3
+          # Test python 3.7 with the newest supported versions
           pip_constraints: test_constraints_max_tf2_version.txt
       - markdown_link_check
       - pre-commit

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -475,7 +475,7 @@ def test_gail_visual_ppo(simple_record, use_discrete):
         step_size=0.2,
     )
     override_vals = {
-        "max_steps": 500,
+        "max_steps": 750,
         "learning_rate": 3.0e-4,
         "behavioral_cloning": {"demo_path": demo_path, "strength": 1.0, "steps": 1000},
         "reward_signals": {

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -48,6 +48,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     # find_namespace_packages will recurse through the directories and find all the packages
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
@@ -61,7 +62,7 @@ setup(
         "Pillow>=4.2.1",
         "protobuf>=3.6",
         "pyyaml",
-        "tensorflow>=1.7,<2.1",
+        "tensorflow>=1.7,<3.0",
         'pypiwin32==223;platform_system=="Windows"',
     ],
     python_requires=">=3.6.1",

--- a/test_constraints_max_tf2_version.txt
+++ b/test_constraints_max_tf2_version.txt
@@ -2,5 +2,5 @@
 # For projects with upper bounds, we should periodically update this list to the latest release version
 grpcio>=1.23.0
 numpy>=1.17.2
-tensorflow>=2.0.0,<2.1.0
+tensorflow>=2.0.0
 h5py>=2.10.0

--- a/test_constraints_max_tf2_version.txt
+++ b/test_constraints_max_tf2_version.txt
@@ -2,5 +2,5 @@
 # For projects with upper bounds, we should periodically update this list to the latest release version
 grpcio>=1.23.0
 numpy>=1.17.2
-tensorflow>=2.0.0
+tensorflow==2.2.0rc3
 h5py>=2.10.0

--- a/test_constraints_max_tf2_version.txt
+++ b/test_constraints_max_tf2_version.txt
@@ -2,5 +2,5 @@
 # For projects with upper bounds, we should periodically update this list to the latest release version
 grpcio>=1.23.0
 numpy>=1.17.2
-tensorflow==2.2.0rc3
+tensorflow>=2.1.0
 h5py>=2.10.0


### PR DESCRIPTION
### Proposed change(s)
Tests with tensorflow 2.1 and 2.2 release candidates look good. We need to support 2.2 in order to support python3.8 as well.

This PR raises the tensorflow version range. I originally intended to test python3.8 here too, but there were some conflicts with onnx that I'll have to try to resolve in another PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/tensorflow/tensorflow/issues/33374

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
