### PR TITLE
Remove comment about logo with --help

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -132,7 +132,7 @@ pip3 install mlagents
 
 Note that this will install `mlagents` from PyPi, _not_ from the cloned
 repository. If you installed this correctly, you should be able to run
-`mlagents-learn --help`, after which you will see the Unity logo and the command
+`mlagents-learn --help`, after which you will see the command
 line parameters you can use with `mlagents-learn`.
 
 By installing the `mlagents` package, the dependencies listed in the


### PR DESCRIPTION
### Proposed change(s)
`--help` only prints the argparse commands, not the logo (this is probably a holdover from when we used docopt).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Reported in https://github.com/Unity-Technologies/ml-agents/issues/4121


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
