### PR TITLE
[bug-fix] Fix exception thrown when quitting in-editor training from editor

### DIFF
--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -23,9 +23,9 @@ from mlagents_envs.base_env import (
 from mlagents_envs.timers import timed, hierarchical_timer
 from mlagents_envs.exception import (
     UnityEnvironmentException,
-    UnityCommunicationException,
     UnityActionException,
     UnityTimeOutException,
+    UnityCommunicatorStoppedException,
 )
 
 from mlagents_envs.communicator_objects.command_pb2 import STEP, RESET
@@ -362,7 +362,7 @@ class UnityEnvironment(BaseEnv):
         if self._loaded:
             outputs = self.communicator.exchange(self._generate_reset_input())
             if outputs is None:
-                raise UnityCommunicationException("Communicator has stopped.")
+                raise UnityCommunicatorStoppedException("Communicator has exited.")
             self._update_behavior_specs(outputs)
             rl_output = outputs.rl_output
             self._update_state(rl_output)
@@ -390,7 +390,7 @@ class UnityEnvironment(BaseEnv):
         with hierarchical_timer("communicator.exchange"):
             outputs = self.communicator.exchange(step_input)
         if outputs is None:
-            raise UnityCommunicationException("Communicator has stopped.")
+            raise UnityCommunicatorStoppedException("Communicator has exited.")
         self._update_behavior_specs(outputs)
         rl_output = outputs.rl_output
         self._update_state(rl_output)

--- a/ml-agents-envs/mlagents_envs/exception.py
+++ b/ml-agents-envs/mlagents_envs/exception.py
@@ -24,7 +24,7 @@ class UnityCommunicationException(UnityException):
 
 class UnityCommunicatorStoppedException(UnityException):
     """
-    The communicator has stopped gracefully.
+    Raised when communicator has stopped gracefully.
     """
 
     pass

--- a/ml-agents-envs/mlagents_envs/exception.py
+++ b/ml-agents-envs/mlagents_envs/exception.py
@@ -22,6 +22,14 @@ class UnityCommunicationException(UnityException):
     pass
 
 
+class UnityCommunicatorStoppedException(UnityException):
+    """
+    The communicator has stopped gracefully.
+    """
+
+    pass
+
+
 class UnityObservationException(UnityException):
     """
     Related to errors with receiving observations.

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -7,6 +7,7 @@ from mlagents_envs.exception import (
     UnityCommunicationException,
     UnityTimeOutException,
     UnityEnvironmentException,
+    UnityCommunicatorStoppedException,
 )
 from multiprocessing import Process, Pipe, Queue
 from multiprocessing.connection import Connection
@@ -185,6 +186,7 @@ def worker(
         UnityCommunicationException,
         UnityTimeOutException,
         UnityEnvironmentException,
+        UnityCommunicatorStoppedException,
     ) as ex:
         logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
         step_queue.put(

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -16,6 +16,7 @@ from mlagents.trainers.env_manager import EnvManager
 from mlagents_envs.exception import (
     UnityEnvironmentException,
     UnityCommunicationException,
+    UnityCommunicatorStoppedException,
 )
 from mlagents.trainers.sampler_class import SamplerManager
 from mlagents_envs.timers import hierarchical_timer, timed
@@ -234,12 +235,15 @@ class TrainerController(object):
             KeyboardInterrupt,
             UnityCommunicationException,
             UnityEnvironmentException,
+            UnityCommunicatorStoppedException,
         ) as ex:
             self.kill_trainers = True
             if self.train_model:
                 self._save_model_when_interrupted()
 
-            if isinstance(ex, KeyboardInterrupt):
+            if isinstance(ex, KeyboardInterrupt) or isinstance(
+                ex, UnityCommunicatorStoppedException
+            ):
                 pass
             else:
                 # If the environment failed, we want to make sure to raise

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -249,8 +249,9 @@ class TrainerController(object):
                 # If the environment failed, we want to make sure to raise
                 # the exception so we exit the process with an return code of 1.
                 raise ex
-        if self.train_model:
-            self._export_graph()
+        finally:
+            if self.train_model:
+                self._export_graph()
 
     def end_trainer_episodes(
         self, env: EnvManager, lessons_incremented: Dict[str, bool]


### PR DESCRIPTION
### Proposed change(s)

An exception was being thrown when the communicator was exited from the editor, causing the trainer to throw an error and not save the model. This PR introduces a new type of exception that is only triggered when communication was exited purposefully, and changes the trainer_controller to catch this exception and quit gracefully. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
