### PR TITLE
use python to call markdown-link-check (instead of bash magic)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,11 +84,8 @@ repos:
     hooks:
     -   id: markdown-link-check
         name: markdown-link-check
-        # markdown-link-check doesn't support multiple files on the commandline, so this hacks around that.
-        # Note that you must install the package separately via npm. For example:
-        #  brew install npm; npm install -g markdown-link-check
-        entry: bash -c 'for i in "$@"; do markdown-link-check -c markdown-link-check.fast.json "$i"; done' --
-        language: system
+        entry: utils/run_markdown_link_check.py
+        language: script
         types: [markdown]
         # Don't check localized files since their target might not be localized.
         exclude: ".*localized.*"
@@ -96,11 +93,14 @@ repos:
         stages: [manual]
     -   id: markdown-link-check-full
         name: markdown-link-check-full
-        entry: bash -c 'for i in "$@"; do markdown-link-check -c markdown-link-check.full.json "$i"; done' --
-        language: system
+        entry: utils/run_markdown_link_check.py
+        language: script
         types: [markdown]
+        # Don't check localized files since their target might not be localized.
         exclude: ".*localized.*"
+        # Only run manually, e.g. pre-commit run --hook-stage manual markdown-link-check-full
         stages: [manual]
+        args: [--check-remote]
     -   id: validate-versions
         name: validate library versions
         language: script

--- a/docs/Training-Curriculum-Learning.md
+++ b/docs/Training-Curriculum-Learning.md
@@ -4,7 +4,8 @@ Curriculum learning is a feature of ML-Agents which allows for the properties of
 
 ## An Instructional Example
 
-*[**Note**: The example provided below is for instructional purposes, and was based on an early version of the [Wall Jump example environment](Example-Environments.md). As such, it is not possible to directly replicate the results here using that environment.]*
+*[**Note**: The example provided below is for instructional purposes, and was based on an early version of the [Wall Jump example environment](Learning-Environment-Examples.md).
+As such, it is not possible to directly replicate the results here using that environment.]*
 
 Imagine a task in which an agent needs to scale a wall to arrive at a goal. The
 starting point when training an agent to accomplish this task will be a random

--- a/docs/Training-on-Microsoft-Azure.md
+++ b/docs/Training-on-Microsoft-Azure.md
@@ -13,7 +13,7 @@ support.
 
 A pre-configured virtual machine image is available in the Azure Marketplace and
 is nearly completely ready for training. You can start by deploying the
-[Data Science Virtual Machine for Linux (Ubuntu)](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-dsvm.linux-data-science-vm-ubuntu)
+[Data Science Virtual Machine for Linux (Ubuntu)](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoft-dsvm.ubuntu-1804)
 into your Azure subscription.
 
 Note that, if you choose to deploy the image to an

--- a/utils/run_markdown_link_check.py
+++ b/utils/run_markdown_link_check.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+
+if __name__ == "__main__":
+    # markdown-link-check doesn't support multiple files on the commandline, so this hacks around that.
+    # Note that you must install the package separately via npm. For example:
+    #  brew install npm; npm install -g markdown-link-check
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-remote", action="store_true")
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+
+    config_file = (
+        "markdown-link-check.full.json"
+        if args.check_remote
+        else "markdown-link-check.fast.json"
+    )
+
+    for f in args.files:
+        subprocess_args = ["markdown-link-check", "-c", config_file, f]
+        subprocess.check_call(subprocess_args)


### PR DESCRIPTION
### Proposed change(s)

Cherry-pick https://github.com/Unity-Technologies/ml-agents/pull/3866

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
