### PR TITLE
Added a random action creator on the BehaviorSpecs

### DIFF
--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -312,10 +312,38 @@ class BehaviorSpec(NamedTuple):
             return None
 
     def create_empty_action(self, n_agents: int) -> np.ndarray:
+        """
+        Generates a numpy array corresponding to an empty action (all zeros)
+        for a number of agents.
+        :param n_agents: The number of agents that will have actions generated
+        """
         if self.action_type == ActionType.DISCRETE:
             return np.zeros((n_agents, self.action_size), dtype=np.int32)
         else:
             return np.zeros((n_agents, self.action_size), dtype=np.float32)
+
+    def create_random_action(
+        self, n_agents: int, generator: np.random.Generator
+    ) -> np.ndarray:
+        """
+        Generates a numpy array corresponding to a random action (either discrete
+        or continuous) for a number of agents.
+        :param n_agents: The number of agents that will have actions generated
+        :param generator: The random number generator used for creating random action
+        """
+        if self.action_type == ActionType.DISCRETE:
+            action = np.zeros((n_agents, 0), dtype=np.int32)
+            for branch_size in self.action_shape:  # type: ignore
+                branch_action = generator.integers(
+                    0, branch_size, size=(n_agents, 1), dtype=np.int32
+                )
+                action = np.concatenate([action, branch_action], axis=1)
+            return action
+        else:
+            return (
+                generator.random((n_agents, self.action_size), dtype=np.float32) * 2.0
+                - 1.0
+            )
 
 
 class BehaviorMapping(Mapping):

--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -322,28 +322,32 @@ class BehaviorSpec(NamedTuple):
         else:
             return np.zeros((n_agents, self.action_size), dtype=np.float32)
 
-    def create_random_action(
-        self, n_agents: int, generator: np.random.Generator
-    ) -> np.ndarray:
+    def create_random_action(self, n_agents: int) -> np.ndarray:
         """
         Generates a numpy array corresponding to a random action (either discrete
         or continuous) for a number of agents.
         :param n_agents: The number of agents that will have actions generated
         :param generator: The random number generator used for creating random action
         """
-        if self.action_type == ActionType.DISCRETE:
-            action = np.zeros((n_agents, 0), dtype=np.int32)
-            for branch_size in self.action_shape:  # type: ignore
-                branch_action = generator.integers(
-                    0, branch_size, size=(n_agents, 1), dtype=np.int32
-                )
-                action = np.concatenate([action, branch_action], axis=1)
+        if self.is_action_continuous():
+            action = np.random.uniform(
+                low=-1.0, high=1.0, size=(n_agents, self.action_size)
+            ).astype(np.float32)
             return action
-        else:
-            return (
-                generator.random((n_agents, self.action_size), dtype=np.float32) * 2.0
-                - 1.0
+        elif self.is_action_discrete():
+            branch_size = self.discrete_action_branches
+            action = np.column_stack(
+                [
+                    np.random.randint(
+                        0,
+                        branch_size[i],  # type: ignore
+                        size=(n_agents),
+                        dtype=np.int32,
+                    )
+                    for i in range(self.action_size)
+                ]
             )
+            return action
 
 
 class BehaviorMapping(Mapping):

--- a/ml-agents-envs/mlagents_envs/tests/test_steps.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_steps.py
@@ -112,9 +112,7 @@ def test_action_generator():
     )
     zero_action = specs.create_empty_action(4)
     assert np.array_equal(zero_action, np.zeros((4, action_len), dtype=np.float32))
-    random_action = specs.create_random_action(
-        4, np.random.Generator(np.random.PCG64())
-    )
+    random_action = specs.create_random_action(4)
     assert random_action.dtype == np.float32
     assert random_action.shape == (4, action_len)
     assert np.min(random_action) >= -1
@@ -130,9 +128,7 @@ def test_action_generator():
     zero_action = specs.create_empty_action(4)
     assert np.array_equal(zero_action, np.zeros((4, len(action_shape)), dtype=np.int32))
 
-    random_action = specs.create_random_action(
-        4, np.random.Generator(np.random.PCG64())
-    )
+    random_action = specs.create_random_action(4)
     assert random_action.dtype == np.int32
     assert random_action.shape == (4, len(action_shape))
     assert np.min(random_action) >= 0

--- a/ml-agents-envs/mlagents_envs/tests/test_steps.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_steps.py
@@ -100,3 +100,41 @@ def test_specs():
     assert specs.action_size == 1
     assert specs.create_empty_action(5).shape == (5, 1)
     assert specs.create_empty_action(5).dtype == np.int32
+
+
+def test_action_generator():
+    # Continuous
+    action_len = 30
+    specs = BehaviorSpec(
+        observation_shapes=[(5,)],
+        action_type=ActionType.CONTINUOUS,
+        action_shape=action_len,
+    )
+    zero_action = specs.create_empty_action(4)
+    assert np.array_equal(zero_action, np.zeros((4, action_len), dtype=np.float32))
+    random_action = specs.create_random_action(
+        4, np.random.Generator(np.random.PCG64())
+    )
+    assert random_action.dtype == np.float32
+    assert random_action.shape == (4, action_len)
+    assert np.min(random_action) >= -1
+    assert np.max(random_action) <= 1
+
+    # Discrete
+    action_shape = (10, 20, 30)
+    specs = BehaviorSpec(
+        observation_shapes=[(5,)],
+        action_type=ActionType.DISCRETE,
+        action_shape=action_shape,
+    )
+    zero_action = specs.create_empty_action(4)
+    assert np.array_equal(zero_action, np.zeros((4, len(action_shape)), dtype=np.int32))
+
+    random_action = specs.create_random_action(
+        4, np.random.Generator(np.random.PCG64())
+    )
+    assert random_action.dtype == np.int32
+    assert random_action.shape == (4, len(action_shape))
+    assert np.min(random_action) >= 0
+    for index, branch_size in enumerate(action_shape):
+        assert np.max(random_action[:, index]) < branch_size

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "cloudpickle",
         "grpcio>=1.11.0",
-        "numpy>=1.14.1,<2.0",
+        "numpy>=1.17.1,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",
         "pyyaml>=3.1.0",

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "cloudpickle",
         "grpcio>=1.11.0",
-        "numpy>=1.18.2,<2.0",
+        "numpy>=1.14.1,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",
         "pyyaml>=3.1.0",

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "cloudpickle",
         "grpcio>=1.11.0",
-        "numpy>=1.17.1,<2.0",
+        "numpy>=1.18.2,<2.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6",
         "pyyaml>=3.1.0",


### PR DESCRIPTION
### Proposed change(s)

I want to add a random action generator to the behavior specs.
This is an example of implementation here are other suggestions :
Option 1 : Create a new class ActionSampler that takes as input a random generator and a behavior spec. Note that this could be some sort of heuristic "policy" on Python
Option2 : Make the BehaviorSpecs an object (and not a named tuple) and have it hold the random generator. (I do not like this option as the random number generator will not be used most of the time)
Option 3 (This) : The create_random_action takes a RandomGenerator as input

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
