### PR TITLE
[bug-fix] Fix hyperparameters for Walker-SAC and WallJump-SAC

### DIFF
--- a/config/sac/Walker.yaml
+++ b/config/sac/Walker.yaml
@@ -4,8 +4,8 @@ behaviors:
     hyperparameters:
       learning_rate: 0.0003
       learning_rate_schedule: constant
-      batch_size: 256
-      buffer_size: 500000
+      batch_size: 1024
+      buffer_size: 2000000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 30.0
@@ -23,7 +23,7 @@ behaviors:
         strength: 1.0
     output_path: default
     keep_checkpoints: 5
-    max_steps: 20000000
+    max_steps: 15000000
     time_horizon: 1000
     summary_freq: 30000
     threaded: true

--- a/config/sac/Walker.yaml
+++ b/config/sac/Walker.yaml
@@ -14,8 +14,8 @@ behaviors:
       reward_signal_steps_per_update: 30.0
     network_settings:
       normalize: true
-      hidden_units: 512
-      num_layers: 4
+      hidden_units: 256
+      num_layers: 3
       vis_encode_type: simple
     reward_signals:
       extrinsic:

--- a/config/sac/WallJump.yaml
+++ b/config/sac/WallJump.yaml
@@ -25,7 +25,7 @@ behaviors:
     keep_checkpoints: 5
     max_steps: 20000000
     time_horizon: 128
-    summary_freq: 1000
+    summary_freq: 20000
     threaded: true
   SmallWallJump:
     trainer_type: sac
@@ -53,5 +53,5 @@ behaviors:
     keep_checkpoints: 5
     max_steps: 5000000
     time_horizon: 128
-    summary_freq: 1000
+    summary_freq: 20000
     threaded: true

--- a/config/sac/WallJump.yaml
+++ b/config/sac/WallJump.yaml
@@ -23,7 +23,7 @@ behaviors:
         strength: 1.0
     output_path: default
     keep_checkpoints: 5
-    max_steps: 20000000
+    max_steps: 15000000
     time_horizon: 128
     summary_freq: 20000
     threaded: true

--- a/config/sac/WallJump.yaml
+++ b/config/sac/WallJump.yaml
@@ -4,8 +4,8 @@ behaviors:
     hyperparameters:
       learning_rate: 0.0003
       learning_rate_schedule: constant
-      batch_size: 256
-      buffer_size: 100000
+      batch_size: 128
+      buffer_size: 200000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 10.0

--- a/config/sac/WallJump.yaml
+++ b/config/sac/WallJump.yaml
@@ -8,7 +8,7 @@ behaviors:
       buffer_size: 200000
       buffer_init_steps: 0
       tau: 0.005
-      steps_per_update: 10.0
+      steps_per_update: 20.0
       save_replay_buffer: false
       init_entcoef: 0.1
       reward_signal_steps_per_update: 10.0
@@ -36,7 +36,7 @@ behaviors:
       buffer_size: 50000
       buffer_init_steps: 0
       tau: 0.005
-      steps_per_update: 10.0
+      steps_per_update: 20.0
       save_replay_buffer: false
       init_entcoef: 0.1
       reward_signal_steps_per_update: 10.0

--- a/config/sac/WallJump.yaml
+++ b/config/sac/WallJump.yaml
@@ -4,8 +4,8 @@ behaviors:
     hyperparameters:
       learning_rate: 0.0003
       learning_rate_schedule: constant
-      batch_size: 128
-      buffer_size: 50000
+      batch_size: 256
+      buffer_size: 100000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 10.0
@@ -25,7 +25,7 @@ behaviors:
     keep_checkpoints: 5
     max_steps: 20000000
     time_horizon: 128
-    summary_freq: 20000
+    summary_freq: 1000
     threaded: true
   SmallWallJump:
     trainer_type: sac
@@ -53,5 +53,5 @@ behaviors:
     keep_checkpoints: 5
     max_steps: 5000000
     time_horizon: 128
-    summary_freq: 20000
+    summary_freq: 1000
     threaded: true


### PR DESCRIPTION
### Proposed change(s)

This PR adds new hyperparameters for Walker-SAC and BigWallJump-SAC to get them to train properly. Both environments trained inconsistently or not at all before. For both environments, we needed a larger buffer size, and for Walker a larger batch size as well. Enabling BigWallJump to learn also solves a hang that was caused by BigWallJump starving out SmallWallJump of samples later in the training run. 

- BigWalljump now trains to 0.7-0.8. 
- Walker now trains to 1800-2000.

This PR should be merged with the corresponding cloud PR Unity-Technologies/ml-agents-cloud#135 that increases resources and sets the reward thresholds correctly.  

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)