### PR TITLE
lower min pyyaml version

### DIFF
--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -51,7 +51,7 @@ setup(
         "numpy>=1.14.1,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",
-        "pyyaml>=5.1.1",
+        "pyyaml>=3.1.0",
     ],
     python_requires=">=3.5",
     cmdclass={"verify": VerifyVersionCommand},

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -63,7 +63,7 @@ setup(
         "numpy>=1.13.3,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",
-        "pyyaml",
+        "pyyaml>=3.1.0",
         "tensorflow>=1.7,<3.0",
         'pypiwin32==223;platform_system=="Windows"',
         # We don't actually need six, but tensorflow does, and pip seems


### PR DESCRIPTION
### Proposed change(s)
The requirement added yesterday is incompatible with the docker builds for nightly training. I believe the version was arbitrary; this is the oldest version that I could confirm has `safe_load()`.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
