### PR TITLE
use typing.Mapping

### DIFF
--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -18,7 +18,17 @@ not necessarily correspond to a fixed simulation time increment.
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import List, NamedTuple, Tuple, Optional, Union, Dict, Iterator, Any
+from typing import (
+    List,
+    NamedTuple,
+    Tuple,
+    Optional,
+    Union,
+    Dict,
+    Iterator,
+    Any,
+    Mapping as MappingType,
+)
 import numpy as np
 from enum import Enum
 
@@ -347,7 +357,7 @@ class BaseEnv(ABC):
 
     @property
     @abstractmethod
-    def behavior_specs(self) -> Mapping:
+    def behavior_specs(self) -> MappingType[str, BehaviorSpec]:
         """
         Returns a Mapping from behavior names to behavior specs.
         Agents grouped under the same behavior name have the same action and

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -4,7 +4,7 @@ from distutils.version import StrictVersion
 import numpy as np
 import os
 import subprocess
-from typing import Dict, List, Optional, Any, Tuple
+from typing import Dict, List, Optional, Any, Tuple, Mapping as MappingType
 
 import mlagents_envs
 
@@ -323,7 +323,7 @@ class UnityEnvironment(BaseEnv):
         self._env_actions.clear()
 
     @property
-    def behavior_specs(self) -> BehaviorMapping:
+    def behavior_specs(self) -> MappingType[str, BehaviorSpec]:
         return BehaviorMapping(self._env_specs)
 
     def _assert_behavior_exists(self, behavior_name: str) -> None:


### PR DESCRIPTION
### Proposed change(s)
Use typing.Mapping so the key and value types are obvious.
