### PR TITLE
raise errors properly on UnityRegistry

### DIFF
--- a/ml-agents-envs/mlagents_envs/registry/binary_utils.py
+++ b/ml-agents-envs/mlagents_envs/registry/binary_utils.py
@@ -40,8 +40,9 @@ def get_local_binary_path(name: str, url: str) -> str:
             download_and_extract_zip(url, name)
         except Exception:  # pylint: disable=W0702
             if attempt + 1 < NUMBER_ATTEMPTS:
-                logger.debug(
-                    f"Attempt {attempt + 1} / {NUMBER_ATTEMPTS} : Failed to download"
+                logger.warning(
+                    f"Attempt {attempt + 1} / {NUMBER_ATTEMPTS}"
+                    ": Failed to download and extract binary."
                 )
             else:
                 raise

--- a/ml-agents-envs/mlagents_envs/registry/binary_utils.py
+++ b/ml-agents-envs/mlagents_envs/registry/binary_utils.py
@@ -131,8 +131,6 @@ def download_and_extract_zip(url: str, name: str) -> None:
     except urllib.error.HTTPError as e:  # type: ignore
         e.msg += " " + url
         raise
-    except urllib.error.URLError:  # type:ignore # pylint: disable=W0706
-        raise
     zip_size = int(request.headers["content-length"])
     zip_file_path = os.path.join(zip_dir, str(uuid.uuid4()) + ".zip")
     with open(zip_file_path, "wb") as zip_file:
@@ -188,8 +186,6 @@ def load_remote_manifest(url: str) -> Dict[str, Any]:
         request = urllib.request.urlopen(url, timeout=30)
     except urllib.error.HTTPError as e:  # type: ignore
         e.msg += " " + url
-        raise
-    except urllib.error.URLError:  # type:ignore # pylint: disable=W0706
         raise
     manifest_path = os.path.join(tmp_dir, str(uuid.uuid4()) + ".yaml")
     with open(manifest_path, "wb") as manifest:


### PR DESCRIPTION
### Proposed change(s)

Raising errors better when something goes wrong when trying to download

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
