### PR TITLE
Removed the default for width and height of the executable training.

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -93,6 +93,7 @@ you will need to change the signature of its `Write()` method. (#3834)
 - The maximum compatible version of tensorflow was changed to allow tensorflow 2.1 and 2.2. This
 will allow use with python 3.8 using tensorflow 2.2.0rc3.
 - `UnityRLCapabilities` was added to help inform users when RL features are mismatched between C# and Python packages. (#3831)
+- `mlagents-learn` will no longer set the width and height of the executable window to 84x84 when no width nor height arguments are given
 
 ### Bug Fixes
 

--- a/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
+++ b/ml-agents-envs/mlagents_envs/side_channel/engine_configuration_channel.py
@@ -9,12 +9,12 @@ from enum import IntEnum
 
 
 class EngineConfig(NamedTuple):
-    width: int
-    height: int
-    quality_level: int
-    time_scale: float
-    target_frame_rate: int
-    capture_frame_rate: int
+    width: Optional[int]
+    height: Optional[int]
+    quality_level: Optional[int]
+    time_scale: Optional[float]
+    target_frame_rate: Optional[int]
+    capture_frame_rate: Optional[int]
 
     @staticmethod
     def default_config():

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -201,14 +201,14 @@ def _create_parser():
     eng_conf = argparser.add_argument_group(title="Engine Configuration")
     eng_conf.add_argument(
         "--width",
-        default=84,
+        default=None,
         type=int,
         help="The width of the executable window of the environment(s) in pixels "
         "(ignored for editor training).",
     )
     eng_conf.add_argument(
         "--height",
-        default=84,
+        default=None,
         type=int,
         help="The height of the executable window of the environment(s) in pixels "
         "(ignored for editor training)",


### PR DESCRIPTION
This is to help resolve #3835 since setting the screen resolution on Linux 2019.3 can cause issues.

### Proposed change(s)

learn.py no longer sets the width and height of the executable window to 84x84.
We do not have a limitation page but we should explain somewhere that linux executable on 2019.3 cannot set the width and height of the executable window.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
