### PR TITLE
Fix a typo in Python-API.md

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -69,7 +69,7 @@ from mlagents_envs.environment import UnityEnvironment
 env = UnityEnvironment(file_name="3DBall", seed=1, side_channels=[])
 # Start interacting with the evironment.
 env.reset()
-behavior_names = env.behavior_spec.keys()
+behavior_names = env.behavior_specs.keys()
 ...
 ```
 **NOTE:** Please read [Interacting with a Unity Environment](#interacting-with-a-unity-environment)


### PR DESCRIPTION
Fix behavior_spec to behavior_specs in Python-API.md

before
```python
behavior_names = env.behavior_spec.keys()
```

after
```python
behavior_names = env.behavior_specs.keys()
```

This is definition of UnityEnvironment  behavior_specs

```python
    @property
    def behavior_specs(self) -> MappingType[str, BehaviorSpec]:
        return BehaviorMapping(self._env_specs)
```
https://github.com/Unity-Technologies/ml-agents/blob/master/ml-agents-envs/mlagents_envs/environment.py#L323





### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
