### PR TITLE
[refactor] Remove references to brain_name in policy

### DIFF
--- a/docs/Training-Configuration-File.md
+++ b/docs/Training-Configuration-File.md
@@ -154,7 +154,7 @@ A few considerations when deciding to use memory:
   too large `memory_size` will slow down training.
 - Adding a recurrent layer increases the complexity of the neural network, it is
   recommended to decrease `num_layers` when using recurrent.
-- It is required that `memory_size` be divisible by 4.
+- It is required that `memory_size` be divisible by 2.
 
 ## Self-Play
 

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -95,18 +95,6 @@ class TFPolicy(Policy):
         if self.network_settings.memory is not None:
             self.m_size = self.network_settings.memory.memory_size
             self.sequence_length = self.network_settings.memory.sequence_length
-            if self.m_size == 0:
-                raise UnityPolicyException(
-                    "The memory size for brain {0} is 0 even "
-                    "though the trainer uses recurrent.".format(brain.brain_name)
-                )
-            elif self.m_size % 2 != 0:
-                raise UnityPolicyException(
-                    "The memory size for brain {0} is {1} "
-                    "but it must be divisible by 2.".format(
-                        brain.brain_name, self.m_size
-                    )
-                )
         self._initialize_tensorflow_references()
         self.load = load
 
@@ -160,11 +148,7 @@ class TFPolicy(Policy):
     def _load_graph(self, model_path: str, reset_global_steps: bool = False) -> None:
         with self.graph.as_default():
             self.saver = tf.train.Saver(max_to_keep=self.keep_checkpoints)
-            logger.info(
-                "Loading model for brain {} from {}.".format(
-                    self.brain.brain_name, model_path
-                )
-            )
+            logger.info(f"Loading model from {model_path}.")
             ckpt = tf.train.get_checkpoint_state(model_path)
             if ckpt is None:
                 raise UnityPolicyException(

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -51,10 +51,21 @@ class ExportableSettings:
 
 @attr.s(auto_attribs=True)
 class NetworkSettings:
-    @attr.s(auto_attribs=True)
+    @attr.s
     class MemorySettings:
-        sequence_length: int = 64
-        memory_size: int = 128
+        sequence_length: int = attr.ib(default=64)
+        memory_size: int = attr.ib(default=128)
+
+        @memory_size.validator
+        def _check_valid_memory_size(self, attribute, value):
+            if value <= 0:
+                raise TrainerConfigError(
+                    "When using a recurrent network, memory size must be greater than 0."
+                )
+            elif value % 2 != 0:
+                raise TrainerConfigError(
+                    "When using a recurrent network, memory size must be divisible by 2."
+                )
 
     normalize: bool = False
     hidden_units: int = 128

--- a/ml-agents/mlagents/trainers/tests/test_settings.py
+++ b/ml-agents/mlagents/trainers/tests/test_settings.py
@@ -6,6 +6,7 @@ from typing import Dict
 from mlagents.trainers.settings import (
     RunOptions,
     TrainerSettings,
+    NetworkSettings,
     PPOSettings,
     SACSettings,
     RewardSignalType,
@@ -153,6 +154,14 @@ def test_reward_signal_structure():
         RewardSignalSettings.structure(
             "notadict", Dict[RewardSignalType, RewardSignalSettings]
         )
+
+
+def test_memory_settings_validation():
+    with pytest.raises(TrainerConfigError):
+        NetworkSettings.MemorySettings(sequence_length=128, memory_size=63)
+
+    with pytest.raises(TrainerConfigError):
+        NetworkSettings.MemorySettings(sequence_length=128, memory_size=0)
 
 
 def test_parameter_randomization_structure():

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -121,7 +121,7 @@ class Trainer(abc.ABC):
         Exports the model
         """
         policy = self.get_policy(name_behavior_id)
-        settings = SerializationSettings(policy.model_path, policy.brain.brain_name)
+        settings = SerializationSettings(policy.model_path, self.brain_name)
         export_policy_model(settings, policy.graph, policy.sess)
 
     @abc.abstractmethod


### PR DESCRIPTION
### Proposed change(s)

Removes all references to `BrainParameters.brain_name` in policy.  `brain_name` is the only thing that's added to `BehaviorSpec` when making a `BrainParameters`, so this sets the stage for removal of `BrainParameters` in Python. 

We also do some cleanup to move the validation of `memory_size` to the `attrs` class in `settings.py` and correct incorrect documentation that says `memory_size` must be divisible by 4. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
