### PR TITLE
Clarification in the Heuristic() documentation

### DIFF
--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -770,6 +770,8 @@ namespace Unity.MLAgents
         /// <seealso cref="OnActionReceived(float[])"/> function, which receives this array and
         /// implements the corresponding agent behavior. See [Actions] for more information
         /// about agent actions.
+        /// Note : Do not create a new float array of action in the `Heuristic()` method,
+        /// as this will prevent writing floats to the original action array.
         ///
         /// An agent calls this `Heuristic()` function to make a decision when you set its behavior
         /// type to <see cref="BehaviorType.HeuristicOnly"/>. The agent also calls this function if

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -67,7 +67,9 @@ includes implementing the following methods:
 - `Agent.Heuristic()` - When the `Behavior Type` is set to `Heuristic Only` in
   the Behavior Parameters of the Agent, the Agent will use the `Heuristic()`
   method to generate the actions of the Agent. As such, the `Heuristic()` method
-  writes to a provided array of floats.
+  writes to the array of floats provided to the Heuristic method as argument.
+  __Note__: Do not create a new float array of action in the `Heuristic()` method,
+  as this will prevent writing floats to the original action array.
 
 As a concrete example, here is how the Ball3DAgent class implements these methods:
 


### PR DESCRIPTION
The `Heuristic()` method will not be able to write to the action array if the action array passed as argument is reassigned in the method.
For example, doing :
```csharp
public override void Heuristic(float[] actionsOut)
{
   actionOut = new float[2];
   actionOut[0] = 1.0f;
}
```
Will not create the action [1, 0] but [0, 0] as the `actionOut` variable was reassigned.

### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
