### PR TITLE
[documentation] Fixed text in GettingStarted sepecifying tensorboard logdir

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -206,12 +206,12 @@ follow the instructions in
 ### Observing Training Progress
 
 Once you start training using `mlagents-learn` in the way described in the
-previous section, the `ml-agents` directory will contain a `summaries`
+previous section, the `ml-agents` directory will contain a `results`
 directory. In order to observe the training process in more detail, you can use
 TensorBoard. From the command line run:
 
 ```sh
-tensorboard --logdir=summaries
+tensorboard --logdir=results
 ```
 
 Then navigate to `localhost:6006` in your browser to view the TensorBoard


### PR DESCRIPTION
### Proposed change(s)

This pull requests corrects text in GettingStarted.md page specifying the logdir for tensorboard. Before it was in a directory called summaries which no longer existed. Results are now saved to the results directory.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
After running the training commands specified I ran the command `tensorboard --logdir=results` and it opened the correct folder. 