### PR TITLE
add debugging option to ModelOverrider, handle scene resets

### DIFF
--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -5,6 +5,9 @@ using Unity.Barracuda;
 using System.IO;
 using Unity.MLAgents;
 using Unity.MLAgents.Policies;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Unity.MLAgentsExamples
 {
@@ -38,8 +41,27 @@ namespace Unity.MLAgentsExamples
         int m_MaxEpisodes;
 
         int m_NumSteps;
+        int m_PreviousNumSteps;
+        int m_PreviousAgentCompletedEpisodes;
 
         bool m_QuitOnLoadFailure;
+        [Tooltip("Debug values to be used in place of the command line for overriding models.")]
+        public string debugCommandLineOverride;
+
+        // Static values to keep track of completed episodes and steps across resets
+        // These are updated in OnDisable.
+        static int s_PreviousAgentCompletedEpisodes;
+        static int s_PreviousNumSteps;
+
+        int TotalCompletedEpisodes
+        {
+            get { return m_PreviousAgentCompletedEpisodes + (m_Agent == null ? 0 : m_Agent.CompletedEpisodes);  }
+        }
+
+        int TotalNumSteps
+        {
+            get { return m_PreviousNumSteps + m_NumSteps; }
+        }
 
         /// <summary>
         /// Get the asset path to use from the commandline arguments.
@@ -50,8 +72,13 @@ namespace Unity.MLAgentsExamples
             m_BehaviorNameOverrides.Clear();
 
             var maxEpisodes = 0;
+            string[] commandLineArgsOverride = null;
+            if (!string.IsNullOrEmpty(debugCommandLineOverride) && Application.isEditor)
+            {
+                commandLineArgsOverride = debugCommandLineOverride.Split(' ');
+            }
 
-            var args = Environment.GetCommandLineArgs();
+            var args = commandLineArgsOverride ?? Environment.GetCommandLineArgs();
             for (var i = 0; i < args.Length; i++)
             {
                 if (args[i] == k_CommandLineModelOverrideFlag && i < args.Length-2)
@@ -80,6 +107,10 @@ namespace Unity.MLAgentsExamples
 
         void OnEnable()
         {
+            // Start with these initialized to previous values in the case where we're resetting scenes.
+            m_PreviousNumSteps = s_PreviousNumSteps;
+            m_PreviousAgentCompletedEpisodes = s_PreviousAgentCompletedEpisodes;
+
             m_Agent = GetComponent<Agent>();
 
             GetAssetPathFromCommandLine();
@@ -87,6 +118,15 @@ namespace Unity.MLAgentsExamples
             {
                 OverrideModel();
             }
+        }
+
+        void OnDisable()
+        {
+            // Update the static episode and step counts.
+            // For a single agent in the scene, this will be a straightforward increment.
+            // If there are multiple agents, we'll increment the count by the Agent that completed the most episodes.
+            s_PreviousAgentCompletedEpisodes = Mathf.Max(s_PreviousAgentCompletedEpisodes, TotalCompletedEpisodes);
+            s_PreviousNumSteps = Mathf.Max(s_PreviousNumSteps, TotalNumSteps);
         }
 
         void FixedUpdate()
@@ -97,9 +137,13 @@ namespace Unity.MLAgentsExamples
                 // For Agents that specify MaxStep, also make sure we've gone at least that many steps.
                 // Since we exit as soon as *any* Agent hits its target, the maxSteps condition keeps us running
                 // a bit longer in case there's an early failure.
-                if (m_Agent.CompletedEpisodes >= m_MaxEpisodes && m_NumSteps > m_MaxEpisodes * m_Agent.MaxStep)
+                if (TotalCompletedEpisodes >= m_MaxEpisodes && TotalNumSteps > m_MaxEpisodes * m_Agent.MaxStep)
                 {
+                    Debug.Log($"ModelOverride reached {TotalCompletedEpisodes} episodes and {TotalNumSteps} steps. Exiting.");
                     Application.Quit(0);
+#if UNITY_EDITOR
+                    EditorApplication.isPlaying = false;
+#endif
                 }
             }
             m_NumSteps++;


### PR DESCRIPTION
### Proposed change(s)
The Basic scene is currently broken for inference testing. This is because we reset the scene (as of https://github.com/Unity-Technologies/ml-agents/pull/3789/files) when the episode ends; since the counts are per-ModelOverride and per-Agent, they also get reset when the scene does.

This PR adds a static counter for the number of episodes completed and steps taken; this does what we want for a single Agent, and I think it will behave reasonably for multiple agents too (although we don't have this scenario right now).

Also adds a debug field to override the commandline options used for configuring the model overrider, so that we can test it in the Editor more easily (and thus with a debugger).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/pull/3789/files
https://jira.unity3d.com/browse/MLA-1021


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
