### PR TITLE
[docs] Add missing config and make sure to use floats in example

### DIFF
--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -206,6 +206,7 @@ BehaviorPPO:
   time_horizon: 64
   summary_freq: 10000
   vis_encoder_type: simple
+  init_path: null
 
   # PPO-specific configs
   beta: 5.0e-3
@@ -227,7 +228,6 @@ BehaviorPPO:
     batch_size: 512
     num_epoch: 3
     samples_per_update: 0
-    init_path:
 
   reward_signals:
     # environment reward

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -204,6 +204,7 @@ BehaviorPPO:
   normalize: false
   num_layers: 2
   time_horizon: 64
+  summary_freq: 10000
   vis_encoder_type: simple
 
   # PPO-specific configs
@@ -239,7 +240,7 @@ BehaviorPPO:
       strength: 0.02
       gamma: 0.99
       encoding_size: 256
-      learning_rate: 3e-4
+      learning_rate: 3.0e-4
 
     # GAIL
     gail:
@@ -247,7 +248,7 @@ BehaviorPPO:
       gamma: 0.99
       encoding_size: 128
       demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
-      learning_rate: 3e-4
+      learning_rate: 3.0e-4
       use_actions: false
       use_vail: false
 


### PR DESCRIPTION
### Proposed change(s)

The example configuration provided in `Training-ML-Agents.md` was missing the `summary_freq` field and formatted others (`learning_rate`) as strings when they should have been floats. Update the documentation with proper formatting and entries. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
