### PR TITLE
Documentation fix: MonoBehaviour.OnAwake -> Awake

### DIFF
--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -255,7 +255,7 @@ in the `TerminalStep` and `TerminalSteps` objects.
     data in the new MonoBehaviour instead.
   - If the class overrode the virtual methods, create a new MonoBehaviour and
     move the logic to it:
-    - Move the InitializeAcademy code to MonoBehaviour.OnAwake
+    - Move the InitializeAcademy code to MonoBehaviour.Awake
     - Move the AcademyStep code to MonoBehaviour.FixedUpdate
     - Move the OnDestroy code to MonoBehaviour.OnDestroy.
     - Move the AcademyReset code to a new method and add it to the


### PR DESCRIPTION
`MonoBehaviour` only calls methods that it knows of in advance. `OnAwake` is not expected to exist and is thus never called. Since there is no real IntelliSense or anything for these "magical" `MonoBehaviour` methods, it's easy to accidentally call the method OnAwake and have it never be called.

### Proposed change(s)

Fix a slight error in the Migrating documentation that might catch developers off-guard otherwise.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
