### PR TITLE
better logging for NaN rewards

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
@@ -1,7 +1,9 @@
+using System;
 using UnityEngine;
 using Unity.MLAgents;
 using Unity.MLAgentsExamples;
 using Unity.MLAgents.Sensors;
+using Random = UnityEngine.Random;
 
 [RequireComponent(typeof(JointDriveController))] // Required to set joint forces
 public class CrawlerAgent : Agent
@@ -111,7 +113,7 @@ public class CrawlerAgent : Agent
     {
         //Add body rotation delta relative to orientation cube
         sensor.AddObservation(Quaternion.FromToRotation(body.forward, orientationCube.transform.forward));
-        
+
         //Add pos of target relative to orientation cube
         sensor.AddObservation(orientationCube.transform.InverseTransformPoint(target.transform.position));
 
@@ -211,7 +213,15 @@ public class CrawlerAgent : Agent
     {
         var movingTowardsDot = Vector3.Dot(orientationCube.transform.forward,
             Vector3.ClampMagnitude(m_JdController.bodyPartsDict[body].rb.velocity, maximumWalkingSpeed));
-        ;
+        if (float.IsNaN(movingTowardsDot))
+        {
+            throw new ArgumentException(
+                "NaN in movingTowardsDot.\n" +
+                $" orientationCube.transform.forward: {orientationCube.transform.forward}\n"+
+                $" body.velocity: {m_JdController.bodyPartsDict[body].rb.velocity}\n"+
+                $" maximumWalkingSpeed: {maximumWalkingSpeed}"
+            );
+        }
         AddReward(0.03f * movingTowardsDot);
     }
 
@@ -220,7 +230,16 @@ public class CrawlerAgent : Agent
     /// </summary>
     void RewardFunctionFacingTarget()
     {
-        AddReward(0.01f * Vector3.Dot(orientationCube.transform.forward, body.forward));
+        var facingReward = Vector3.Dot(orientationCube.transform.forward, body.forward);
+        if (float.IsNaN(facingReward))
+        {
+            throw new ArgumentException(
+                "NaN in movingTowardsDot.\n" +
+                $" orientationCube.transform.forward: {orientationCube.transform.forward}\n"+
+                $" body.forward: {body.forward}"
+            );
+        }
+        AddReward(0.01f * facingReward);
     }
 
     /// <summary>

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -1,9 +1,11 @@
+using System;
 using MLAgentsExamples;
 using UnityEngine;
 using Unity.MLAgents;
 using Unity.MLAgentsExamples;
 using Unity.MLAgents.Sensors;
 using BodyPart = Unity.MLAgentsExamples.BodyPart;
+using Random = UnityEngine.Random;
 
 public class WalkerAgent : Agent
 {
@@ -171,11 +173,40 @@ public class WalkerAgent : Agent
         // a. Velocity alignment with goal direction.
         var moveTowardsTargetReward = Vector3.Dot(cubeForward,
             Vector3.ClampMagnitude(m_JdController.bodyPartsDict[hips].rb.velocity, maximumWalkingSpeed));
+        if (float.IsNaN(moveTowardsTargetReward))
+        {
+            throw new ArgumentException(
+                "NaN in moveTowardsTargetReward.\n" +
+                $" cubeForward: {cubeForward}\n"+
+                $" hips.velocity: {m_JdController.bodyPartsDict[hips].rb.velocity}\n"+
+                $" maximumWalkingSpeed: {maximumWalkingSpeed}"
+            );
+        }
+
         // b. Rotation alignment with goal direction.
         var lookAtTargetReward = Vector3.Dot(cubeForward, head.forward);
+        if (float.IsNaN(lookAtTargetReward))
+        {
+            throw new ArgumentException(
+                "NaN in lookAtTargetReward.\n" +
+                $" cubeForward: {cubeForward}\n"+
+                $" head.forward: {head.forward}"
+            );
+        }
+
         // c. Encourage head height. //Should normalize to ~1
-        var headHeightOverFeetReward = 
+        var headHeightOverFeetReward =
             ((head.position.y - footL.position.y) + (head.position.y - footR.position.y) / 10);
+        if (float.IsNaN(headHeightOverFeetReward))
+        {
+            throw new ArgumentException(
+                "NaN in headHeightOverFeetReward.\n" +
+                $" head.position: {head.position}\n"+
+                $" footL.position: {footL.position}\n"+
+                $" footR.position: {footR.position}"
+            );
+        }
+
         AddReward(
             + 0.02f * moveTowardsTargetReward
             + 0.02f * lookAtTargetReward


### PR DESCRIPTION
### Proposed change(s)
Still seeing NaN rewards in the daily trainings. This will at least help narrow down where they're coming from.

```
ArgumentException: NaN increment passed to AddReward.
  at Unity.MLAgents.Utilities.DebugCheckNanAndInfinity (System.Single value, System.String valueCategory, System.String caller) [0x0000c] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/com.unity.ml-agents/Runtime/Utilities.cs:84 
  at Unity.MLAgents.Agent.AddReward (System.Single increment) [0x00001] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/com.unity.ml-agents/Runtime/Agent.cs:643 
  at CrawlerAgent.RewardFunctionMovingTowards () [0x00043] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs:215 
  at CrawlerAgent.FixedUpdate () [0x00128] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs:193 
```

```
ArgumentException: NaN increment passed to AddReward.
  at Unity.MLAgents.Utilities.DebugCheckNanAndInfinity (System.Single value, System.String valueCategory, System.String caller) [0x0000c] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/com.unity.ml-agents/Runtime/Utilities.cs:84 
  at Unity.MLAgents.Agent.AddReward (System.Single increment) [0x00001] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/com.unity.ml-agents/Runtime/Agent.cs:643 
  at WalkerAgent.FixedUpdate () [0x000bd] in /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs:179 
```

Still also seeing this but not sure what to do about it:
```
Look rotation viewing vector is zero
UnityEngine.Quaternion:LookRotation_Injected(Vector3&, Vector3&, Quaternion&)
UnityEngine.Quaternion:LookRotation(Vector3, Vector3)
UnityEngine.Quaternion:LookRotation(Vector3)
Unity.MLAgentsExamples.OrientationCubeController:UpdateOrientation(Transform, Transform) (at /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/OrientationCubeController.cs:15)
WalkerAgent:FixedUpdate() (at /opt/workspace/workspace/ml-agents.ml-agents.automated-linux-do-not-modify/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs:169)
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
