### PR TITLE
(case 1255312) Conditionally use different namespace for ScriptedImporters

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
 #### com.unity.ml-agents (C#)
 - `SideChannelsManager` was renamed to `SideChannelManager`. The old name is still supported, but deprecated. (#4137)
 - `RayPerceptionSensor.Perceive()` now additionally store the GameObject that was hit by the ray. (#4111)
-- The Barracuda dependency was upgraded to 1.0.0 (#4118)
+- The Barracuda dependency was upgraded to 1.0.1 (#4187)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added new Google Colab notebooks to show how to use `UnityEnvironment'. (#4117)
 - Fixed issue with FoodCollector when playing with keyboard. (#4147)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
 #### com.unity.ml-agents (C#)
 - `SideChannelsManager` was renamed to `SideChannelManager`. The old name is still supported, but deprecated. (#4137)
 - `RayPerceptionSensor.Perceive()` now additionally store the GameObject that was hit by the ray. (#4111)
-- The Barracuda dependency was upgraded to 1.0.1 (#4187)
+- The Barracuda dependency was upgraded to 1.0.1 (#4188)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added new Google Colab notebooks to show how to use `UnityEnvironment'. (#4117)
 - Fixed issue with FoodCollector when playing with keyboard. (#4147)

--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -5,7 +5,7 @@ using Unity.MLAgents.CommunicatorObjects;
 using UnityEditor;
 using UnityEngine;
 #if UNITY_2020_2_OR_NEWER
-using UnityEditor.AssetImporters
+using UnityEditor.AssetImporters;
 #else
 using UnityEditor.Experimental.AssetImporters;
 #endif

--- a/com.unity.ml-agents/Editor/DemonstrationImporter.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationImporter.cs
@@ -4,7 +4,11 @@ using System.IO;
 using Unity.MLAgents.CommunicatorObjects;
 using UnityEditor;
 using UnityEngine;
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif
 using Unity.MLAgents.Demonstrations;
 
 namespace Unity.MLAgents.Editor

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,6 +5,6 @@
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.barracuda": "1.0.0"
+    "com.unity.barracuda": "1.0.1"
   }
 }


### PR DESCRIPTION
### Proposed change(s)

(case 1255312) Conditionally use different namespace for ScriptedImporters

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
