### PR TITLE
[tests] Increase buffer_init_steps for recurrent sac test

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/test_simple_rl.py
@@ -314,7 +314,7 @@ def test_recurrent_sac(use_discrete):
         SAC_CONFIG.hyperparameters,
         batch_size=128,
         learning_rate=1e-3,
-        buffer_init_steps=500,
+        buffer_init_steps=1000,
         steps_per_update=2,
     )
     config = attr.evolve(


### PR DESCRIPTION
### Proposed change(s)

A recent PR fixed a bug with `buffer_init_steps` that effectively doubled it for the simple RL recurrent-SAC test. This PR actually doubles it so the behavior is the same. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
