### PR TITLE
Fix #3932

### DIFF
--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -124,6 +124,10 @@ namespace Unity.MLAgents.Editor
         static void DrawContinuousVectorAction(Rect position, SerializedProperty property)
         {
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
+
+            // This check is here due to:
+            // https://fogbugz.unity3d.com/f/cases/1246524/
+            // If this case has been resolved, please remove this if condition.
             if (vecActionSize.arraySize != 1)
             {
                 vecActionSize.arraySize = 1;
@@ -147,10 +151,15 @@ namespace Unity.MLAgents.Editor
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
             var newSize = EditorGUI.IntField(
                 position, "Branches Size", vecActionSize.arraySize);
+
+            // This check is here due to:
+            // https://fogbugz.unity3d.com/f/cases/1246524/
+            // If this case has been resolved, please remove this if condition.
             if (newSize != vecActionSize.arraySize)
             {
                 vecActionSize.arraySize = newSize;
             }
+
             position.y += k_LineHeight;
             position.x += 20;
             position.width -= 20;

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -124,7 +124,10 @@ namespace Unity.MLAgents.Editor
         static void DrawContinuousVectorAction(Rect position, SerializedProperty property)
         {
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
-            vecActionSize.arraySize = 1;
+            if (vecActionSize.arraySize != 1)
+            {
+                vecActionSize.arraySize = 1;
+            }
             var continuousActionSize =
                 vecActionSize.GetArrayElementAtIndex(0);
             EditorGUI.PropertyField(
@@ -142,8 +145,12 @@ namespace Unity.MLAgents.Editor
         static void DrawDiscreteVectorAction(Rect position, SerializedProperty property)
         {
             var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
-            vecActionSize.arraySize = EditorGUI.IntField(
+            var newSize = EditorGUI.IntField(
                 position, "Branches Size", vecActionSize.arraySize);
+            if (newSize != vecActionSize.arraySize)
+            {
+                vecActionSize.arraySize = newSize;
+            }
             position.y += k_LineHeight;
             position.x += 20;
             position.width -= 20;


### PR DESCRIPTION
#3663 # Proposed change(s)
Stop the editor from going into a loop when a prefab is selected.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Fogbugz case for the editor bug: 
https://fogbugz.unity3d.com/f/cases/1246524/


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
bug is in the unity editor
