### PR TITLE
store hit GameObject in raycast output

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)
+- `RayPerceptionSensor.Perceive()` now additionally store the GameObject that was hit by the ray. (#4111)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Bug Fixes

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -340,7 +340,7 @@ namespace Unity.MLAgents.Sensors
         }
 
         /// <inheritdoc/>
-        public void Reset() { }
+        public void Reset() {}
 
         /// <inheritdoc/>
         public int[] GetObservationShape()

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -162,6 +162,12 @@ namespace Unity.MLAgents.Sensors
             public float HitFraction;
 
             /// <summary>
+            /// The hit GameObject (or null if there was no hit).
+            /// </summary>
+            public GameObject HitGameObject;
+
+
+            /// <summary>
             /// Writes the ray output information to a subset of the float array.  Each element in the rayAngles array
             /// determines a sublist of data to the observation. The sublist contains the observation data for a single cast.
             /// The list is composed of the following:
@@ -456,7 +462,8 @@ namespace Unity.MLAgents.Sensors
                 HasHit = castHit,
                 HitFraction = hitFraction,
                 HitTaggedObject = false,
-                HitTagIndex = -1
+                HitTagIndex = -1,
+                HitGameObject = hitObject
             };
 
             if (castHit)

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -44,18 +44,22 @@ namespace Unity.MLAgents.Tests
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.position = new Vector3(0, 0, 10);
             cube.tag = k_CubeTag;
+            cube.name = "cube";
 
             var sphere1 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             sphere1.transform.position = new Vector3(-5, 0, 5);
             sphere1.tag = k_SphereTag;
+            sphere1.name = "sphere1";
 
             var sphere2 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             sphere2.transform.position = new Vector3(5, 0, 5);
             // No tag for sphere2
+            sphere2.name = "sphere2";
 
             var sphere3 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             sphere3.transform.position = new Vector3(0, 0, -10);
             sphere3.tag = k_SphereTag;
+            sphere3.name = "sphere3";
 
             Physics.SyncTransforms();
         }
@@ -294,6 +298,34 @@ namespace Unity.MLAgents.Tests
                 // hit fraction is arbitrary but should be finite in [0,1]
                 Assert.GreaterOrEqual(outputBuffer[2], 0.0f);
                 Assert.LessOrEqual(outputBuffer[2], 1.0f);
+            }
+        }
+
+        [Test]
+        public void TestStaticPerceive()
+        {
+            SetupScene();
+            var obj = new GameObject("agent");
+            var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
+
+            perception.RaysPerDirection = 0; // single ray
+            perception.MaxRayDegrees = 45;
+            perception.RayLength = 20;
+            perception.DetectableTags = new List<string>();
+            perception.DetectableTags.Add(k_CubeTag);
+            perception.DetectableTags.Add(k_SphereTag);
+
+            var radii = new[] { 0f, .5f };
+            foreach (var castRadius in radii)
+            {
+                perception.SphereCastRadius = castRadius;
+                var castInput = perception.GetRayPerceptionInput();
+                var castOutput = RayPerceptionSensor.Perceive(castInput);
+
+                Assert.AreEqual(1, castOutput.RayOutputs.Length);
+
+                // Expected to hit the cube
+                Assert.AreEqual("cube", castOutput.RayOutputs[0].HitGameObject.name);
             }
         }
     }

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -27,6 +27,15 @@ namespace Unity.MLAgents.Tests
         const string k_CubeTag = "Player";
         const string k_SphereTag = "Respawn";
 
+        [TearDown]
+        public void RemoveGameObjects()
+        {
+            var objects = GameObject.FindObjectsOfType<GameObject>();
+            foreach (var o in objects) {
+                UnityEngine.Object.DestroyImmediate(o);
+            }
+        }
+
         void SetupScene()
         {
             /* Creates game objects in the world for testing.

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -31,7 +31,8 @@ namespace Unity.MLAgents.Tests
         public void RemoveGameObjects()
         {
             var objects = GameObject.FindObjectsOfType<GameObject>();
-            foreach (var o in objects) {
+            foreach (var o in objects)
+            {
                 UnityEngine.Object.DestroyImmediate(o);
             }
         }


### PR DESCRIPTION
### Proposed change(s)
Requested in linked issue. The original request was for the Collider, but GameObject is a lot more convenient, because 2D and 3D casts use a different collider type (Collider vs Collider2D). Users should be able to get the type that they want from the GameObject.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1075
https://github.com/Unity-Technologies/ml-agents/issues/4018


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
