### PR TITLE
[docs] Update docs for new results and trainer config

### DIFF
--- a/docs/Learning-Environment-Executable.md
+++ b/docs/Learning-Environment-Executable.md
@@ -89,7 +89,7 @@ For example, if you are training with a 3DBall executable you exported to the
 the directory where you installed the ML-Agents Toolkit, run:
 
 ```sh
-mlagents-learn ../config/ppo/3DBall.yaml --env=3DBall --run-id=firstRun
+mlagents-learn config/ppo/3DBall.yaml --env=3DBall --run-id=firstRun
 ```
 
 And you should see something like

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -465,8 +465,8 @@ Below is a list of included `sampler-type` as part of the toolkit.
     `interval_2_max`], ...]
   - **sub-arguments** - `intervals`
 
-The implementation of the samplers can be found at
-`ml-agents/mlagents/trainers/sampler_class.py`.
+The implementation of the samplers can be found in the
+[sampler_class.py file.](../ml-agents/mlagents/trainers/sampler_class.py).
 
 #### Defining a New Sampler Type
 

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -466,7 +466,7 @@ Below is a list of included `sampler-type` as part of the toolkit.
   - **sub-arguments** - `intervals`
 
 The implementation of the samplers can be found in the
-[sampler_class.py file.](../ml-agents/mlagents/trainers/sampler_class.py).
+[sampler_class.py file](../ml-agents/mlagents/trainers/sampler_class.py).
 
 #### Defining a New Sampler Type
 

--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -5,7 +5,7 @@ with a TensorFlow utility named,
 [TensorBoard](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard).
 
 The `mlagents-learn` command saves training statistics to a folder named
-`summaries`, organized by the `run-id` value you assign to a training session.
+`results`, organized by the `run-id` value you assign to a training session.
 
 In order to observe the training process, either during training or afterward,
 start TensorBoard:
@@ -21,10 +21,8 @@ session running on port 6006 a new session can be launched on an open port using
 the --port option.
 
 **Note:** If you don't assign a `run-id` identifier, `mlagents-learn` uses the
-default string, "ppo". All the statistics will be saved to the same sub-folder
-and displayed as one session in TensorBoard. After a few runs, the displays can
-become difficult to interpret in this situation. You can delete the folders
-under the `summaries` directory to clear out old statistics.
+default string, "ppo". You can delete the folders under the `results` directory
+to clear out old statistics.
 
 On the left side of the TensorBoard window, you can select which of the training
 runs you want to display. You can select multiple run-ids to compare statistics.


### PR DESCRIPTION
### Proposed change(s)

Recent PRs merged the curriculum and parameter randomization YAML files into the main configuration, and moved all artifacts to a single `results/` directory. These doc changes weren't reflected in the refactored release docs. This PR ports those changes over to the new doc format. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
