### PR TITLE
[bugfix] Make FoodCollector heuristic playable

### DIFF
--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -209,6 +209,9 @@ public class FoodCollectorAgent : Agent
 
     public override void Heuristic(float[] actionsOut)
     {
+        actionsOut[0] = 0f;
+        actionsOut[1] = 0f;
+        actionsOut[2] = 0f;
         if (Input.GetKey(KeyCode.D))
         {
             actionsOut[2] = 2f;

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - The Barracuda dependency was upgraded to 1.0.0 (#4118)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added new Google Colab notebooks to show how to use `UnityEnvironment'. (#4117)
+- Fixed issue with FoodCollector when playing with keyboard. (#4147)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)


### PR DESCRIPTION
### Proposed change(s)

Foodcollector player controls were uncontrollable as the agent would keep moving when keys were lifted. Set actions back to 0 when keys are not pressed. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
