### PR TITLE
(case 1255312) Conditionally use different namespace for ScriptedImporters

### DIFF
--- a/DevProject/Packages/manifest.json
+++ b/DevProject/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.1.4",
     "com.unity.ml-agents": "file:../../com.unity.ml-agents",
-    "com.unity.multiplayer-hlapi": "1.0.4",
+    "com.unity.multiplayer-hlapi": "1.0.6",
     "com.unity.package-manager-doctools": "1.1.1-preview.3",
     "com.unity.package-validation-suite": "0.7.15-preview",
     "com.unity.purchasing": "2.0.6",

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.3] - 2020-07-07
+### Minor Changes
+#### com.unity.ml-agents (C#)
+- Update Barracuda to 1.0.1. (#4187)
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
 - Fixed an issue where RayPerceptionSensor would raise an exception when the

--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -5,7 +5,7 @@ using Unity.MLAgents.CommunicatorObjects;
 using UnityEditor;
 using UnityEngine;
 #if UNITY_2020_2_OR_NEWER
-using UnityEditor.AssetImporters
+using UnityEditor.AssetImporters;
 #else
 using UnityEditor.Experimental.AssetImporters;
 #endif

--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -4,7 +4,11 @@ using System.IO;
 using Unity.MLAgents.CommunicatorObjects;
 using UnityEditor;
 using UnityEngine;
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif
 using Unity.MLAgents.Demonstrations;
 
 namespace Unity.MLAgents.Editor

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -68,7 +68,7 @@ namespace Unity.MLAgents
         /// Unity package version of com.unity.ml-agents.
         /// This must match the version string in package.json and is checked in a unit test.
         /// </summary>
-        internal const string k_PackageVersion = "1.0.2";
+        internal const string k_PackageVersion = "1.0.3";
 
         const int k_EditorTrainingPort = 5004;
 

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,6 +5,6 @@
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.barracuda": "1.0.0"
+    "com.unity.barracuda": "1.0.1"
   }
 }

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents",
   "displayName": "ML Agents",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {


### PR DESCRIPTION
# Proposed change(s)
(case 1255312) Conditionally use different namespace for ScriptedImporters

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
