### PR TITLE
Update Tensorboard doc. Change "results" directory to "summaries"

### DIFF
--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -5,14 +5,14 @@ with a TensorFlow utility named,
 [TensorBoard](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard).
 
 The `mlagents-learn` command saves training statistics to a folder named
-`results`, organized by the `run-id` value you assign to a training session.
+`summaries`, organized by the `run-id` value you assign to a training session.
 
 In order to observe the training process, either during training or afterward,
 start TensorBoard:
 
 1. Open a terminal or console window:
 1. Navigate to the directory where the ML-Agents Toolkit is installed.
-1. From the command line run: `tensorboard --logdir=results --port=6006`
+1. From the command line run: `tensorboard --logdir=summaries --port=6006`
 1. Open a browser window and navigate to
    [localhost:6006](http://localhost:6006).
 
@@ -21,7 +21,7 @@ session running on port 6006 a new session can be launched on an open port using
 the --port option.
 
 **Note:** If you don't assign a `run-id` identifier, `mlagents-learn` uses the
-default string, "ppo". You can delete the folders under the `results` directory
+default string, "ppo". You can delete the folders under the `summaries` directory
 to clear out old statistics.
 
 On the left side of the TensorBoard window, you can select which of the training


### PR DESCRIPTION
### Proposed change(s)

Update Tensorboard doc. Change "results" directory to "summaries"
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
