### PR TITLE
Ignore ci log file that causes warnings to spam console.

### DIFF
--- a/com.unity.ml-agents/.npmignore
+++ b/com.unity.ml-agents/.npmignore
@@ -17,3 +17,4 @@ build.sh
 build.sh.meta
 build.bat
 build.bat.meta
+upm-ci.log


### PR DESCRIPTION
### Proposed change(s)

Ignore ci log file that causes warnings to spam console.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) See Description.

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
