### PR TITLE
Fixed a typo on ML-Agents-Overview.md

### DIFF
--- a/docs/ML-Agents-Overview.md
+++ b/docs/ML-Agents-Overview.md
@@ -569,7 +569,7 @@ for later lessons. The same principle can be applied to machine learning, where
 training on easier tasks can provide a scaffolding for harder tasks in the
 future.
 
-Imagine training the medic to to scale a wall to arrive at a wounded team
+Imagine training the medic to scale a wall to arrive at a wounded team
 member. The starting point when training a medic to accomplish this task will be
 a random policy. That starting policy will have the medic running in circles,
 and will likely never, or very rarely scale the wall properly to revive their


### PR DESCRIPTION
Fixed redundant "to" word from the sentence since it is probably a typo in document.
From:
Imagine training the medic to to scale a wall to arrive at a wounded team member.
To:
Imagine training the medic to scale a wall to arrive at a wounded team member.

### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
