### PR TITLE
Release tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,14 @@ jobs:
       directory:
         type: string
         description: Local directory to use for publishing (e.g. ml-agents)
+      username:
+        type: string
+        description: pypi username
+        default: mlagents
+      test_repository_args:
+        type: string
+        description: Optional override repository URL. Only use for tests, leave blank for "real"
+        default:
     docker:
       - image: circleci/python:3.6
     steps:
@@ -210,7 +218,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd << parameters.directory >>
-            twine upload -u mlagents -p $PYPI_PASSWORD dist/*
+            twine upload -u << parameters.username >> -p $PYPI_PASSWORD << parameters.test_repository_args >> dist/*
 
 workflows:
   version: 2
@@ -244,12 +252,14 @@ workflows:
           pip_constraints: test_constraints_max_tf2_version.txt
       - markdown_link_check
       - pre-commit
+      # The first deploy jobs are the "real" ones that upload to pypi
       - deploy:
           name: deploy ml-agents-envs
           directory: ml-agents-envs
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
+              # Matches e.g. "release_123"
+              only: /^release_[0-9]+$/
             branches:
               ignore: /.*/
       - deploy:
@@ -257,7 +267,8 @@ workflows:
           directory: ml-agents
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
+              # Matches e.g. "release_123"
+              only: /^release_[0-9]+$/
             branches:
               ignore: /.*/
       - deploy:
@@ -265,7 +276,42 @@ workflows:
           directory: gym-unity
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(\.dev[0-9]+)*/
+              # Matches e.g. "release_123"
+              only: /^release_[0-9]+$/
+            branches:
+              ignore: /.*/
+      # These deploy jobs upload to the pypi test repo. They have different tag triggers than the real ones.
+      - deploy:
+          name: test deploy ml-agents-envs
+          directory: ml-agents-envs
+          username: mlagents-test
+          test_repository_args: --repository-url https://test.pypi.org/legacy/
+          filters:
+            tags:
+              # Matches e.g. "release_123_test456
+              only: /^release_[0-9]+_test[0-9]+$/
+            branches:
+              ignore: /.*/
+      - deploy:
+          name: test deploy ml-agents
+          directory: ml-agents
+          username: mlagents-test
+          test_repository_args: --repository-url https://test.pypi.org/legacy/
+          filters:
+            tags:
+              # Matches e.g. "release_123_test456
+              only: /^release_[0-9]+_test[0-9]+$/
+            branches:
+              ignore: /.*/
+      - deploy:
+          name: test deploy gym-unity
+          directory: gym-unity
+          username: mlagents-test
+          test_repository_args: --repository-url https://test.pypi.org/legacy/
+          filters:
+            tags:
+              # Matches e.g. "release_123_test456
+              only: /^release_[0-9]+_test[0-9]+$/
             branches:
               ignore: /.*/
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       test_repository_args:
         type: string
         description: Optional override repository URL. Only use for tests, leave blank for "real"
-        default:
+        default: ""
     docker:
       - image: circleci/python:3.6
     steps:

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,1 +1,6 @@
+
+# Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
+
+# Git tag that will be checked to determine whether to trigger upload to pypi
+__release_tag__ = None

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -2,4 +2,4 @@
 __version__ = "0.16.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_1"

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,4 +1,3 @@
-
 # Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
 

--- a/gym-unity/setup.py
+++ b/gym-unity/setup.py
@@ -7,12 +7,14 @@ from setuptools.command.install import install
 import gym_unity
 
 VERSION = gym_unity.__version__
+EXPECTED_TAG = gym_unity.__release_tag__
 
 
 class VerifyVersionCommand(install):
     """
-    Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    Custom command to verify that the git tag is the expected one for the release.
+    Based on https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    This differs slightly because our tags and versions are different.
     """
 
     description = "verify that the git tag matches our version"
@@ -20,9 +22,9 @@ class VerifyVersionCommand(install):
     def run(self):
         tag = os.getenv("CIRCLE_TAG")
 
-        if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
+        if tag != EXPECTED_TAG:
+            info = "Git tag: {0} does not match the expected tag of this app: {1}".format(
+                tag, EXPECTED_TAG
             )
             sys.exit(info)
 

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,1 +1,6 @@
+
+# Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
+
+# Git tag that will be checked to determine whether to trigger upload to pypi
+__release_tag__ = None

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -2,4 +2,4 @@
 __version__ = "0.16.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_1"

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,4 +1,3 @@
-
 # Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -5,14 +5,16 @@ from setuptools.command.install import install
 import mlagents_envs
 
 VERSION = mlagents_envs.__version__
+EXPECTED_TAG = mlagents_envs.__release_tag__
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 
 class VerifyVersionCommand(install):
     """
-    Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    Custom command to verify that the git tag is the expected one for the release.
+    Based on https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    This differs slightly because our tags and versions are different.
     """
 
     description = "verify that the git tag matches our version"
@@ -20,9 +22,9 @@ class VerifyVersionCommand(install):
     def run(self):
         tag = os.getenv("CIRCLE_TAG")
 
-        if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
+        if tag != EXPECTED_TAG:
+            info = "Git tag: {0} does not match the expected tag of this app: {1}".format(
+                tag, EXPECTED_TAG
             )
             sys.exit(info)
 

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,1 +1,6 @@
+
+# Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
+
+# Git tag that will be checked to determine whether to trigger upload to pypi
+__release_tag__ = None

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -2,4 +2,4 @@
 __version__ = "0.16.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_1"

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,4 +1,3 @@
-
 # Version of the library that will be used to upload to pypi
 __version__ = "0.16.0"
 

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -7,14 +7,16 @@ from setuptools.command.install import install
 import mlagents.trainers
 
 VERSION = mlagents.trainers.__version__
+EXPECTED_TAG = mlagents.trainers.__release_tag__
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 
 class VerifyVersionCommand(install):
     """
-    Custom command to verify that the git tag matches our version
-    See https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    Custom command to verify that the git tag is the expected one for the release.
+    Based on https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/
+    This differs slightly because our tags and versions are different.
     """
 
     description = "verify that the git tag matches our version"
@@ -22,9 +24,9 @@ class VerifyVersionCommand(install):
     def run(self):
         tag = os.getenv("CIRCLE_TAG")
 
-        if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
+        if tag != EXPECTED_TAG:
+            info = "Git tag: {0} does not match the expected tag of this app: {1}".format(
+                tag, EXPECTED_TAG
             )
             sys.exit(info)
 

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -61,7 +61,14 @@ def check_versions() -> bool:
     return True
 
 
-def set_version(python_version: str, csharp_version: str, release_tag: str) -> None:
+def set_version(
+    python_version: str, csharp_version: str, release_tag: Optional[str]
+) -> None:
+    # Sanity check - make sure test tags have a test or dev version
+    if release_tag and "test" in release_tag:
+        if not ("dev" in python_version or "test" in python_version):
+            raise RuntimeError('Test tags must use a "test" or "dev" version.')
+
     new_contents = PYTHON_VERSION_FILE_TEMPLATE.format(
         version=_escape_non_none(python_version),
         release_tag=_escape_non_none(release_tag),

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -17,8 +17,7 @@ DIRECTORIES = [
 UNITY_PACKAGE_JSON_PATH = "com.unity.ml-agents/package.json"
 ACADEMY_PATH = "com.unity.ml-agents/Runtime/Academy.cs"
 
-PYTHON_VERSION_FILE_TEMPLATE = """
-# Version of the library that will be used to upload to pypi
+PYTHON_VERSION_FILE_TEMPLATE = """# Version of the library that will be used to upload to pypi
 __version__ = {version}
 
 # Git tag that will be checked to determine whether to trigger upload to pypi


### PR DESCRIPTION
### Proposed change(s)
Previously, when we published to pypi (python package index), we had an extra check that the library version matched the tag being applied (this is the process that CircleCI recommends). This won’t work in the upcoming release, because we’ll be tagging `release_1` but publishing `0.16.0` libraries.
This PR adds an extra `__release_tag__` to the files that also contain the version number. and compare that against the tag being applied instead. This tag is now adjusted via the same script that we use to update the version numbers. Will document in the release checklist when it’s ready.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/)


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (see above)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
