### PR TITLE
Fix unused variable warning in RayPerceptionSensor.cs

### DIFF
--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -1,22 +1,15 @@
-packages:
-  - name: com.unity.ml-agents
-  - name: com.unity.ml-agents.extensions
----
-
-{% for package in packages %}
-pack_{{ package.name }}:
-  name: Pack {{ package.name }}
+pack:
+  name: Pack
   agent:
     type: Unity::VM::osx
     image: package-ci/mac:stable
     flavor: b1.small
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package pack --package-path {{ package.name }}
+    - upm-ci project pack --project-path Project
   artifacts:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
   triggers:
     cancel_old_ci: true
-{% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -117,9 +117,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    {% for dep_package in packages %}
-    - .yamato/com.unity.ml-agents-pack.yml#pack_{{ dep_package.name }}
-    {% endfor %}
+    - .yamato/com.unity.ml-agents-pack.yml#pack
   triggers:
     cancel_old_ci: true
     {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,8 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
+
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} -warnings-as-errors {{ editor.coverageOptions }}
+    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
@@ -106,7 +106,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} -warnings-as-errors {{ editor.coverageOptions }}
+    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} -warnings-as-errors {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
@@ -106,7 +106,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} -warnings-as-errors {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
 
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
@@ -107,7 +107,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
@@ -117,7 +117,9 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack_{{ package.name }}
+    {% for dep_package in packages %}
+    - .yamato/com.unity.ml-agents-pack.yml#pack_{{ dep_package.name }}
+    {% endfor %}
   triggers:
     cancel_old_ci: true
     {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -76,7 +76,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack_{{ package.name }}
+    - .yamato/com.unity.ml-agents-pack.yml#pack
   triggers:
     cancel_old_ci: true
     {% if platform.name == "mac" %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -85,7 +85,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
       pull_request.target match "release.+") AND
       NOT pull_request.draft AND
       (pull_request.changes.any match "com.unity.ml-agents/**" OR
-      {% if package.name == "com.unity.ml-agents" %}
+      {% if package.name == "com.unity.ml-agents.extensions" %}
         pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
       {% endif %}
       pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
 
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
@@ -107,7 +107,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} --warnings-as-errors {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path DevProject --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/DevProject/Packages/manifest.json
+++ b/DevProject/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.ide.vscode": "1.1.4",
     "com.unity.ml-agents": "file:../../com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../../com.unity.ml-agents.extensions",
-    "com.unity.multiplayer-hlapi": "1.0.4",
+    "com.unity.multiplayer-hlapi": "1.0.6",
     "com.unity.package-manager-doctools": "1.1.1-preview.3",
     "com.unity.package-validation-suite": "0.11.0-preview",
     "com.unity.purchasing": "2.0.6",

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -481,7 +481,7 @@ namespace Unity.MLAgents.Sensors
                             tagsEqual = hitObject.CompareTag(tag);
                         }
                     }
-                    catch (UnityException e)
+                    catch (UnityException)
                     {
                         // If the tag is null, empty, or not a valid tag, just ignore it.
                     }


### PR DESCRIPTION
### Proposed change(s)

Fix compile warning:
> com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs(484,43): warning CS0168: The variable 'e' is declared but never used

(trying to get CI to fail first).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
