### PR TITLE
[refactor] Remove unused param keys

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -47,26 +47,6 @@ class PPOTrainer(RLTrainer):
         super(PPOTrainer, self).__init__(
             brain_name, trainer_settings, training, run_id, reward_buff_cap
         )
-        self.param_keys = [
-            "batch_size",
-            "beta",
-            "buffer_size",
-            "epsilon",
-            "hidden_units",
-            "lambd",
-            "learning_rate",
-            "max_steps",
-            "normalize",
-            "num_epoch",
-            "num_layers",
-            "time_horizon",
-            "sequence_length",
-            "summary_freq",
-            "use_recurrent",
-            "memory_size",
-            "output_path",
-            "reward_signals",
-        ]
         self.hyperparameters: PPOSettings = cast(
             PPOSettings, self.trainer_settings.hyperparameters
         )

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -38,7 +38,6 @@ class Trainer(abc.ABC):
         :str run_id: The identifier of the current run
         :int reward_buff_cap:
         """
-        self.param_keys: List[str] = []
         self.brain_name = brain_name
         self.run_id = run_id
         self.trainer_settings = trainer_settings


### PR DESCRIPTION
### Proposed change(s)

Remove vestigial param_keys leftover from the config file changes. These checks are now done in `settings.py`. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
