### PR TITLE
Docs: remove --curriculum flag

### DIFF
--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -390,7 +390,7 @@ The curriculum for each Behavior has the following parameters:
 #### Training with a Curriculum
 
 Once we have specified our metacurriculum and curricula, we can launch
-`mlagents-learn` using the `–curriculum` flag to point to the config file for
+`mlagents-learn` using the config file for
 our curricula and PPO will train using Curriculum Learning. For example, to
 train agents in the Wall Jump environment with curriculum learning, we can run:
 


### PR DESCRIPTION
### Proposed change(s)

The `--curriculum` flag doesn't seem to be needed anymore.

Also I'm not sure when it was removed (I updated from 0.13 recently) but I didn't see a mention in the migration docs.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
