### PR TITLE
[CI] Better hyperparameters for Pyramids-SAC, WalkerStatic-SAC, and Reacher-PPO

### DIFF
--- a/config/ppo/Reacher.yaml
+++ b/config/ppo/Reacher.yaml
@@ -5,7 +5,7 @@ behaviors:
       batch_size: 2024
       buffer_size: 20240
       learning_rate: 0.0003
-      beta: 0.005
+      beta: 0.001
       epsilon: 0.2
       lambd: 0.95
       num_epoch: 3

--- a/config/ppo/Reacher.yaml
+++ b/config/ppo/Reacher.yaml
@@ -2,8 +2,8 @@ behaviors:
   Reacher:
     trainer_type: ppo
     hyperparameters:
-      batch_size: 2024
-      buffer_size: 20240
+      batch_size: 512
+      buffer_size: 20480
       learning_rate: 0.0003
       beta: 0.001
       epsilon: 0.2

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -5,7 +5,7 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 128
-      buffer_size: 2000000
+      buffer_size: 5000000
       buffer_init_steps: 1000
       tau: 0.01
       steps_per_update: 10.0

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -21,16 +21,21 @@ behaviors:
       extrinsic:
         gamma: 0.995
         strength: 2.0
-      gail:
+      curiosity:
         gamma: 0.99
-        strength: 0.01
-        encoding_size: 128
+        strength: 0.02
+        encoding_size: 256
         learning_rate: 0.0003
-        use_actions: true
-        use_vail: false
-        demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
+      # gail:
+      #   gamma: 0.99
+      #   strength: 0.01
+      #   encoding_size: 128
+      #   learning_rate: 0.0003
+      #   use_actions: true
+      #   use_vail: false
+      #   demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
     keep_checkpoints: 5
-    max_steps: 2000000
+    max_steps: 5000000
     time_horizon: 128
     summary_freq: 30000
     threaded: true

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -5,7 +5,7 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 128
-      buffer_size: 5000000
+      buffer_size: 2000000
       buffer_init_steps: 1000
       tau: 0.01
       steps_per_update: 10.0
@@ -30,7 +30,7 @@ behaviors:
         use_vail: false
         demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
     keep_checkpoints: 5
-    max_steps: 5000000
+    max_steps: 3000000
     time_horizon: 128
     summary_freq: 30000
     threaded: true

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -21,11 +21,6 @@ behaviors:
       extrinsic:
         gamma: 0.995
         strength: 2.0
-      # curiosity:
-      #   gamma: 0.99
-      #   strength: 0.02
-      #   encoding_size: 256
-      #   learning_rate: 0.0003
       gail:
         gamma: 0.99
         strength: 0.01

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -5,8 +5,8 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 128
-      buffer_size: 500000
-      buffer_init_steps: 10000
+      buffer_size: 2000000
+      buffer_init_steps: 1000
       tau: 0.01
       steps_per_update: 10.0
       save_replay_buffer: false
@@ -19,18 +19,18 @@ behaviors:
       vis_encode_type: simple
     reward_signals:
       extrinsic:
-        gamma: 0.99
+        gamma: 0.995
         strength: 2.0
       gail:
         gamma: 0.99
-        strength: 0.02
+        strength: 0.01
         encoding_size: 128
         learning_rate: 0.0003
         use_actions: true
         use_vail: false
         demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
     keep_checkpoints: 5
-    max_steps: 10000000
+    max_steps: 2000000
     time_horizon: 128
     summary_freq: 30000
     threaded: true

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -14,8 +14,8 @@ behaviors:
       reward_signal_steps_per_update: 10.0
     network_settings:
       normalize: false
-      hidden_units: 256
-      num_layers: 2
+      hidden_units: 512
+      num_layers: 3
       vis_encode_type: simple
     reward_signals:
       extrinsic:

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -5,7 +5,7 @@ behaviors:
       learning_rate: 0.0003
       learning_rate_schedule: constant
       batch_size: 128
-      buffer_size: 5000000
+      buffer_size: 2000000
       buffer_init_steps: 1000
       tau: 0.01
       steps_per_update: 10.0

--- a/config/sac/Pyramids.yaml
+++ b/config/sac/Pyramids.yaml
@@ -21,19 +21,19 @@ behaviors:
       extrinsic:
         gamma: 0.995
         strength: 2.0
-      curiosity:
-        gamma: 0.99
-        strength: 0.02
-        encoding_size: 256
-        learning_rate: 0.0003
-      # gail:
+      # curiosity:
       #   gamma: 0.99
-      #   strength: 0.01
-      #   encoding_size: 128
+      #   strength: 0.02
+      #   encoding_size: 256
       #   learning_rate: 0.0003
-      #   use_actions: true
-      #   use_vail: false
-      #   demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
+      gail:
+        gamma: 0.99
+        strength: 0.01
+        encoding_size: 128
+        learning_rate: 0.0003
+        use_actions: true
+        use_vail: false
+        demo_path: Project/Assets/ML-Agents/Examples/Pyramids/Demos/ExpertPyramid.demo
     keep_checkpoints: 5
     max_steps: 5000000
     time_horizon: 128

--- a/config/sac/WalkerStatic.yaml
+++ b/config/sac/WalkerStatic.yaml
@@ -4,8 +4,8 @@ behaviors:
     hyperparameters:
       learning_rate: 0.0003
       learning_rate_schedule: constant
-      batch_size: 256
-      buffer_size: 500000
+      batch_size: 1024
+      buffer_size: 2000000
       buffer_init_steps: 0
       tau: 0.005
       steps_per_update: 30.0
@@ -14,15 +14,15 @@ behaviors:
       reward_signal_steps_per_update: 30.0
     network_settings:
       normalize: true
-      hidden_units: 512
-      num_layers: 4
+      hidden_units: 256
+      num_layers: 3
       vis_encode_type: simple
     reward_signals:
       extrinsic:
         gamma: 0.995
         strength: 1.0
     keep_checkpoints: 5
-    max_steps: 20000000
+    max_steps: 15000000
     time_horizon: 1000
     summary_freq: 30000
     threaded: true


### PR DESCRIPTION
### Proposed change(s)

Better hyperparameters for the 3 environments above. Should train more reliably (especially Pyramids-SAC) and have a higher final reward. Requires https://github.com/Unity-Technologies/ml-agents-cloud/pull/150 to pass daily tests.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
