### PR TITLE
Modified the documentation of the Heuristic method (default action = previous action)

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Scripts/AgentSoccer.cs
@@ -166,6 +166,7 @@ public class AgentSoccer : Agent
 
     public override void Heuristic(float[] actionsOut)
     {
+        Array.Clear(actionsOut, 0, actionsOut.Length);
         //forward
         if (Input.GetKey(KeyCode.W))
         {

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -261,7 +261,7 @@ public class WallJumpAgent : Agent
 
     public override void Heuristic(float[] actionsOut)
     {
-        Array.Clear(actionsOut, 0, actionsOut.Length);
+        System.Array.Clear(actionsOut, 0, actionsOut.Length);
         if (Input.GetKey(KeyCode.D))
         {
             actionsOut[1] = 2f;

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -261,6 +261,7 @@ public class WallJumpAgent : Agent
 
     public override void Heuristic(float[] actionsOut)
     {
+        Array.Clear(actionsOut, 0, actionsOut.Length);
         if (Input.GetKey(KeyCode.D))
         {
             actionsOut[1] = 2f;

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -766,8 +766,8 @@ namespace Unity.MLAgents
         ///
         /// Your heuristic implementation can use any decision making logic you specify. Assign decision
         /// values to the float[] array, <paramref name="actionsOut"/>, passed to your function as a parameter.
-        /// The default actions passed to the `Heuristic()` method are the previous actions decided by the
-        /// Heuristic. You can reset these actions by calling `Array.Clear(actionsOut, 0, actionsOut.Length);`.
+        /// The same array will be reused between steps. It is up to the user to initialize
+        /// the values on each call, for example by calling `Array.Clear(actionsOut, 0, actionsOut.Length);`.
         /// Add values to the array at the same indexes as they are used in your
         /// <seealso cref="OnActionReceived(float[])"/> function, which receives this array and
         /// implements the corresponding agent behavior. See [Actions] for more information

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -766,6 +766,8 @@ namespace Unity.MLAgents
         ///
         /// Your heuristic implementation can use any decision making logic you specify. Assign decision
         /// values to the float[] array, <paramref name="actionsOut"/>, passed to your function as a parameter.
+        /// The default actions passed to the `Heuristic()` method are the previous actions decided by the
+        /// Heuristic. You can reset these actions by calling `Array.Clear(actionsOut, 0, actionsOut.Length);`.
         /// Add values to the array at the same indexes as they are used in your
         /// <seealso cref="OnActionReceived(float[])"/> function, which receives this array and
         /// implements the corresponding agent behavior. See [Actions] for more information


### PR DESCRIPTION
Modifying the documentation to explain that Heuristic method default action will be the previous action decided by the heuristic. Changing this behavior would be a breaking change.

### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
