### PR TITLE
Installation.md: package.json is a file

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,7 +62,7 @@ this repository. Until then, you will need to
 just cloned. You can add the `com.unity.ml-agents` package to
 your project by navigating to the menu `Window`  -> `Package Manager`. In the package manager
 window click on the `+` button. Select `Add package from disk...` and navigate into the
-`com.unity.ml-agents` folder and select the `package.json` folder.
+`com.unity.ml-agents` folder and select the `package.json` file.
 
 **NOTE:** In Unity 2018.4 it's on the bottom right of the packages list, and in Unity 2019.3 it's
 on the top left of the packages list.


### PR DESCRIPTION
### Proposed change(s)

Very small change, `package.json` is a file and not a folder.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
