### PR TITLE
ObservableAttribute - use dictionary for sensor type too

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/BoolReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/BoolReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class BoolReflectionSensor : ReflectionSensorBase
     {
-        internal BoolReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public BoolReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 1)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/FloatReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/FloatReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class FloatReflectionSensor : ReflectionSensorBase
     {
-        internal FloatReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public FloatReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 1)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/IntReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/IntReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class IntReflectionSensor : ReflectionSensorBase
     {
-        internal IntReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public IntReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 1)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
@@ -55,7 +55,7 @@ namespace Unity.MLAgents.Sensors.Reflection
         const BindingFlags k_BindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
         /// <summary>
-        /// Supported types and their observation sizes.
+        /// Supported types and their observation sizes and corresponding sensor type.
         /// </summary>
         static Dictionary<Type, (int, Type)> s_TypeToSensorInfo = new Dictionary<Type, (int, Type)>()
         {

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
@@ -57,15 +57,16 @@ namespace Unity.MLAgents.Sensors.Reflection
         /// <summary>
         /// Supported types and their observation sizes.
         /// </summary>
-        static Dictionary<Type, int> s_TypeSizes = new Dictionary<Type, int>()
+        static Dictionary<Type, (int, Type)> s_TypeToSensorInfo = new Dictionary<Type, (int, Type)>()
         {
-            {typeof(int), 1},
-            {typeof(bool), 1},
-            {typeof(float), 1},
-            {typeof(Vector2), 2},
-            {typeof(Vector3), 3},
-            {typeof(Vector4), 4},
-            {typeof(Quaternion), 4},
+            {typeof(int), (1, typeof(IntReflectionSensor))},
+            {typeof(bool), (1, typeof(BoolReflectionSensor))},
+            {typeof(float), (1, typeof(FloatReflectionSensor))},
+
+            {typeof(Vector2), (2, typeof(Vector2ReflectionSensor))},
+            {typeof(Vector3), (3, typeof(Vector3ReflectionSensor))},
+            {typeof(Vector4), (4, typeof(Vector4ReflectionSensor))},
+            {typeof(Quaternion), (4, typeof(QuaternionReflectionSensor))},
         };
 
         /// <summary>
@@ -184,6 +185,12 @@ namespace Unity.MLAgents.Sensors.Reflection
                 memberType = propertyInfo.PropertyType;
             }
 
+            if (!s_TypeToSensorInfo.ContainsKey(memberType))
+            {
+                // For unsupported types, return null and we'll filter them out later.
+                return null;
+            }
+
             string sensorName;
             if (string.IsNullOrEmpty(observableAttribute.m_Name))
             {
@@ -203,40 +210,8 @@ namespace Unity.MLAgents.Sensors.Reflection
                 SensorName = sensorName
             };
 
-            ISensor sensor = null;
-            if (memberType == typeof(Int32))
-            {
-                sensor = new IntReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(float))
-            {
-                sensor = new FloatReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(bool))
-            {
-                sensor = new BoolReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(Vector2))
-            {
-                sensor = new Vector2ReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(Vector3))
-            {
-                sensor = new Vector3ReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(Vector4))
-            {
-                sensor = new Vector4ReflectionSensor(reflectionSensorInfo);
-            }
-            else if (memberType == typeof(Quaternion))
-            {
-                sensor = new QuaternionReflectionSensor(reflectionSensorInfo);
-            }
-            else
-            {
-                // For unsupported types, return null and we'll filter them out later.
-                return null;
-            }
+            var (_, sensorType) = s_TypeToSensorInfo[memberType];
+            var sensor = (ISensor) Activator.CreateInstance(sensorType, reflectionSensorInfo);
 
             // Wrap the base sensor in a StackingSensor if we're using stacking.
             if (observableAttribute.m_NumStackedObservations > 1)
@@ -260,9 +235,10 @@ namespace Unity.MLAgents.Sensors.Reflection
             int sizeOut = 0;
             foreach (var(field, attr) in GetObservableFields(o, excludeInherited))
             {
-                if (s_TypeSizes.ContainsKey(field.FieldType))
+                if (s_TypeToSensorInfo.ContainsKey(field.FieldType))
                 {
-                    sizeOut += s_TypeSizes[field.FieldType] * attr.m_NumStackedObservations;
+                    var (obsSize, _) = s_TypeToSensorInfo[field.FieldType];
+                    sizeOut += obsSize * attr.m_NumStackedObservations;
                 }
                 else
                 {
@@ -272,11 +248,12 @@ namespace Unity.MLAgents.Sensors.Reflection
 
             foreach (var(prop, attr) in GetObservableProperties(o, excludeInherited))
             {
-                if (s_TypeSizes.ContainsKey(prop.PropertyType))
+                if (s_TypeToSensorInfo.ContainsKey(prop.PropertyType))
                 {
                     if (prop.CanRead)
                     {
-                        sizeOut += s_TypeSizes[prop.PropertyType] * attr.m_NumStackedObservations;
+                        var (obsSize, _) = s_TypeToSensorInfo[prop.PropertyType];
+                        sizeOut += obsSize * attr.m_NumStackedObservations;
                     }
                     else
                     {

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/QuaternionReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/QuaternionReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class QuaternionReflectionSensor : ReflectionSensorBase
     {
-        internal QuaternionReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public QuaternionReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 4)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector2ReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector2ReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class Vector2ReflectionSensor : ReflectionSensorBase
     {
-        internal Vector2ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public Vector2ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 2)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector3ReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector3ReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class Vector3ReflectionSensor : ReflectionSensorBase
     {
-        internal Vector3ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public Vector3ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 3)
         {}
 

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector4ReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/Vector4ReflectionSensor.cs
@@ -6,7 +6,7 @@ namespace Unity.MLAgents.Sensors.Reflection
     /// </summary>
     internal class Vector4ReflectionSensor : ReflectionSensorBase
     {
-        internal Vector4ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+        public Vector4ReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, 4)
         {}
 


### PR DESCRIPTION
### Proposed change(s)
This simplifies the sensor creation code a bit.

I initially considered using a delegate for the sensor writing instead, but I think that would be problematic if we want to handle enums here (which I do later).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
