### PR TITLE
Fix timers when using multithreading.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -46,3 +46,6 @@ disable =
 
     # Using the global statement
     W0603,
+
+    # "Access to a protected member _foo of a client class (protected-access)"
+    W0212

--- a/docs/Profiling-Python.md
+++ b/docs/Profiling-Python.md
@@ -43,9 +43,14 @@ By default, at the end of training, timers are collected and written in json for
  is optional and defaults to false.
 
 ### Parallel execution
+#### Subprocesses
 For code that executes in multiple processes (for example, SubprocessEnvManager), we periodically send the timer
 information back to the "main" process, aggregate the timers there, and flush them in the subprocess. Note that
 (depending on the number of processes) this can result in timers where the total time may exceed the parent's total
 time. This is analogous to the difference between "real" and "user" values reported from the unix `time` command. In the
 timer output, blocks that were run in parallel are indicated by the `is_parallel` flag.
+
+#### Threads
+Timers currently use `time.perf_counter()` to track time spent, which may not give accurate results for multiple
+threads. If this is problematic, set `threaded: false` in your trainer configuration.
 

--- a/ml-agents-envs/mlagents_envs/tests/test_timers.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_timers.py
@@ -10,9 +10,8 @@ def decorated_func(x: int = 0, y: float = 1.0) -> str:
 
 
 def test_timers() -> None:
-    with mock.patch(
-        "mlagents_envs.timers._global_timer_stack", new_callable=timers.TimerStack
-    ) as test_timer:
+    test_timer = timers.TimerStack()
+    with mock.patch("mlagents_envs.timers._get_thread_timer", return_value=test_timer):
         # First, run some simple code
         with timers.hierarchical_timer("top_level"):
             for i in range(3):

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -19,7 +19,12 @@ from mlagents_envs.exception import (
     UnityCommunicatorStoppedException,
 )
 from mlagents.trainers.sampler_class import SamplerManager
-from mlagents_envs.timers import hierarchical_timer, timed, get_timer_stack_for_thread
+from mlagents_envs.timers import (
+    hierarchical_timer,
+    timed,
+    get_timer_stack_for_thread,
+    merge_gauges,
+)
 from mlagents.trainers.trainer import Trainer
 from mlagents.trainers.meta_curriculum import MetaCurriculum
 from mlagents.trainers.trainer_util import TrainerFactory
@@ -335,6 +340,7 @@ class TrainerController(object):
                         root_name="thread_root",
                         is_parallel=True,
                     )
+                    merge_gauges(thread_timer_stack.gauges)
 
     def trainer_update_func(self, trainer: Trainer) -> None:
         while not self.kill_trainers:


### PR DESCRIPTION
### Proposed change(s)
Fix handling of timers in threaded trainers. 
Previously, we'd keep a single TimerStack, which would get completely garbled when threads switched context.
Now we keep one TimerStack per thread, and merge them when shutting down.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
