### PR TITLE
Enforce warnings-as-errors, fix warning

### DIFF
--- a/DevProject/Assets/csc.rsp
+++ b/DevProject/Assets/csc.rsp
@@ -1,0 +1,2 @@
+-warnaserror+
+-warnaserror-:618

--- a/DevProject/Assets/csc.rsp.meta
+++ b/DevProject/Assets/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a867228d11c914383b374dc178415a0f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/csc.rsp
+++ b/Project/Assets/csc.rsp
@@ -1,0 +1,2 @@
+-warnaserror+
+-warnaserror-:618

--- a/Project/Assets/csc.rsp.meta
+++ b/Project/Assets/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c919ab2efb86f4001a0176ec5a1a3329
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -481,7 +481,7 @@ namespace Unity.MLAgents.Sensors
                             tagsEqual = hitObject.CompareTag(tag);
                         }
                     }
-                    catch (UnityException e)
+                    catch (UnityException)
                     {
                         // If the tag is null, empty, or not a valid tag, just ignore it.
                     }


### PR DESCRIPTION
### Proposed change(s)
* Make the projects treat compilation warnings as errors
* Fix the one warning we had.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
