### PR TITLE
Fix 3DBall and 3DBallHard SAC regressions

### DIFF
--- a/config/ppo/3DBallHard.yaml
+++ b/config/ppo/3DBallHard.yaml
@@ -5,7 +5,7 @@ behaviors:
       batch_size: 1200
       buffer_size: 12000
       learning_rate: 0.0003
-      beta: 0.0
+      beta: 0.001
       epsilon: 0.2
       lambd: 0.95
       num_epoch: 3
@@ -20,7 +20,7 @@ behaviors:
         gamma: 0.995
         strength: 1.0
     keep_checkpoints: 5
-    max_steps: 2000000
+    max_steps: 5000000
     time_horizon: 1000
     summary_freq: 12000
     threaded: true

--- a/config/ppo/3DBallHard.yaml
+++ b/config/ppo/3DBallHard.yaml
@@ -5,7 +5,7 @@ behaviors:
       batch_size: 1200
       buffer_size: 12000
       learning_rate: 0.0003
-      beta: 0.0001
+      beta: 0.0
       epsilon: 0.2
       lambd: 0.95
       num_epoch: 3

--- a/config/ppo/3DBallHard.yaml
+++ b/config/ppo/3DBallHard.yaml
@@ -5,7 +5,7 @@ behaviors:
       batch_size: 1200
       buffer_size: 12000
       learning_rate: 0.0003
-      beta: 0.001
+      beta: 0.0001
       epsilon: 0.2
       lambd: 0.95
       num_epoch: 3
@@ -20,7 +20,7 @@ behaviors:
         gamma: 0.995
         strength: 1.0
     keep_checkpoints: 5
-    max_steps: 5000000
+    max_steps: 2000000
     time_horizon: 1000
     summary_freq: 12000
     threaded: true

--- a/config/sac/3DBall.yaml
+++ b/config/sac/3DBall.yaml
@@ -5,7 +5,7 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 64
-      buffer_size: 12000
+      buffer_size: 200000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 10.0
@@ -22,7 +22,7 @@ behaviors:
         gamma: 0.99
         strength: 1.0
     keep_checkpoints: 5
-    max_steps: 500000
+    max_steps: 200000
     time_horizon: 1000
     summary_freq: 12000
     threaded: true

--- a/config/sac/3DBallHard.yaml
+++ b/config/sac/3DBallHard.yaml
@@ -5,7 +5,7 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 256
-      buffer_size: 50000
+      buffer_size: 500000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 10.0


### PR DESCRIPTION
### Proposed change(s)

The buffers were too small and 'catastrophic forgetting' caused regressions. 

**Ignore the first four rows which are PPO** for 3DBallHard which I will address in a different PR.  This shows no inference regressions over four random seeds. I've run this multiple times and it appears to be stable.
<img width="829" alt="Screen Shot 2020-06-17 at 2 54 07 PM" src="https://user-images.githubusercontent.com/54679309/84954581-7c073f00-b0aa-11ea-9603-d11dc930e2a0.png">


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
