### PR TITLE
Linux: reuse ports faster

### DIFF
--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -76,6 +76,8 @@ class RpcCommunicator(Communicator):
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if platform == "linux" or platform == "linux2":
+            # On linux, the port remains unusable for TIME_WAIT=60 seconds after closing
+            # This change allows to reuse the port right after closing the environment
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             s.bind(("localhost", port))

--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -76,6 +76,7 @@ class RpcCommunicator(Communicator):
         Attempts to bind to the requested communicator port, checking if it is already in use.
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             s.bind(("localhost", port))
         except socket.error:

--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -77,7 +77,7 @@ class RpcCommunicator(Communicator):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if platform == "linux" or platform == "linux2":
             # On linux, the port remains unusable for TIME_WAIT=60 seconds after closing
-            # This change allows to reuse the port right after closing the environment
+            # SO_REUSEADDR frees the port right after closing the environment
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             s.bind(("localhost", port))

--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -56,7 +56,9 @@ class RpcCommunicator(Communicator):
 
         try:
             # Establish communication grpc
-            self.server = grpc.server(ThreadPoolExecutor(max_workers=10))
+            self.server = grpc.server(
+                ThreadPoolExecutor(max_workers=10), options=(("grpc.so_reuseport", 0),)
+            )
             self.unity_to_external = UnityToExternalServicerImplementation()
             add_UnityToExternalProtoServicer_to_server(
                 self.unity_to_external, self.server


### PR DESCRIPTION
### Proposed change(s)

Linux has a limitation where the same port cannot be used for 6 seconds after it has been closed.
This fix allows to reuse the port faster.
There is a possibility that there are unintended consequences for other platforms, but it seems on mac, the error for trying to use the same port with 2 different mlagents-learn session raises correctly.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Issue #1505

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
