### PR TITLE
Fix a fatal error that doesn't allow training to run.

### DIFF
--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -414,6 +414,7 @@ behaviors:
     learning_rate: 3.0e-4
     learning_rate_schedule: linear
     max_steps: 5.0e4
+    memory_size: 128
     normalize: false
     num_epoch: 3
     num_layers: 2


### PR DESCRIPTION
mlagents.trainers.exception.UnityTrainerException: The hyper-parameter memory_size could not be found for the <class 'mlagents.trainers.ppo.trainer.PPOTrainer'> trainer of brain RollerBall.

### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
