### PR TITLE
replace some crefs with direct links

### DIFF
--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -281,7 +281,8 @@ namespace Unity.MLAgents
         internal VectorSensor collectObservationsSensor;
 
         /// <summary>
-        /// Called when the attached <see cref="GameObject"/> becomes enabled and active.
+        /// Called when the attached [GameObject] becomes enabled and active.
+        /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
         /// </summary>
         /// <remarks>
         /// This function initializes the Agent instance, if it hasn't been initialized yet.
@@ -428,7 +429,8 @@ namespace Unity.MLAgents
         }
 
         /// <summary>
-        /// Called when the attached <see cref="GameObject"/> becomes disabled and inactive.
+        /// Called when the attached [GameObject] becomes disabled and inactive.
+        /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
         /// </summary>
         /// <remarks>
         /// Always call the base Agent class version of this function if you implement `OnDisable()`
@@ -810,7 +812,7 @@ namespace Unity.MLAgents
 
         /// <summary>
         /// Set up the list of ISensors on the Agent. By default, this will select any
-        /// SensorBase's attached to the Agent.
+        /// SensorComponent's attached to the Agent.
         /// </summary>
         internal void InitializeSensors()
         {

--- a/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
@@ -18,7 +18,6 @@ namespace Unity.MLAgents.Sensors
 
     /// <summary>
     /// Sensor interface for generating observations.
-    /// For custom implementations, it is recommended to <see cref="SensorBase"/> instead.
     /// </summary>
     public interface ISensor
     {
@@ -32,8 +31,6 @@ namespace Unity.MLAgents.Sensors
 
         /// <summary>
         /// Write the observation data directly to the <see cref="ObservationWriter"/>.
-        /// This is considered an advanced interface; for a simpler approach, use
-        /// <see cref="SensorBase"/> and override <see cref="SensorBase.WriteObservation"/> instead.
         /// Note that this (and  <see cref="GetCompressedObservation"/>) may
         /// be called multiple times per agent step, so should not mutate any internal state.
         /// </summary>

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 namespace Unity.MLAgents.Sensors
 {
     /// <summary>
-    /// Sensor class that wraps a <see cref="RenderTexture"/> instance.
+    /// Sensor class that wraps a [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html) instance.
     /// </summary>
     public class RenderTextureSensor : ISensor
     {
@@ -26,10 +26,12 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// Initializes the sensor.
         /// </summary>
-        /// <param name="renderTexture">The <see cref="RenderTexture"/> instance to wrap.</param>
+        /// <param name="renderTexture">The [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html)
+        /// instance to wrap.</param>
         /// <param name="grayscale">Whether to convert it to grayscale or not.</param>
         /// <param name="name">Name of the sensor.</param>
         /// <param name="compressionType">Compression method for the render texture.</param>
+        /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
         public RenderTextureSensor(
             RenderTexture renderTexture, bool grayscale, string name, SensorCompressionType compressionType)
         {
@@ -83,7 +85,7 @@ namespace Unity.MLAgents.Sensors
         public void Update() {}
 
         /// <inheritdoc/>
-        public void Reset() { }
+        public void Reset() {}
 
         /// <inheritdoc/>
         public SensorCompressionType GetCompressionType()

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -12,14 +12,15 @@ namespace Unity.MLAgents.Sensors
         RenderTextureSensor m_Sensor;
 
         /// <summary>
-        /// The <see cref="UnityEngine.RenderTexture"/> instance that the associated
-        /// <see cref="RenderTextureSensor"/> wraps.
+        /// The [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html) instance
+        /// that the associated <see cref="RenderTextureSensor"/> wraps.
         /// </summary>
         [HideInInspector, SerializeField, FormerlySerializedAs("renderTexture")]
         RenderTexture m_RenderTexture;
 
         /// <summary>
-        /// Stores the <see cref="UnityEngine.RenderTexture"/> associated with this sensor.
+        /// Stores the [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html)
+        /// associated with this sensor.
         /// </summary>
         public RenderTexture RenderTexture
         {


### PR DESCRIPTION
### Proposed change(s)
Replace some `cref`s with explicit links, since the classes in question aren't part of our docs.
Remove references to SensorBase since it's part of Examples now.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
