### PR TITLE
Docs: note about required Windows Python x86-64

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -39,7 +39,7 @@ enable you to manage multiple Unity versions.
 ### Install **Python 3.6.1** or Higher
 
 We recommend [installing](https://www.python.org/downloads/) Python 3.6 or 3.7.
-Be aware that under Windows the TensorFlow package needs **Python x86-64**, so do not install the 32 bit version, but the x86-64 one.
+If you are using Windows, please install the x86-64 version and not x86.
 If your Python environment doesn't include `pip3`, see these
 [instructions](https://packaging.python.org/guides/installing-using-linux-tools/#installing-pip-setuptools-wheel-with-linux-package-managers)
 on installing it.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -39,6 +39,7 @@ enable you to manage multiple Unity versions.
 ### Install **Python 3.6.1** or Higher
 
 We recommend [installing](https://www.python.org/downloads/) Python 3.6 or 3.7.
+Be aware that under Windows the TensorFlow package needs **Python x86-64**, so do not install the 32 bit version, but the x86-64 one.
 If your Python environment doesn't include `pip3`, see these
 [instructions](https://packaging.python.org/guides/installing-using-linux-tools/#installing-pip-setuptools-wheel-with-linux-package-managers)
 on installing it.


### PR DESCRIPTION
since TensorFlow Windows needs Python x86-64, but the default Python installs 32 bit, it is better to be explain which version they should install

### Proposed change(s)

info line in the Docs

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)