### PR TITLE
Set communication protocol to 1.0.0

### DIFF
--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -57,12 +57,12 @@ namespace Unity.MLAgents
     {
         /// <summary>
         /// Communication protocol version.
-        /// When connecting to python, this must match UnityEnvironment.API_VERSION.
-        /// Currently we require strict equality between the communication protocol
-        /// on each side, although we may allow some flexibility in the future.
-        /// This should be incremented whenever a change is made to the communication protocol.
+        /// When connecting to python, this must be compatible with UnityEnvironment.API_VERSION.
+        /// We follow semantic versioning on the communication version, so existing
+        /// functionality will work as long the major versions match.
+        /// This should be changed whenever a change is made to the communication protocol.
         /// </summary>
-        const string k_ApiVersion = "0.17.0";
+        const string k_ApiVersion = "1.0.0";
 
         /// <summary>
         /// Unity package version of com.unity.ml-agents.

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -55,11 +55,11 @@ class UnityEnvironment(BaseEnv):
     SINGLE_BRAIN_ACTION_TYPES = SCALAR_ACTION_TYPES + (list, np.ndarray)
 
     # Communication protocol version.
-    # When connecting to C#, this must match Academy.k_ApiVersion
-    # Currently we require strict equality between the communication protocol
-    # on each side, although we may allow some flexibility in the future.
-    # This should be incremented whenever a change is made to the communication protocol.
-    API_VERSION = "0.17.0"
+    # When connecting to C#, this must be compatible with Academy.k_ApiVersion.
+    # We follow semantic versioning on the communication version, so existing
+    # functionality will work as long the major versions match.
+    # This should be changed whenever a change is made to the communication protocol.
+    API_VERSION = "1.0.0"
 
     # Default port that the editor listens on. If an environment executable
     # isn't specified, this port will be used.


### PR DESCRIPTION
### Proposed change(s)
Set communication protocol to 1.0.0

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-973 (post release, re-enable backcompat test)


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
