### PR TITLE
re-enable backwards compat tests

### DIFF
--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -17,8 +17,8 @@ test_mac_training_int_{{ editor.version }}:
     # Backwards-compatibility tests.
     # If we make a breaking change to the communication protocol, these will need
     # to be disabled until the next release.
-    # - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.15.0
-    # - python -u -m ml-agents.tests.yamato.training_int_tests --csharp=0.15.0
+    - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.16.0
+    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp=1.0.0
   dependencies:
     - .yamato/standalone-build-test.yml#test_mac_standalone_{{ editor.version }}
   triggers:

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -22,7 +22,8 @@ def run_training(python_version, csharp_version):
     print(
         f"Running training with python={python_version or latest} and c#={csharp_version or latest}"
     )
-    nn_file_expected = f"./results/{run_id}/3DBall.nn"
+    output_dir = "models" if python_version else "results"
+    nn_file_expected = f"./{output_dir}/{run_id}/3DBall.nn"
     if os.path.exists(nn_file_expected):
         # Should never happen - make sure nothing leftover from an old test.
         print("Artifacts from previous build found!")

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -71,7 +71,7 @@ def run_training(python_version, csharp_version):
     )
 
     mla_learn_cmd = (
-        f"mlagents-learn override.yaml --train --env="
+        f"mlagents-learn override.yaml --force --env="
         f"{os.path.join(get_base_output_path(), standalone_player_path)} "
         f"--run-id={run_id} --no-graphics --env-args -logFile -"
     )  # noqa

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -10,6 +10,7 @@ from .yamato_utils import (
     run_standalone_build,
     init_venv,
     override_config_file,
+    override_legacy_config_file,
     checkout_csharp_version,
     undo_git_checkout,
 )
@@ -62,16 +63,17 @@ def run_training(python_version, csharp_version):
 
     # Copy the default training config but override the max_steps parameter,
     # and reduce the batch_size and buffer_size enough to ensure an update step happens.
-    override_config_file(
-        "config/ppo/3DBall.yaml",
-        "override.yaml",
-        max_steps=100,
-        batch_size=10,
-        buffer_size=10,
-    )
+    overrides = {"max_steps": 100, "batch_size": 10, "buffer_size": 10}
+    yaml_out = "override.yaml"
+    if python_version:
+        override_legacy_config_file(
+            python_version, "config/trainer_config.yaml", yaml_out, **overrides
+        )
+    else:
+        override_config_file("config/ppo/3DBall.yaml", yaml_out, **overrides)
 
     mla_learn_cmd = (
-        f"mlagents-learn override.yaml --force --env="
+        f"mlagents-learn {yaml_out} --force --env="
         f"{os.path.join(get_base_output_path(), standalone_player_path)} "
         f"--run-id={run_id} --no-graphics --env-args -logFile -"
     )  # noqa

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -135,12 +135,11 @@ def checkout_csharp_version(csharp_version):
     if csharp_version is None:
         return
 
+    csharp_tag = f"com.unity.ml-agents_{csharp_version}"
     csharp_dirs = ["com.unity.ml-agents", "Project"]
     for csharp_dir in csharp_dirs:
         subprocess.check_call(f"rm -rf {csharp_dir}", shell=True)
-        subprocess.check_call(
-            f"git checkout {csharp_version} -- {csharp_dir}", shell=True
-        )
+        subprocess.check_call(f"git checkout {csharp_tag} -- {csharp_dir}", shell=True)
 
 
 def undo_git_checkout():

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -162,12 +162,8 @@ def override_config_file(src_path, dest_path, **kwargs):
         configs = yaml.safe_load(f)
         behavior_configs = configs["behaviors"]
 
-    for config_name, config in behavior_configs.items():
+    for config in behavior_configs.values():
         config.update(**kwargs)
-
-        # Backwards compat - also put each behavior at the top level for when
-        # we're running against old versions
-        configs[config_name] = config
 
     with open(dest_path, "w") as f:
         yaml.dump(configs, f)

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -171,3 +171,24 @@ def override_config_file(src_path, dest_path, **kwargs):
 
     with open(dest_path, "w") as f:
         yaml.dump(configs, f)
+
+
+def override_legacy_config_file(python_version, src_path, dest_path, **kwargs):
+    """
+    Override settings in a trainer config file, using an old version of the src_path. For example,
+        override_config_file("0.16.0", src_path, dest_path, max_steps=42)
+    will sync the file at src_path from version 0.16.0, copy it to dest_path, and override the
+    max_steps field to 42 for all brains.
+    """
+    # Sync the old version of the file
+    python_tag = f"python_{python_version}"
+    subprocess.check_call(f"git checkout {python_tag} -- {src_path}", shell=True)
+
+    with open(src_path) as f:
+        configs = yaml.safe_load(f)
+
+    for config in configs.values():
+        config.update(**kwargs)
+
+    with open(dest_path, "w") as f:
+        yaml.dump(configs, f)

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -162,8 +162,12 @@ def override_config_file(src_path, dest_path, **kwargs):
         configs = yaml.safe_load(f)
         behavior_configs = configs["behaviors"]
 
-    for config in behavior_configs.values():
+    for config_name, config in behavior_configs.items():
         config.update(**kwargs)
+
+        # Backwards compat - also put each behavior at the top level for when
+        # we're running against old versions
+        configs[config_name] = config
 
     with open(dest_path, "w") as f:
         yaml.dump(configs, f)

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -177,7 +177,7 @@ def override_legacy_config_file(python_version, src_path, dest_path, **kwargs):
     max_steps field to 42 for all brains.
     """
     # Sync the old version of the file
-    python_tag = f"python_{python_version}"
+    python_tag = f"python-packages_{python_version}"
     subprocess.check_call(f"git checkout {python_tag} -- {src_path}", shell=True)
 
     with open(src_path) as f:


### PR DESCRIPTION
### Proposed change(s)
These were disabled before, because we didn't have any published versions compatible with master. Now we do!

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-973


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
