### PR TITLE
Python-API md: behavior_spec changed with get_behavior_spec for corre…

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -109,7 +109,7 @@ A `BaseEnv` has the following methods:
   act.
 - **Close : `env.close()`** Sends a shutdown signal to the environment and
   terminates the communication.
-- **Behavior Specs : `env.behavior_specs`** Returns a Mapping of
+- **Behavior Specs : `env.get_behavior_spec(behavior_name: str)`** Returns a Mapping of
   `BehaviorName` to `BehaviorSpec` objects (read only).
   A `BehaviorSpec` contains information such as the observation shapes, the
   action type (multi-discrete or continuous) and the action shape. Note that


### PR DESCRIPTION
![behavior](https://i.ibb.co/rbv2j63/Screenshot-from-2020-05-15-22-09-42.png)

### Proposed change(s)

"env.behavior_specs" mentioned in documentation doesn't exist. Correct call for this I believe should be "env.get_behavior_spec with string name BehaviorName given as argument to this function
To get results said by part below I fixed correct syntax 
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [X] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
