### PR TITLE
[versioning] Save ML-Agents version in checkpoints and check on load

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -31,6 +31,8 @@ vector observations to be used simultaneously. (#3981) Thank you @shakenes !
   directory. (#3829)
 - Unity Player logs are now written out to the results directory. (#3877)
 - Run configuration YAML files are written out to the results directory at the end of the run. (#3815)
+- When trying to load/resume from a checkpoint created with an earlier verison of ML-Agents,
+  a warning will be thrown. (#4035)
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)

--- a/ml-agents/mlagents/model_serialization.py
+++ b/ml-agents/mlagents/model_serialization.py
@@ -49,9 +49,10 @@ MODEL_CONSTANTS = frozenset(
         "action_output_shape",
         "is_continuous_control",
         "memory_size",
-        "major_version",
-        "minor_version",
-        "patch_version",
+        "version_number",
+        "trainer_major_version",
+        "trainer_minor_version",
+        "trainer_patch_version",
     ]
 )
 VISUAL_OBSERVATION_PREFIX = "visual_observation_"

--- a/ml-agents/mlagents/model_serialization.py
+++ b/ml-agents/mlagents/model_serialization.py
@@ -45,7 +45,14 @@ POSSIBLE_OUTPUT_NODES = frozenset(
 )
 
 MODEL_CONSTANTS = frozenset(
-    ["action_output_shape", "is_continuous_control", "memory_size", "version_number"]
+    [
+        "action_output_shape",
+        "is_continuous_control",
+        "memory_size",
+        "major_version",
+        "minor_version",
+        "patch_version",
+    ]
 )
 VISUAL_OBSERVATION_PREFIX = "visual_observation_"
 

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -524,13 +524,13 @@ class TFPolicy(Policy):
             )
             self.version_tensors = (major_ver_t, minor_ver_t, patch_ver_t)
             tf.Variable(
-                self.m_size, name="memory_size", trainable=False, dtype=tf.int32
-            )
-            tf.Variable(
                 MODEL_FORMAT_VERSION,
                 name="version_number",
                 trainable=False,
                 dtype=tf.int32,
+            )
+            tf.Variable(
+                self.m_size, name="memory_size", trainable=False, dtype=tf.int32
             )
             if self.brain.vector_action_space_type == "continuous":
                 tf.Variable(

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -127,18 +127,21 @@ class TFPolicy(Policy):
             int_version.append(int(num))
         return tuple(int_version)
 
-    def _check_model_version(self):
+    def _check_model_version(self, version: str) -> None:
         """
         Checks whether the model being loaded was created with the same version of
         ML-Agents, and throw a warning if not so.
         """
-        loaded_ver = tuple(num.eval(session=self.sess) for num in self.version_tensors)
-        if loaded_ver != TFPolicy._convert_version_string(__version__):
-            logger.warning(
-                f"The model checkpoint you are loading from was saved with ML-Agents version "
-                f"{loaded_ver[0]}.{loaded_ver[1]}.{loaded_ver[2]} but your current ML-Agents"
-                f"version is {__version__}. Model may not behave properly."
+        if self.version_tensors is not None:
+            loaded_ver = tuple(
+                num.eval(session=self.sess) for num in self.version_tensors
             )
+            if loaded_ver != TFPolicy._convert_version_string(version):
+                logger.warning(
+                    f"The model checkpoint you are loading from was saved with ML-Agents version "
+                    f"{loaded_ver[0]}.{loaded_ver[1]}.{loaded_ver[2]} but your current ML-Agents"
+                    f"version is {version}. Model may not behave properly."
+                )
 
     def _initialize_graph(self):
         with self.graph.as_default():
@@ -172,7 +175,7 @@ class TFPolicy(Policy):
                         model_path
                     )
                 )
-            self._check_model_version()
+            self._check_model_version(__version__)
             if reset_global_steps:
                 self._set_step(0)
                 logger.info(

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -20,6 +20,11 @@ from mlagents.trainers import __version__
 logger = get_logger(__name__)
 
 
+# This is the version number of the inputs and outputs of the model, and
+# determines compatibility with inference in Barracuda.
+API_VERSION_NUMBER = 2
+
+
 class UnityPolicyException(UnityException):
     """
     Related to errors with the Trainer.
@@ -47,6 +52,7 @@ class TFPolicy(Policy):
         :param brain: The corresponding Brain for this policy.
         :param trainer_settings: The trainer parameters.
         """
+
         self.m_size = 0
         self.trainer_settings = trainer_settings
         self.network_settings: NetworkSettings = trainer_settings.network_settings
@@ -500,17 +506,32 @@ class TFPolicy(Policy):
             )
             int_version = TFPolicy._convert_version_string(__version__)
             major_ver_t = tf.Variable(
-                int_version[0], name="major_version", trainable=False, dtype=tf.int32
+                int_version[0],
+                name="trainer_major_version",
+                trainable=False,
+                dtype=tf.int32,
             )
             minor_ver_t = tf.Variable(
-                int_version[1], name="minor_version", trainable=False, dtype=tf.int32
+                int_version[1],
+                name="trainer_minor_version",
+                trainable=False,
+                dtype=tf.int32,
             )
             patch_ver_t = tf.Variable(
-                int_version[2], name="patch_version", trainable=False, dtype=tf.int32
+                int_version[2],
+                name="trainer_patch_version",
+                trainable=False,
+                dtype=tf.int32,
             )
             self.version_tensors = (major_ver_t, minor_ver_t, patch_ver_t)
             tf.Variable(
                 self.m_size, name="memory_size", trainable=False, dtype=tf.int32
+            )
+            tf.Variable(
+                API_VERSION_NUMBER,
+                name="version_number",
+                trainable=False,
+                dtype=tf.int32,
             )
             if self.brain.vector_action_space_type == "continuous":
                 tf.Variable(

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import abc
 import os
 import numpy as np
+from distutils.version import LooseVersion
+
 from mlagents.tf_utils import tf
 from mlagents import tf_utils
 from mlagents_envs.exception import UnityException
@@ -22,7 +24,7 @@ logger = get_logger(__name__)
 
 # This is the version number of the inputs and outputs of the model, and
 # determines compatibility with inference in Barracuda.
-API_VERSION_NUMBER = 2
+MODEL_FORMAT_VERSION = 2
 
 
 class UnityPolicyException(UnityException):
@@ -127,11 +129,8 @@ class TFPolicy(Policy):
         :param version_string: The semantic-versioned version string (X.Y.Z).
         :return: A Tuple containing (major_ver, minor_ver, patch_ver).
         """
-        split_ver = version_string.split(".")[0:3]  # Remove dev tag
-        int_version = []
-        for num in split_ver:
-            int_version.append(int(num))
-        return tuple(int_version)
+        ver = LooseVersion(version_string)
+        return tuple(map(int, ver.version[0:3]))
 
     def _check_model_version(self, version: str) -> None:
         """
@@ -528,7 +527,7 @@ class TFPolicy(Policy):
                 self.m_size, name="memory_size", trainable=False, dtype=tf.int32
             )
             tf.Variable(
-                API_VERSION_NUMBER,
+                MODEL_FORMAT_VERSION,
                 name="version_number",
                 trainable=False,
                 dtype=tf.int32,

--- a/ml-agents/mlagents/trainers/tests/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/test_policy.py
@@ -61,3 +61,11 @@ def test_take_action_returns_action_info_when_available():
         policy_eval_out["action"], policy_eval_out["value"], policy_eval_out, [0]
     )
     assert result == expected
+
+
+def test_convert_version_string():
+    result = TFPolicy._convert_version_string("200.300.100")
+    assert result == (200, 300, 100)
+    # Test dev versions
+    result = TFPolicy._convert_version_string("200.300.100.dev0")
+    assert result == (200, 300, 100)

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -167,12 +167,12 @@ def test_simple_ppo(use_discrete):
 @pytest.mark.parametrize("use_discrete", [True, False])
 def test_2d_ppo(use_discrete):
     env = SimpleEnvironment(
-        [BRAIN_NAME], use_discrete=use_discrete, action_size=2, step_size=0.5
+        [BRAIN_NAME], use_discrete=use_discrete, action_size=2, step_size=0.8
     )
     new_hyperparams = attr.evolve(
         PPO_CONFIG.hyperparameters, batch_size=64, buffer_size=640
     )
-    config = attr.evolve(PPO_CONFIG, hyperparameters=new_hyperparams)
+    config = attr.evolve(PPO_CONFIG, hyperparameters=new_hyperparams, max_steps=10000)
     _check_environment_trains(env, {BRAIN_NAME: config})
 
 
@@ -312,8 +312,8 @@ def test_recurrent_sac(use_discrete):
     )
     new_hyperparams = attr.evolve(
         SAC_CONFIG.hyperparameters,
-        batch_size=64,
-        learning_rate=1e-3,
+        batch_size=128,
+        learning_rate=3e-4,
         buffer_init_steps=500,
         steps_per_update=2,
     )

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -308,12 +308,12 @@ def test_recurrent_sac(use_discrete):
     )
     new_networksettings = attr.evolve(
         SAC_CONFIG.network_settings,
-        memory=NetworkSettings.MemorySettings(memory_size=16, sequence_length=32),
+        memory=NetworkSettings.MemorySettings(memory_size=16, sequence_length=16),
     )
     new_hyperparams = attr.evolve(
         SAC_CONFIG.hyperparameters,
         batch_size=128,
-        learning_rate=3e-4,
+        learning_rate=1e-3,
         buffer_init_steps=500,
         steps_per_update=2,
     )

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -308,14 +308,14 @@ def test_recurrent_sac(use_discrete):
         SAC_CONFIG.hyperparameters,
         batch_size=64,
         learning_rate=1e-3,
-        buffer_init_steps=500,
+        buffer_init_steps=1000,
         steps_per_update=2,
     )
     config = attr.evolve(
         SAC_CONFIG,
         hyperparameters=new_hyperparams,
         network_settings=new_networksettings,
-        max_steps=5000,
+        max_steps=7000,
     )
     _check_environment_trains(env, {BRAIN_NAME: config})
 

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -302,7 +302,7 @@ def test_visual_advanced_sac(vis_encode_type, num_visual):
 
 @pytest.mark.parametrize("use_discrete", [True, False])
 def test_recurrent_sac(use_discrete):
-    step_size = 0.2 if use_discrete else 0.8
+    step_size = 0.2 if use_discrete else 1.0
     env = MemoryEnvironment(
         [BRAIN_NAME], use_discrete=use_discrete, step_size=step_size
     )

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -169,7 +169,9 @@ def test_2d_ppo(use_discrete):
     env = SimpleEnvironment(
         [BRAIN_NAME], use_discrete=use_discrete, action_size=2, step_size=0.5
     )
-    new_hyperparams = attr.evolve(PPO_CONFIG.hyperparameters, batch_size=64)
+    new_hyperparams = attr.evolve(
+        PPO_CONFIG.hyperparameters, batch_size=64, buffer_size=640
+    )
     config = attr.evolve(PPO_CONFIG, hyperparameters=new_hyperparams)
     _check_environment_trains(env, {BRAIN_NAME: config})
 
@@ -300,7 +302,7 @@ def test_visual_advanced_sac(vis_encode_type, num_visual):
 
 @pytest.mark.parametrize("use_discrete", [True, False])
 def test_recurrent_sac(use_discrete):
-    step_size = 0.2 if use_discrete else 0.5
+    step_size = 0.2 if use_discrete else 0.8
     env = MemoryEnvironment(
         [BRAIN_NAME], use_discrete=use_discrete, step_size=step_size
     )

--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -169,7 +169,8 @@ def test_2d_ppo(use_discrete):
     env = SimpleEnvironment(
         [BRAIN_NAME], use_discrete=use_discrete, action_size=2, step_size=0.5
     )
-    config = attr.evolve(PPO_CONFIG)
+    new_hyperparams = attr.evolve(PPO_CONFIG.hyperparameters, batch_size=64)
+    config = attr.evolve(PPO_CONFIG, hyperparameters=new_hyperparams)
     _check_environment_trains(env, {BRAIN_NAME: config})
 
 
@@ -299,7 +300,10 @@ def test_visual_advanced_sac(vis_encode_type, num_visual):
 
 @pytest.mark.parametrize("use_discrete", [True, False])
 def test_recurrent_sac(use_discrete):
-    env = MemoryEnvironment([BRAIN_NAME], use_discrete=use_discrete)
+    step_size = 0.2 if use_discrete else 0.5
+    env = MemoryEnvironment(
+        [BRAIN_NAME], use_discrete=use_discrete, step_size=step_size
+    )
     new_networksettings = attr.evolve(
         SAC_CONFIG.network_settings,
         memory=NetworkSettings.MemorySettings(memory_size=16, sequence_length=32),
@@ -308,14 +312,14 @@ def test_recurrent_sac(use_discrete):
         SAC_CONFIG.hyperparameters,
         batch_size=64,
         learning_rate=1e-3,
-        buffer_init_steps=1000,
+        buffer_init_steps=500,
         steps_per_update=2,
     )
     config = attr.evolve(
         SAC_CONFIG,
         hyperparameters=new_hyperparams,
         network_settings=new_networksettings,
-        max_steps=7000,
+        max_steps=5000,
     )
     _check_environment_trains(env, {BRAIN_NAME: config})
 


### PR DESCRIPTION
### Proposed change(s)

This PR saves the semantic version of the trainer package (`major`, `minor`, and `patch`) as 3 variables in the TF graph. It is also exported into the .nn file. This lets us check whether a checkpoint is being loaded from the same version of ML-Agents, and (in the future) check which version of ML-Agents created a particular NN file. 

Note that this is different than the existing version number in the NN, which is checked by C#. That number corresponds to the input and output tensors. It is possible, when upgrading the Trainer code, for an NN file to remain compatible with C# but not be loadable into Python for training (e.g. if the network architecture changes). 

Currently, we throw a warning if the versions don't match when a user tries to load a checkpoint.

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)