### PR TITLE
[bug-fix] Fix issue where curriculum was advancing too early

### DIFF
--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -259,7 +259,7 @@ class CurriculumSettings:
         REWARD: str = "reward"
 
     measure: str = attr.ib(default=MeasureType.REWARD)
-    thresholds: List[int] = attr.ib(factory=list)
+    thresholds: List[float] = attr.ib(factory=list)
     min_lesson_length: int = 0
     signal_smoothing: bool = True
     parameters: Dict[str, List[float]] = attr.ib(kw_only=True)

--- a/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
+++ b/ml-agents/mlagents/trainers/tests/test_meta_curriculum.py
@@ -1,5 +1,7 @@
 import pytest
 from unittest.mock import patch, Mock, call
+import yaml
+import cattr
 
 from mlagents.trainers.meta_curriculum import MetaCurriculum
 
@@ -22,6 +24,27 @@ def measure_vals():
 @pytest.fixture
 def reward_buff_sizes():
     return {"Brain1": 7, "Brain2": 8}
+
+
+def test_convert_from_dict():
+    config = yaml.safe_load(
+        """
+        measure: progress
+        thresholds: [0.1, 0.3, 0.5]
+        min_lesson_length: 100
+        signal_smoothing: true
+        parameters:
+            param1: [0.0, 4.0, 6.0, 8.0]
+        """
+    )
+    should_be_config = CurriculumSettings(
+        thresholds=[0.1, 0.3, 0.5],
+        min_lesson_length=100,
+        signal_smoothing=True,
+        measure=CurriculumSettings.MeasureType.PROGRESS,
+        parameters={"param1": [0.0, 4.0, 6.0, 8.0]},
+    )
+    assert cattr.structure(config, CurriculumSettings) == should_be_config
 
 
 def test_curriculum_config(param_name="test_param1", min_lesson_length=100):


### PR DESCRIPTION
### Proposed change(s)

Fixes a rounding error in curriculum thresholds which was causing progress curriculums to advance quickly. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)
