### PR TITLE
fix missing metafile checks

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs.meta
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/EnumReflectionSensor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d86e42cede474ec28dc3b1ef1c7a63c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/utils/validate_meta_files.py
+++ b/utils/validate_meta_files.py
@@ -2,34 +2,56 @@ import os
 
 
 def main():
-    asset_path = "Project/Assets"
+    asset_paths = ["Project/Assets", "com.unity.ml-agents"]
     meta_suffix = ".meta"
     python_suffix = ".py"
+    whitelist = frozenset(
+        [
+            "com.unity.ml-agents/.editorconfig",
+            "com.unity.ml-agents/.gitignore",
+            "com.unity.ml-agents/.npmignore",
+            "com.unity.ml-agents/Tests/.tests.json",
+        ]
+    )
+    ignored_dirs = {"Documentation~"}
 
     num_matched = 0
 
     unmatched = set()
 
-    for root, dirs, files in os.walk(asset_path):
-        dirs = set(dirs)
-        files = set(files)
+    for asset_path in asset_paths:
+        for root, dirs, files in os.walk(asset_path, topdown=True):
+            # Modifying the dirs list with topdown=True will prevent us from recursing those directories
+            for ignored in ignored_dirs:
+                try:
+                    dirs.remove(ignored)
+                except ValueError:
+                    pass
 
-        combined = dirs | files
-        for f in combined:
-            if f.endswith(python_suffix):
-                # Probably this script; skip it
-                continue
+            dirs = set(dirs)
+            files = set(files)
 
-            # We expect each non-.meta file to have a .meta file, and each .meta file to have a non-.meta file
-            if f.endswith(meta_suffix):
-                expected = f.replace(meta_suffix, "")
-            else:
-                expected = f + meta_suffix
+            combined = dirs | files
+            for f in combined:
 
-            if expected not in combined:
-                unmatched.add(os.path.join(root, f))
-            else:
-                num_matched += 1
+                if f.endswith(python_suffix):
+                    # Probably this script; skip it
+                    continue
+
+                full_path = os.path.join(root, f)
+                if full_path in whitelist:
+                    continue
+
+                # We expect each non-.meta file to have a .meta file, and each .meta file to have a non-.meta file
+                if f.endswith(meta_suffix):
+                    expected = f.replace(meta_suffix, "")
+                else:
+                    expected = f + meta_suffix
+
+                if expected not in combined:
+                    unmatched.add(full_path)
+                else:
+                    num_matched += 1
 
     if unmatched:
         raise Exception(

--- a/utils/validate_meta_files.py
+++ b/utils/validate_meta_files.py
@@ -20,8 +20,8 @@ def main():
     unmatched = set()
 
     for asset_path in asset_paths:
-        for root, dirs, files in os.walk(asset_path, topdown=True):
-            # Modifying the dirs list with topdown=True will prevent us from recursing those directories
+        for root, dirs, files in os.walk(asset_path):
+            # Modifying the dirs list with topdown=True (the default) will prevent us from recursing those directories
             for ignored in ignored_dirs:
                 try:
                     dirs.remove(ignored)


### PR DESCRIPTION
### Proposed change(s)
This has been broken for a while because it doesn't check the package directory. This led to shipping with a missing metafile, which was discovered when installing the package from packman.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
