### PR TITLE
Remove package validation suite from Project

### DIFF
--- a/Project/Packages/manifest.json
+++ b/Project/Packages/manifest.json
@@ -6,7 +6,6 @@
     "com.unity.ml-agents": "file:../../com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../../com.unity.ml-agents.extensions",
     "com.unity.package-manager-ui": "2.0.8",
-    "com.unity.package-validation-suite": "0.7.15-preview",
     "com.unity.purchasing": "2.0.3",
     "com.unity.textmeshpro": "1.4.1",
     "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
### Proposed change(s)
There have been various issues around this, for example:
https://github.com/Unity-Technologies/ml-agents/issues/4022
https://github.com/Unity-Technologies/ml-agents/issues/4124

We don't need it in Project (just DevProject) so no need to keep it in the manifest.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
