### PR TITLE
Add warning if behavior name not found in trainer config

### DIFF
--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -39,6 +39,10 @@ class TrainerFactory:
         self.ghost_controller = GhostController()
 
     def generate(self, brain_name: str) -> Trainer:
+        if brain_name not in self.trainer_config.keys():
+            logger.warning(
+                f"Behavior name {brain_name} does not match any behaviors in the trainer configuration file. "
+            )
         return initialize_trainer(
             self.trainer_config[brain_name],
             brain_name,

--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -41,7 +41,8 @@ class TrainerFactory:
     def generate(self, brain_name: str) -> Trainer:
         if brain_name not in self.trainer_config.keys():
             logger.warning(
-                f"Behavior name {brain_name} does not match any behaviors specified in the trainer configuration file: {sorted(self.trainer_config.keys())}"
+                f"Behavior name {brain_name} does not match any behaviors specified in the trainer configuration file:"
+                f"{sorted(self.trainer_config.keys())}"
             )
         return initialize_trainer(
             self.trainer_config[brain_name],

--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -41,7 +41,7 @@ class TrainerFactory:
     def generate(self, brain_name: str) -> Trainer:
         if brain_name not in self.trainer_config.keys():
             logger.warning(
-                f"Behavior name {brain_name} does not match any behaviors specified in the trainer configuration file."
+                f"Behavior name {brain_name} does not match any behaviors specified in the trainer configuration file: {sorted(self.trainer_config.keys())}"
             )
         return initialize_trainer(
             self.trainer_config[brain_name],

--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -41,7 +41,7 @@ class TrainerFactory:
     def generate(self, brain_name: str) -> Trainer:
         if brain_name not in self.trainer_config.keys():
             logger.warning(
-                f"Behavior name {brain_name} does not match any behaviors in the trainer configuration file. "
+                f"Behavior name {brain_name} does not match any behaviors in the trainer configuration file."
             )
         return initialize_trainer(
             self.trainer_config[brain_name],

--- a/ml-agents/mlagents/trainers/trainer_util.py
+++ b/ml-agents/mlagents/trainers/trainer_util.py
@@ -41,7 +41,7 @@ class TrainerFactory:
     def generate(self, brain_name: str) -> Trainer:
         if brain_name not in self.trainer_config.keys():
             logger.warning(
-                f"Behavior name {brain_name} does not match any behaviors in the trainer configuration file."
+                f"Behavior name {brain_name} does not match any behaviors specified in the trainer configuration file."
             )
         return initialize_trainer(
             self.trainer_config[brain_name],


### PR DESCRIPTION
### Proposed change(s)

User had a mismatch between the behavior name in the behavior parameters script and trainer config. This will raise a warning if there is no match found. 

https://github.com/Unity-Technologies/ml-agents/issues/4199

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
