### PR TITLE
[bug-fix] Fix issue with SAC updating too much on resume

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -32,6 +32,8 @@ vector observations to be used simultaneously. (#3981) Thank you @shakenes !
 - Unity Player logs are now written out to the results directory. (#3877)
 - Run configuration YAML files are written out to the results directory at the end of the run. (#3815)
 ### Bug Fixes
+- Fixed an issue where SAC would perform a large number of model updates when resuming from a
+  checkpoint (#4038)
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -32,8 +32,8 @@ vector observations to be used simultaneously. (#3981) Thank you @shakenes !
 - Unity Player logs are now written out to the results directory. (#3877)
 - Run configuration YAML files are written out to the results directory at the end of the run. (#3815)
 ### Bug Fixes
-- Fixed an issue where SAC would perform a large number of model updates when resuming from a
-  checkpoint (#4038)
+- Fixed an issue where SAC would perform too many model updates when resuming from a
+  checkpoint, and too few when using `buffer_init_steps`. (#4038)
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -65,9 +65,9 @@ class SACTrainer(RLTrainer):
         )
         self.step = 0
 
-        # Don't count buffer_init_steps in steps_per_update ratio, but also don't divide-by-0
-        self.update_steps = max(1, self.hyperparameters.buffer_init_steps)
-        self.reward_signal_update_steps = max(1, self.hyperparameters.buffer_init_steps)
+        # Don't divide by zero
+        self.update_steps = 1
+        self.reward_signal_update_steps = 1
 
         self.steps_per_update = self.hyperparameters.steps_per_update
         self.reward_signal_steps_per_update = (
@@ -229,7 +229,9 @@ class SACTrainer(RLTrainer):
         )
 
         batch_update_stats: Dict[str, list] = defaultdict(list)
-        while self.step / self.update_steps > self.steps_per_update:
+        while (
+            self.step - self.hyperparameters.buffer_init_steps
+        ) / self.update_steps > self.steps_per_update:
             logger.debug("Updating SAC policy at step {}".format(self.step))
             buffer = self.update_buffer
             if self.update_buffer.num_experiences >= self.hyperparameters.batch_size:
@@ -282,9 +284,8 @@ class SACTrainer(RLTrainer):
         )
         batch_update_stats: Dict[str, list] = defaultdict(list)
         while (
-            self.step / self.reward_signal_update_steps
-            > self.reward_signal_steps_per_update
-        ):
+            self.step - self.hyperparameters.buffer_init_steps
+        ) / self.reward_signal_update_steps > self.reward_signal_steps_per_update:
             # Get minibatches for reward signal update if needed
             reward_signal_minibatches = {}
             for name, signal in self.optimizer.reward_signals.items():
@@ -327,6 +328,11 @@ class SACTrainer(RLTrainer):
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
         # Needed to resume loads properly
         self.step = policy.get_current_step()
+        # Assume steps were updated at the correct ratio before
+        self.update_steps = int(max(1, self.step / self.steps_per_update))
+        self.reward_signal_update_steps = int(
+            max(1, self.step / self.reward_signal_steps_per_update)
+        )
         self.next_summary_step = self._get_next_summary_step()
 
     def get_policy(self, name_behavior_id: str) -> TFPolicy:

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -151,6 +151,7 @@ def test_advance(dummy_config):
         discrete_action=False, visual_inputs=0, vec_obs_size=6
     )
     dummy_config.hyperparameters.steps_per_update = 20
+    dummy_config.hyperparameters.reward_signal_steps_per_update = 20
     dummy_config.hyperparameters.buffer_init_steps = 0
     trainer = SACTrainer(brain_params, 0, dummy_config, True, False, 0, "0")
     policy = trainer.create_policy(brain_params.brain_name, brain_params)
@@ -219,6 +220,18 @@ def test_advance(dummy_config):
     trainer.advance()
     with pytest.raises(AgentManagerQueue.Empty):
         policy_queue.get_nowait()
+
+    # Call add_policy and check that we update the correct number of times.
+    # This is to emulate a load from checkpoint.
+    policy = trainer.create_policy(brain_params.brain_name, brain_params)
+    policy.get_current_step = lambda: 200
+    trainer.add_policy(brain_params.brain_name, policy)
+    trainer.optimizer.update = mock.Mock()
+    trainer.optimizer.update.return_value = {}
+    trajectory_queue.put(trajectory)
+    trainer.advance()
+    # Make sure we did exactly 1 update
+    assert trainer.optimizer.update.call_count == 1
 
 
 if __name__ == "__main__":

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -227,11 +227,14 @@ def test_advance(dummy_config):
     policy.get_current_step = lambda: 200
     trainer.add_policy(brain_params.brain_name, policy)
     trainer.optimizer.update = mock.Mock()
+    trainer.optimizer.update_reward_signals = mock.Mock()
+    trainer.optimizer.update_reward_signals.return_value = {}
     trainer.optimizer.update.return_value = {}
     trajectory_queue.put(trajectory)
     trainer.advance()
     # Make sure we did exactly 1 update
     assert trainer.optimizer.update.call_count == 1
+    assert trainer.optimizer.update_reward_signals.call_count == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Proposed change(s)

SAC when resuming from a checkpoint would do many updates before continuing to step the environment. This is because we don't set the `update_steps` properly when resuming from a checkpoint, so the SAC trainer will update until it has enough `update_steps`. 

Also fixes a bug where SAC doesn't update even after hitting `buffer_init_steps`. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)
