### PR TITLE
[docs] Fix a typo in a link in the package docs

### DIFF
--- a/com.unity.ml-agents/Documentation~/com.unity.ml-agents.md
+++ b/com.unity.ml-agents/Documentation~/com.unity.ml-agents.md
@@ -108,7 +108,7 @@ ML-Agents with a neural network behavior.
 ## Helpful links
 
 If you are new to the Unity ML-Agents package, or have a question after reading
-the documentation, you can checkout our [GitHUb Repository], which also includes
+the documentation, you can checkout our [GitHub Repository], which also includes
 a number of ways to [connect with us] including our [ML-Agents Forum].
 
 [unity ML-Agents Toolkit]: https://github.com/Unity-Technologies/ml-agents


### PR DESCRIPTION
### Proposed change(s)

Fix the capitalization of the word GitHub in the package docs. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
