### PR TITLE
RayPerceptionSensor: handle empty and invalid tags

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
+- Fixed an issue where RayPerceptionSensor would raise an exception when the
+list of tags was empty, or a tag in the list was invalid (unknown, null, or
+empty string). (#4155)
+
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ## [1.1.0-preview] - 2020-06-10

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -475,7 +475,11 @@ namespace Unity.MLAgents.Sensors
                     var tagsEqual = false;
                     try
                     {
-                        tagsEqual = hitObject.CompareTag(input.DetectableTags[i]);
+                        var tag = input.DetectableTags[i];
+                        if (!string.IsNullOrEmpty(tag))
+                        {
+                            tagsEqual = hitObject.CompareTag(tag);
+                        }
                     }
                     catch (UnityException e)
                     {

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -469,9 +469,20 @@ namespace Unity.MLAgents.Sensors
             if (castHit)
             {
                 // Find the index of the tag of the object that was hit.
-                for (var i = 0; i < input.DetectableTags.Count; i++)
+                var numTags = input.DetectableTags?.Count ?? 0;
+                for (var i = 0; i < numTags; i++)
                 {
-                    if (hitObject.CompareTag(input.DetectableTags[i]))
+                    var tagsEqual = false;
+                    try
+                    {
+                        tagsEqual = hitObject.CompareTag(input.DetectableTags[i]);
+                    }
+                    catch (UnityException e)
+                    {
+                        // If the tag is null, empty, or not a valid tag, just ignore it.
+                    }
+
+                    if (tagsEqual)
                     {
                         rayOutput.HitTaggedObject = true;
                         rayOutput.HitTagIndex = i;

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -281,6 +281,11 @@ namespace Unity.MLAgents.Sensors
             else
             {
                 var rayInput = GetRayPerceptionInput();
+                // We don't actually need the tags here, since they don't affect the display of the rays.
+                // Additionally, the user might be in the middle of typing the tag name when this is called,
+                // and there's no way to turn off the "Tag ... is not defined" error logs.
+                // So just don't use any tags here.
+                rayInput.DetectableTags = null;
                 for (var rayIndex = 0; rayIndex < rayInput.Angles.Count; rayIndex++)
                 {
                     DebugDisplayInfo.RayInfo debugRay;

--- a/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/RayPerceptionSensorTests.cs
@@ -363,9 +363,9 @@ namespace Unity.MLAgents.Tests
                 perception.SphereCastRadius = castRadius;
                 var castInput = perception.GetRayPerceptionInput();
 
+                // There's no clean way that I can find to check for a defined tag without
+                // logging an error.
                 LogAssert.Expect(LogType.Error, "Tag: Bad tag is not defined.");
-                LogAssert.Expect(LogType.Error, "Tag: tag name is null or empty.");
-                LogAssert.Expect(LogType.Error, "Tag: tag name is null or empty.");
                 var castOutput = RayPerceptionSensor.Perceive(castInput);
 
                 Assert.AreEqual(1, castOutput.RayOutputs.Length);


### PR DESCRIPTION
### Proposed change(s)

Previously, RayPerceptionSensor would raise an exception when the list of tags was empty, or a tag in the list was invalid (unknown, null, or empty string). This PR fixes both, although an unknown tag will still log an error.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/issues/4151
https://jira.unity3d.com/browse/MLA-1106
https://jira.unity3d.com/browse/MLA-1109


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
