### PR TITLE
Allow visual and vector observations at the same time

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - `max_step` in the `TerminalStep` and `TerminalSteps` objects was renamed `interrupted`.
 - `beta` and `epsilon` in `PPO` are no longer decayed by default but follow the same schedule as learning rate. (#3940)
 - `get_behavior_names()` and `get_behavior_spec()` on UnityEnvironment were replaced by the `behavior_specs` property. (#3946)
-- Visual and vector observations can now be used simultaneously. 
+- Visual and vector observations can now be used simultaneously. (#3981)
 ### Minor Changes
 #### com.unity.ml-agents (C#)
 - `ObservableAttribute` was added. Adding the attribute to fields or properties on an Agent will allow it to generate

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - `max_step` in the `TerminalStep` and `TerminalSteps` objects was renamed `interrupted`.
 - `beta` and `epsilon` in `PPO` are no longer decayed by default but follow the same schedule as learning rate. (#3940)
 - `get_behavior_names()` and `get_behavior_spec()` on UnityEnvironment were replaced by the `behavior_specs` property. (#3946)
+- Visual and vector observations can now be used simultaneously. 
 ### Minor Changes
 #### com.unity.ml-agents (C#)
 - `ObservableAttribute` was added. Adding the attribute to fields or properties on an Agent will allow it to generate

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to
 - `max_step` in the `TerminalStep` and `TerminalSteps` objects was renamed `interrupted`.
 - `beta` and `epsilon` in `PPO` are no longer decayed by default but follow the same schedule as learning rate. (#3940)
 - `get_behavior_names()` and `get_behavior_spec()` on UnityEnvironment were replaced by the `behavior_specs` property. (#3946)
-- Visual and vector observations can now be used simultaneously. (#3981)
+- `use_visual` and `allow_multiple_visual_obs` are replaced by `allow_multiple_obs` which allows
+  visual and vector observations to be used simultaneously. (#3981)
 ### Minor Changes
 #### com.unity.ml-agents (C#)
 - `ObservableAttribute` was added. Adding the attribute to fields or properties on an Agent will allow it to generate

--- a/gym-unity/README.md
+++ b/gym-unity/README.md
@@ -31,14 +31,10 @@ from the root of the project repository use:
 ```python
 from gym_unity.envs import UnityToGymWrapper
 
-env = UnityToGymWrapper(unity_environment, worker_id, use_visual, uint8_visual)
+env = UnityToGymWrapper(unity_environment, uint8_visual, allow_multiple_obs)
 ```
 
 - `unity_environment` refers to the Unity environment to be wrapped.
-
-- `use_visual` refers to whether to use visual observations (True) or vector
-  observations (False) as the default observation provided by the `reset` and
-  `step` functions. Defaults to `False`.
 
 - `uint8_visual` refers to whether to output visual observations as `uint8`
   values (0-255). Many common Gym environments (e.g. Atari) do this. By default
@@ -48,8 +44,9 @@ env = UnityToGymWrapper(unity_environment, worker_id, use_visual, uint8_visual)
   Discrete. Otherwise, it will be converted into a MultiDiscrete. Defaults to
   `False`.
 
-- `allow_multiple_visual_obs` will return a list of observation instead of only
-  one if disabled. Defaults to `False`.
+- `allow_multiple_obs` will return a list of observations. The first elements contain the visual observations and the
+  last element contains the array of vector observations. If False the environment returns a single array (containing
+  a single visual observations, if present, otherwise the vector observation)
 
 The returned environment `env` will function as a gym.
 
@@ -58,9 +55,9 @@ The returned environment `env` will function as a gym.
 - It is only possible to use an environment with a **single** Agent.
 - By default, the first visual observation is provided as the `observation`, if
   present. Otherwise, vector observations are provided. You can receive all
-  visual observations by using the `allow_multiple_visual_obs=True` option in
+  visual and vector observations by using the `allow_multiple_obs=True` option in
   the gym parameters. If set to `True`, you will receive a list of `observation`
-  instead of only the first one.
+  instead of only one.
 - The `TerminalSteps` or `DecisionSteps` output from the environment can still
   be accessed from the `info` provided by `env.step(action)`.
 - Stacked vector observations are not supported.
@@ -105,7 +102,7 @@ from gym_unity.envs import UnityToGymWrapper
 
 def main():
     unity_env = UnityEnvironment("./envs/GridWorld")
-    env = UnityToGymWrapper(unity_env, 0, use_visual=True, uint8_visual=True)
+    env = UnityToGymWrapper(unity_env, 0, uint8_visual=True)
     logger.configure('./logs') # Çhange to log in a different directory
     act = deepq.learn(
         env,
@@ -178,7 +175,7 @@ def make_unity_env(env_directory, num_env, visual, start_index=0):
     def make_env(rank, use_visual=True): # pylint: disable=C0111
         def _thunk():
             unity_env = UnityEnvironment(env_directory)
-            env = UnityToGymWrapper(unity_env, rank, use_visual=use_visual, uint8_visual=True)
+            env = UnityToGymWrapper(unity_env, rank, uint8_visual=True)
             env = Monitor(env, logger.get_dir() and os.path.join(logger.get_dir(), str(rank)))
             return env
         return _thunk
@@ -241,7 +238,7 @@ method with the following code.
     game_version = 'v0' if sticky_actions else 'v4'
     full_game_name = '{}NoFrameskip-{}'.format(game_name, game_version)
     unity_env = UnityEnvironment('./envs/GridWorld')
-    env = UnityToGymWrapper(unity_env, use_visual=True, uint8_visual=True)
+    env = UnityToGymWrapper(unity_env, uint8_visual=True)
     return env
 ```
 

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -192,6 +192,10 @@ class UnityToGymWrapper(gym.Env):
                 self.visual_obs = self._preprocess_single(visual_obs[0][0])
 
             default_observation = self.visual_obs
+            if self._get_vec_obs_size() > 0:
+                if not isinstance(default_observation, list):
+                    default_observation = [default_observation]
+                default_observation.append(self._get_vector_obs(info)[0, :])
         elif self._get_vec_obs_size() > 0:
             default_observation = self._get_vector_obs(info)[0, :]
         else:

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -40,7 +40,7 @@ class UnityToGymWrapper(gym.Env):
         """
         Environment initialization
         :param unity_env: The Unity BaseEnv to be wrapped in the gym. Will be closed when the UnityToGymWrapper closes.
-        :param use_visual: Whether to use visual observations. 
+        :param use_visual: Whether to use visual observations.
         :param uint8_visual: Return visual observations as uint8 (0-255) matrices instead of float (0.0-1.0).
         :param flatten_branched: If True, turn branched discrete action spaces into a Discrete space rather than
             MultiDiscrete.

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -40,7 +40,7 @@ class UnityToGymWrapper(gym.Env):
         """
         Environment initialization
         :param unity_env: The Unity BaseEnv to be wrapped in the gym. Will be closed when the UnityToGymWrapper closes.
-        :param use_visual: Whether to use visual observation or vector observation.
+        :param use_visual: Whether to use visual observations. 
         :param uint8_visual: Return visual observations as uint8 (0-255) matrices instead of float (0.0-1.0).
         :param flatten_branched: If True, turn branched discrete action spaces into a Discrete space rather than
             MultiDiscrete.

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -82,6 +82,33 @@ def test_gym_wrapper_visual(use_uint8):
     assert isinstance(info, dict)
 
 
+@pytest.mark.parametrize("use_uint8", [True, False], ids=["float", "uint8"])
+def test_gym_wrapper_visual_and_vector(use_uint8):
+    mock_env = mock.MagicMock()
+    mock_spec = create_mock_group_spec(
+        number_visual_observations=1, vector_observation_space_size=3
+    )
+    mock_decision_step, mock_terminal_step = create_mock_vector_steps(
+        mock_spec, number_visual_observations=1
+    )
+    setup_mock_unityenvironment(
+        mock_env, mock_spec, mock_decision_step, mock_terminal_step
+    )
+
+    env = UnityToGymWrapper(mock_env, use_visual=True, uint8_visual=use_uint8)
+    assert isinstance(env, UnityToGymWrapper)
+    assert isinstance(env.reset()[0], np.ndarray)
+    assert isinstance(env.reset()[1], np.ndarray)
+    actions = env.action_space.sample()
+    assert actions.shape[0] == 2
+    obs, rew, done, info = env.step(actions)
+    assert isinstance(obs[0], np.ndarray)
+    assert isinstance(obs[1], np.ndarray)
+    assert isinstance(rew, float)
+    assert isinstance(done, (bool, np.bool_))
+    assert isinstance(info, dict)
+
+
 # Helper methods
 
 

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -86,7 +86,9 @@ def test_gym_wrapper_visual(use_uint8):
 def test_gym_wrapper_visual_and_vector(use_uint8):
     mock_env = mock.MagicMock()
     mock_spec = create_mock_group_spec(
-        number_visual_observations=1, vector_observation_space_size=3
+        number_visual_observations=1,
+        vector_observation_space_size=3,
+        vector_action_space_size=[2],
     )
     mock_decision_step, mock_terminal_step = create_mock_vector_steps(
         mock_spec, number_visual_observations=1
@@ -100,7 +102,7 @@ def test_gym_wrapper_visual_and_vector(use_uint8):
     assert isinstance(env.reset()[0], np.ndarray)
     assert isinstance(env.reset()[1], np.ndarray)
     actions = env.action_space.sample()
-    assert actions.shape[0] == 2
+    assert actions.shape == (2,)
     obs, rew, done, info = env.step(actions)
     assert isinstance(obs[0], np.ndarray)
     assert isinstance(obs[1], np.ndarray)

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -59,7 +59,7 @@ def test_branched_flatten():
 @pytest.mark.parametrize("use_uint8", [True, False], ids=["float", "uint8"])
 def test_gym_wrapper_visual(use_uint8):
     mock_env = mock.MagicMock()
-    mock_spec = create_mock_group_spec(number_visual_observations=1)
+    mock_spec = create_mock_group_spec(number_visual_observations=1, vector_observation_space_size=0)
     mock_decision_step, mock_terminal_step = create_mock_vector_steps(
         mock_spec, number_visual_observations=1
     )

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -152,7 +152,9 @@ def create_mock_vector_steps(specs, num_agents=1, number_visual_observations=0):
     """
     obs = [np.array([num_agents * [1, 2, 3]]).reshape(num_agents, 3)]
     if number_visual_observations:
-        obs += [np.zeros(shape=(num_agents, 8, 8, 3), dtype=np.float32)]
+        obs += [
+            np.zeros(shape=(num_agents, 8, 8, 3), dtype=np.float32)
+        ] * number_visual_observations
     rewards = np.array(num_agents * [1.0])
     agents = np.array(range(0, num_agents))
     return DecisionSteps(obs, rewards, agents, None), TerminalSteps.empty(specs)

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -59,7 +59,9 @@ def test_branched_flatten():
 @pytest.mark.parametrize("use_uint8", [True, False], ids=["float", "uint8"])
 def test_gym_wrapper_visual(use_uint8):
     mock_env = mock.MagicMock()
-    mock_spec = create_mock_group_spec(number_visual_observations=1, vector_observation_space_size=0)
+    mock_spec = create_mock_group_spec(
+        number_visual_observations=1, vector_observation_space_size=0
+    )
     mock_decision_step, mock_terminal_step = create_mock_vector_steps(
         mock_spec, number_visual_observations=1
     )


### PR DESCRIPTION
### Proposed change(s)
Allow vector observations also when visual observations are used. In this case, the array of vector observations are appended to the list of visual observations. 
Compatibility should be maintained. If no visual observations are used, this PR changes nothing. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
The initial discussion including arguments took place here: https://github.com/Unity-Technologies/ml-agents/issues/3960


### Types of change(s)

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
