### PR TITLE
Adding the Unity Environment Registry to the Table of Content

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -45,6 +45,7 @@
 
 - [API Reference](API-Reference.md)
 - [How to use the Python API](Python-API.md)
+- [How to use the Unity Environment Registry](Unity-Environment-Registry.md)
 - [Wrapping Learning Environment as a Gym (+Baselines/Dopamine Integration)](../gym-unity/README.md)
 
 ## Translations


### PR DESCRIPTION


### Proposed change(s)

The Unity-Environment-Registry.md file is not linked to by any markdown. Changed that

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
