### PR TITLE
The environment can now close right after being instantiated

### DIFF
--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -366,6 +366,8 @@ namespace Unity.MLAgents
                         port = port
                     }
                 );
+                Communicator.QuitCommandReceived += OnQuitCommandReceived;
+                Communicator.ResetCommandReceived += OnResetCommand;
             }
 
             if (Communicator != null)
@@ -396,12 +398,6 @@ namespace Unity.MLAgents
                         "Will perform inference instead."
                     );
                     Communicator = null;
-                }
-
-                if (Communicator != null)
-                {
-                    Communicator.QuitCommandReceived += OnQuitCommandReceived;
-                    Communicator.ResetCommandReceived += OnResetCommand;
                 }
             }
 

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -214,10 +214,16 @@ namespace Unity.MLAgents
 
             m_Client = new UnityToExternalProto.UnityToExternalProtoClient(channel);
             var result = m_Client.Exchange(WrapMessage(unityOutput, 200));
-            unityInput = m_Client.Exchange(WrapMessage(null, 200)).UnityInput;
+            var inputMessage = m_Client.Exchange(WrapMessage(null, 200));
+            unityInput = inputMessage.UnityInput;
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += HandleOnPlayModeChanged;
 #endif
+            if (result.Header.Status != 200 || inputMessage.Header.Status != 200)
+            {
+                m_IsOpen = false;
+                QuitCommandReceived?.Invoke();
+            }
             return result.UnityInput;
 #else
             throw new UnityAgentsException(


### PR DESCRIPTION
### Proposed change(s)

```python
env = UnityEnvironment("path-to-env")
env.close()
```

Now properly does nothing.
This change is on the C# side. 
The environment currently on the registry will be unaffected by that fix.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
