### PR TITLE
update versions for patch release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,20 @@ repos:
         files: "gym-unity/.*"
         args: [--ignore-missing-imports, --disallow-incomplete-defs]
 
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.1
+    hooks:
+    -   id: flake8
+        exclude: >
+            (?x)^(
+                .*_pb2.py|
+                .*_pb2_grpc.py
+            )$
+        # flake8-tidy-imports is used for banned-modules, not actually tidying
+        additional_dependencies: [flake8-comprehensions==3.2.2, flake8-tidy-imports==4.1.0, flake8-bugbear==20.1.4]
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
     -   id: mixed-line-ending
         exclude: >
@@ -38,14 +50,7 @@ repos:
                 .*.meta
             )$
         args: [--fix=lf]
-    -   id: flake8
-        exclude: >
-            (?x)^(
-                .*_pb2.py|
-                .*_pb2_grpc.py
-            )$
-        # flake8-tidy-imports is used for banned-modules, not actually tidying
-        additional_dependencies: [flake8-comprehensions==3.1.4, flake8-tidy-imports==4.0.0, flake8-bugbear==20.1.2]
+
     -   id: trailing-whitespace
         name: trailing-whitespace-markdown
         types: [markdown]

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1-preview] - 2020-05-19
+### Bug Fixes
+#### com.unity.ml-agents (C#)
+#### ml-agents / ml-agents-envs / gym-unity (Python)
+
 ## [1.0.0-preview] - 2020-05-06
 
 ### Major Changes

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -68,7 +68,7 @@ namespace Unity.MLAgents
         /// Unity package version of com.unity.ml-agents.
         /// This must match the version string in package.json and is checked in a unit test.
         /// </summary>
-        internal const string k_PackageVersion = "1.0.0-preview";
+        internal const string k_PackageVersion = "1.0.1-preview";
 
         const int k_EditorTrainingPort = 5004;
 

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents",
   "displayName": "ML Agents",
-  "version": "1.0.0-preview",
+  "version": "1.0.1-preview",
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = "release_1"
+__release_tag__ = "release_2"

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = "release_1"
+__release_tag__ = "release_2"

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = "release_1"
+__release_tag__ = "release_2"

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -204,9 +204,9 @@ class PPOTrainer(RLTrainer):
             self.update_buffer.shuffle(sequence_length=self.policy.sequence_length)
             buffer = self.update_buffer
             max_num_batch = buffer_length // batch_size
-            for l in range(0, max_num_batch * batch_size, batch_size):
+            for i in range(0, max_num_batch * batch_size, batch_size):
                 update_stats = self.optimizer.update(
-                    buffer.make_mini_batch(l, l + batch_size), n_sequences
+                    buffer.make_mini_batch(i, i + batch_size), n_sequences
                 )
                 for stat_name, value in update_stats.items():
                     batch_update_stats[stat_name].append(value)

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -301,7 +301,7 @@ class SubprocessEnvManager(EnvManager):
         return self.env_workers[0].recv().payload
 
     def close(self) -> None:
-        logger.debug(f"SubprocessEnvManager closing.")
+        logger.debug("SubprocessEnvManager closing.")
         self.step_queue.close()
         self.step_queue.join_thread()
         for env_worker in self.env_workers:

--- a/ml-agents/tests/yamato/check_coverage_percent.py
+++ b/ml-agents/tests/yamato/check_coverage_percent.py
@@ -25,9 +25,9 @@ def check_coverage(root_dir, min_percentage):
         # Rather than try to parse the XML, just look for a line of the form
         # <Linecoverage>73.9</Linecoverage>
         lines = f.readlines()
-        for l in lines:
-            if "Linecoverage" in l:
-                pct = l.replace("<Linecoverage>", "").replace("</Linecoverage>", "")
+        for line in lines:
+            if "Linecoverage" in line:
+                pct = line.replace("<Linecoverage>", "").replace("</Linecoverage>", "")
                 pct = float(pct)
                 if pct < min_percentage:
                     print(

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -150,7 +150,7 @@ def undo_git_checkout():
     subprocess.check_call("git reset HEAD .", shell=True)
     subprocess.check_call("git checkout -- .", shell=True)
     # Ensure the cache isn't polluted with old compiled assemblies.
-    subprocess.check_call(f"rm -rf Project/Library", shell=True)
+    subprocess.check_call("rm -rf Project/Library", shell=True)
 
 
 def override_config_file(src_path, dest_path, **kwargs):

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -39,9 +39,9 @@ def _escape_non_none(s: Optional[str]) -> str:
 
 def extract_version_string(filename):
     with open(filename) as f:
-        for l in f.readlines():
-            if l.startswith(VERSION_LINE_START):
-                return l.replace(VERSION_LINE_START, "").strip()
+        for line in f.readlines():
+            if line.startswith(VERSION_LINE_START):
+                return line.replace(VERSION_LINE_START, "").strip()
     return None
 
 

--- a/utils/validate_versions.py
+++ b/utils/validate_versions.py
@@ -117,6 +117,30 @@ def set_academy_version_string(new_version):
         f.writelines(lines)
 
 
+def print_release_tag_commands(
+    python_version: str, csharp_version: str, release_tag: str
+):
+    python_tag = f"python-packages_{python_version}"
+    csharp_tag = f"com.unity.ml-agents_{csharp_version}"
+    docs_tag = f"{release_tag}_docs"
+    print(
+        f"""
+###
+Use these commands to create the tags after the release:
+###
+git checkout {release_tag}
+git tag -f latest_release
+git push -f origin latest_release
+git tag -f {docs_tag}
+git push -f origin {docs_tag}
+git tag {python_tag}
+git push -f origin {python_tag}
+git tag {csharp_tag}
+git push -f origin {csharp_tag}
+"""
+    )
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--python-version", default=None)
@@ -131,6 +155,10 @@ if __name__ == "__main__":
         if args.csharp_version:
             print(f"Updating C# package to version {args.csharp_version}")
         set_version(args.python_version, args.csharp_version, args.release_tag)
+        if args.release_tag is not None:
+            print_release_tag_commands(
+                args.python_version, args.csharp_version, args.release_tag
+            )
     else:
         ok = check_versions()
         return_code = 0 if ok else 1


### PR DESCRIPTION
### Proposed change(s)
Ran this to update the versions:
```
python utils/validate_versions.py --python-version=0.16.1 --csharp-version=1.0.1 --release-tag=release_2
```
Also output the tags that we'll need for release at the end.

And cherrypick the precommit fixes from master so that tests pass.
