### PR TITLE
Enum reflection sensor

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -20,7 +20,7 @@ vector observations to be used simultaneously. (#3981) Thank you @shakenes !
 ### Minor Changes
 #### com.unity.ml-agents (C#)
 - `ObservableAttribute` was added. Adding the attribute to fields or properties on an Agent will allow it to generate
-  observations via reflection.
+  observations via reflection. (#3925, #4006)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Curriculum and Parameter Randomization configurations have been merged
   into the main training configuration file. Note that this means training

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs
@@ -1,0 +1,50 @@
+using System;
+using UnityEngine;
+
+namespace Unity.MLAgents.Sensors.Reflection
+{
+    internal class EnumReflectionSensor: ReflectionSensorBase
+    {
+        Array m_Values;
+
+        internal EnumReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
+            : base(reflectionSensorInfo, GetEnumObservationSize(reflectionSensorInfo))
+        {
+            var t = reflectionSensorInfo.FieldInfo != null ? reflectionSensorInfo.FieldInfo.FieldType : reflectionSensorInfo.PropertyInfo.PropertyType;
+            m_Values = Enum.GetValues(t);
+        }
+
+        internal override void WriteReflectedField(ObservationWriter writer)
+        {
+            var enumValue = GetReflectedValue();
+            int i = 0;
+            foreach(var val in m_Values)
+            {
+                //Debug.Log($"{val.GetType()}  {enumValue.GetType()}");
+                if (val.Equals(enumValue))
+                {
+                    writer[i] = 1.0f;
+                }
+                else
+                {
+                    writer[i] = 0.0f;
+                }
+
+                i++;
+            }
+        }
+
+        internal static int GetEnumObservationSize(ReflectionSensorInfo reflectionSensorInfo)
+        {
+            var t = reflectionSensorInfo.FieldInfo != null ? reflectionSensorInfo.FieldInfo.FieldType : reflectionSensorInfo.PropertyInfo.PropertyType;
+            return GetEnumObservationSize(t);
+        }
+
+        internal static int GetEnumObservationSize(Type t)
+        {
+            // TODO allow for unknown value
+            var values = Enum.GetValues(t);
+            return values.Length;
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs
@@ -6,43 +6,57 @@ namespace Unity.MLAgents.Sensors.Reflection
     internal class EnumReflectionSensor: ReflectionSensorBase
     {
         Array m_Values;
+        bool m_IsFlags;
 
         internal EnumReflectionSensor(ReflectionSensorInfo reflectionSensorInfo)
             : base(reflectionSensorInfo, GetEnumObservationSize(reflectionSensorInfo.GetMemberType()))
         {
-            m_Values = Enum.GetValues(reflectionSensorInfo.GetMemberType());
+            var memberType = reflectionSensorInfo.GetMemberType();
+            m_Values = Enum.GetValues(memberType);
+            m_IsFlags = memberType.IsDefined(typeof(FlagsAttribute), false);
         }
 
         internal override void WriteReflectedField(ObservationWriter writer)
         {
             // Write the enum value as a one-hot encoding.
-            // If it's not one of the enum values, put a 1 in the last "bit"
-            var enumValue = GetReflectedValue();
+            // Note that unknown enum values will record all 0's.
+            // Flags will get treated as a sequence of bools.
+            var enumValue = (Enum)GetReflectedValue();
 
-            var knownValue = false;
             int i = 0;
             foreach(var val in m_Values)
             {
-                if (val.Equals(enumValue))
+                if (m_IsFlags)
                 {
-                    writer[i] = 1.0f;
-                    knownValue = true;
+                    if (enumValue.HasFlag((Enum)val))
+                    {
+                        writer[i] = 1.0f;
+                    }
+                    else
+                    {
+                        writer[i] = 0.0f;
+                    }
                 }
                 else
                 {
-                    writer[i] = 0.0f;
+                    if (val.Equals(enumValue))
+                    {
+                        writer[i] = 1.0f;
+                    }
+                    else
+                    {
+                        writer[i] = 0.0f;
+                    }
                 }
                 i++;
             }
-
-            writer[i] = knownValue ? 0.0f : 1.0f;
         }
 
         internal static int GetEnumObservationSize(Type t)
         {
             var values = Enum.GetValues(t);
-            // Account for all enum values, plus an extra for unknown values.
-            return values.Length + 1;
+            // Account for all enum values
+            return values.Length;
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/ObservableAttribute.cs
@@ -185,7 +185,7 @@ namespace Unity.MLAgents.Sensors.Reflection
                 memberType = propertyInfo.PropertyType;
             }
 
-            if (!s_TypeToSensorInfo.ContainsKey(memberType))
+            if (!s_TypeToSensorInfo.ContainsKey(memberType) && !memberType.IsEnum)
             {
                 // For unsupported types, return null and we'll filter them out later.
                 return null;
@@ -210,8 +210,16 @@ namespace Unity.MLAgents.Sensors.Reflection
                 SensorName = sensorName
             };
 
-            var (_, sensorType) = s_TypeToSensorInfo[memberType];
-            var sensor = (ISensor) Activator.CreateInstance(sensorType, reflectionSensorInfo);
+            ISensor sensor = null;
+            if (memberType.IsEnum)
+            {
+                sensor = new EnumReflectionSensor(reflectionSensorInfo);
+            }
+            else
+            {
+                var (_, sensorType) = s_TypeToSensorInfo[memberType];
+                sensor = (ISensor) Activator.CreateInstance(sensorType, reflectionSensorInfo);
+            }
 
             // Wrap the base sensor in a StackingSensor if we're using stacking.
             if (observableAttribute.m_NumStackedObservations > 1)
@@ -240,6 +248,10 @@ namespace Unity.MLAgents.Sensors.Reflection
                     var (obsSize, _) = s_TypeToSensorInfo[field.FieldType];
                     sizeOut += obsSize * attr.m_NumStackedObservations;
                 }
+                else if (field.FieldType.IsEnum)
+                {
+                    sizeOut += EnumReflectionSensor.GetEnumObservationSize(field.FieldType);
+                }
                 else
                 {
                     errorsOut.Add($"Unsupported Observable type {field.FieldType.Name} on field {field.Name}");
@@ -248,17 +260,18 @@ namespace Unity.MLAgents.Sensors.Reflection
 
             foreach (var(prop, attr) in GetObservableProperties(o, excludeInherited))
             {
-                if (s_TypeToSensorInfo.ContainsKey(prop.PropertyType))
+                if (!prop.CanRead)
                 {
-                    if (prop.CanRead)
-                    {
-                        var (obsSize, _) = s_TypeToSensorInfo[prop.PropertyType];
-                        sizeOut += obsSize * attr.m_NumStackedObservations;
-                    }
-                    else
-                    {
-                        errorsOut.Add($"Observable property {prop.Name} is write-only.");
-                    }
+                    errorsOut.Add($"Observable property {prop.Name} is write-only.");
+                }
+                else if (s_TypeToSensorInfo.ContainsKey(prop.PropertyType))
+                {
+                    var (obsSize, _) = s_TypeToSensorInfo[prop.PropertyType];
+                    sizeOut += obsSize * attr.m_NumStackedObservations;
+                }
+                else if (prop.PropertyType.IsEnum)
+                {
+                    sizeOut += EnumReflectionSensor.GetEnumObservationSize(prop.PropertyType);
                 }
                 else
                 {

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/ReflectionSensorBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/ReflectionSensorBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 
 namespace Unity.MLAgents.Sensors.Reflection
@@ -13,6 +14,11 @@ namespace Unity.MLAgents.Sensors.Reflection
         public PropertyInfo PropertyInfo;
         public ObservableAttribute ObservableAttribute;
         public string SensorName;
+
+        public Type GetMemberType()
+        {
+            return FieldInfo != null ? FieldInfo.FieldType : PropertyInfo.PropertyType;
+        }
     }
 
     /// <summary>

--- a/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
@@ -10,6 +10,13 @@ namespace Unity.MLAgents.Tests
     [TestFixture]
     public class ObservableAttributeTests
     {
+        public enum TestEnum
+        {
+            ValueA = -100,
+            ValueB = 1,
+            ValueC = 42,
+        }
+
         class TestClass
         {
             // Non-observables
@@ -120,6 +127,23 @@ namespace Unity.MLAgents.Tests
                 get => m_QuaternionProperty;
                 set => m_QuaternionProperty = value;
             }
+
+            //
+            // Enum
+            //
+
+            [Observable("enumMember")]
+            public TestEnum m_EnumMember = TestEnum.ValueA;
+
+            TestEnum m_EnumProperty = TestEnum.ValueC;
+
+            [Observable("enumProperty")]
+            public TestEnum EnumProperty
+            {
+                get => m_EnumProperty;
+                set => m_EnumProperty = value;
+            }
+
         }
 
         [Test]
@@ -178,6 +202,10 @@ namespace Unity.MLAgents.Tests
 
             SensorTestHelper.CompareObservation(sensorsByName["quaternionMember"], new[] { 5.0f, 5.1f, 5.2f, 5.3f });
             SensorTestHelper.CompareObservation(sensorsByName["quaternionProperty"], new[] { 5.4f, 5.5f, 5.5f, 5.7f });
+
+            // Actual ordering is B, C, A
+            SensorTestHelper.CompareObservation(sensorsByName["enumMember"], new[] { 0.0f, 0.0f, 1.0f });
+            //SensorTestHelper.CompareObservation(sensorsByName["enumProperty"], new[] { 0.0f, 1.0f, 0.0f });
         }
 
         [Test]
@@ -185,7 +213,7 @@ namespace Unity.MLAgents.Tests
         {
             var testClass = new TestClass();
             var errors = new List<string>();
-            var expectedObsSize = 2 * (1 + 1 + 1 + 2 + 3 + 4 + 4);
+            var expectedObsSize = 2 * (1 + 1 + 1 + 2 + 3 + 4 + 4 + 3);
             Assert.AreEqual(expectedObsSize, ObservableAttribute.GetTotalObservationSize(testClass, false, errors));
             Assert.AreEqual(0, errors.Count);
         }

--- a/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
@@ -17,6 +17,14 @@ namespace Unity.MLAgents.Tests
             ValueC = 42,
         }
 
+        [Flags]
+        public enum TestFlags
+        {
+            FlagA = 1,
+            FlagB = 2,
+            FlagC = 4
+        }
+
         class TestClass
         {
             // Non-observables
@@ -147,6 +155,21 @@ namespace Unity.MLAgents.Tests
             [Observable("badEnumMember")]
             public TestEnum m_BadEnumMember = (TestEnum)1337;
 
+            //
+            // Flags
+            //
+            [Observable("flagMember")]
+            public TestFlags m_FlagMember = TestFlags.FlagA;
+
+            TestFlags m_FlagProperty = TestFlags.FlagB | TestFlags.FlagC;
+
+            [Observable("flagProperty")]
+            public TestFlags FlagProperty
+            {
+                get => m_FlagProperty;
+                set => m_FlagProperty = value;
+            }
+
         }
 
         [Test]
@@ -207,10 +230,12 @@ namespace Unity.MLAgents.Tests
             SensorTestHelper.CompareObservation(sensorsByName["quaternionProperty"], new[] { 5.4f, 5.5f, 5.5f, 5.7f });
 
             // Actual ordering is B, C, A
-            SensorTestHelper.CompareObservation(sensorsByName["enumMember"], new[] { 0.0f, 0.0f, 1.0f, 0.0f });
-            SensorTestHelper.CompareObservation(sensorsByName["enumProperty"], new[] { 0.0f, 1.0f, 0.0f, 0.0f });
-            SensorTestHelper.CompareObservation(sensorsByName["badEnumMember"], new[] { 0.0f, 0.0f, 0.0f, 1.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["enumMember"], new[] { 0.0f, 0.0f, 1.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["enumProperty"], new[] { 0.0f, 1.0f, 0.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["badEnumMember"], new[] { 0.0f, 0.0f, 0.0f });
 
+            SensorTestHelper.CompareObservation(sensorsByName["flagMember"], new[] { 1.0f, 0.0f, 0.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["flagProperty"], new[] { 0.0f, 1.0f, 1.0f });
         }
 
         [Test]
@@ -226,9 +251,10 @@ namespace Unity.MLAgents.Tests
                     + 3 // vector3
                     + 4 // vector4
                     + 4 // quaternion
-                    + 4 // TestEnum - 3 values + 1 invalid
+                    + 3 // TestEnum - 3 values
+                    + 3 // TestFlags - 3 values
                 )
-                + 4; // TestEnum with bad value
+                + 3; // TestEnum with bad value
             Assert.AreEqual(expectedObsSize, ObservableAttribute.GetTotalObservationSize(testClass, false, errors));
             Assert.AreEqual(0, errors.Count);
         }

--- a/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/ObservableAttributeTests.cs
@@ -144,6 +144,9 @@ namespace Unity.MLAgents.Tests
                 set => m_EnumProperty = value;
             }
 
+            [Observable("badEnumMember")]
+            public TestEnum m_BadEnumMember = (TestEnum)1337;
+
         }
 
         [Test]
@@ -204,8 +207,10 @@ namespace Unity.MLAgents.Tests
             SensorTestHelper.CompareObservation(sensorsByName["quaternionProperty"], new[] { 5.4f, 5.5f, 5.5f, 5.7f });
 
             // Actual ordering is B, C, A
-            SensorTestHelper.CompareObservation(sensorsByName["enumMember"], new[] { 0.0f, 0.0f, 1.0f });
-            //SensorTestHelper.CompareObservation(sensorsByName["enumProperty"], new[] { 0.0f, 1.0f, 0.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["enumMember"], new[] { 0.0f, 0.0f, 1.0f, 0.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["enumProperty"], new[] { 0.0f, 1.0f, 0.0f, 0.0f });
+            SensorTestHelper.CompareObservation(sensorsByName["badEnumMember"], new[] { 0.0f, 0.0f, 0.0f, 1.0f });
+
         }
 
         [Test]
@@ -213,7 +218,17 @@ namespace Unity.MLAgents.Tests
         {
             var testClass = new TestClass();
             var errors = new List<string>();
-            var expectedObsSize = 2 * (1 + 1 + 1 + 2 + 3 + 4 + 4 + 3);
+            var expectedObsSize = 2 * ( // two fields each of these
+                    1 // int
+                    + 1 // float
+                    + 1 // bool
+                    + 2 // vector2
+                    + 3 // vector3
+                    + 4 // vector4
+                    + 4 // quaternion
+                    + 4 // TestEnum - 3 values + 1 invalid
+                )
+                + 4; // TestEnum with bad value
             Assert.AreEqual(expectedObsSize, ObservableAttribute.GetTotalObservationSize(testClass, false, errors));
             Assert.AreEqual(0, errors.Count);
         }

--- a/com.unity.ml-agents/Tests/Editor/Sensor/VectorSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/VectorSensorTests.cs
@@ -24,10 +24,7 @@ namespace Unity.MLAgents.Tests
             Assert.AreEqual(fill, output[0]);
 
             sensor.Write(writer);
-            for (var i = 0; i < numExpected; i++)
-            {
-                Assert.AreEqual(expected[i], output[i]);
-            }
+            Assert.AreEqual(expected, output);
         }
     }
 


### PR DESCRIPTION
### Proposed change(s)
Allow enums with ObservableAttribute. Since the number of possibilities is known ahead of time, we can treat this as a one-hot encoding.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1007


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
