### PR TITLE
When using an executable, we will no longer display process logs in the console

### DIFF
--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -97,6 +97,8 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
                 # This is generally good since we want the environment to have a chance to shutdown,
                 # but may be undesirable in come cases; if so, we'll add a command-line toggle.
                 # Note that on Windows, the CTRL_C signal will still be sent.
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
                 start_new_session=True,
             )
         except PermissionError as perm:

--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -92,12 +92,12 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
         try:
             return subprocess.Popen(
                 subprocess_args,
+                stdout=subprocess.DEVNULL,
                 # start_new_session=True means that signals to the parent python process
                 # (e.g. SIGINT from keyboard interrupt) will not be sent to the new process on POSIX platforms.
                 # This is generally good since we want the environment to have a chance to shutdown,
                 # but may be undesirable in come cases; if so, we'll add a command-line toggle.
                 # Note that on Windows, the CTRL_C signal will still be sent.
-                stdout=subprocess.DEVNULL,
                 start_new_session=True,
             )
         except PermissionError as perm:

--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -97,7 +97,6 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
                 # This is generally good since we want the environment to have a chance to shutdown,
                 # but may be undesirable in come cases; if so, we'll add a command-line toggle.
                 # Note that on Windows, the CTRL_C signal will still be sent.
-                stderr=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 start_new_session=True,
             )


### PR DESCRIPTION


### Proposed change(s)

`subprocess.Popen` will not have stdout in the console.
If this is acceptable, I will update the changelog

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
