### PR TITLE
Pytorch port of SAC

### DIFF
--- a/ml-agents/mlagents/trainers/distributions_torch.py
+++ b/ml-agents/mlagents/trainers/distributions_torch.py
@@ -69,6 +69,9 @@ class CategoricalDistInstance(nn.Module):
     def log_prob(self, value):
         return torch.log(self.pdf(value))
 
+    def all_log_prob(self):
+        return torch.log(self.probs)
+
     def entropy(self):
         return torch.sum(self.probs * torch.log(self.probs), dim=-1)
 

--- a/ml-agents/mlagents/trainers/models_torch.py
+++ b/ml-agents/mlagents/trainers/models_torch.py
@@ -336,14 +336,12 @@ class ActorCritic(nn.Module):
         for action_dist in dists:
             action = action_dist.sample()
             actions.append(action)
-        actions = torch.stack(actions, dim=-1)
         return actions
 
-    def get_probs_and_entropy(self, actions, dists):
+    def get_probs_and_entropy(self, action_list, dists):
         log_probs = []
         entropies = []
-        for idx, action_dist in enumerate(dists):
-            action = actions[..., idx]
+        for action, action_dist in zip(action_list, dists):
             log_prob = action_dist.log_prob(action)
             log_probs.append(log_prob)
             entropies.append(action_dist.entropy())
@@ -379,7 +377,8 @@ class ActorCritic(nn.Module):
         dists, value_outputs, memories = self.get_dist_and_value(
             vec_inputs, vis_inputs, masks, memories, sequence_length
         )
-        sampled_actions = self.sample_action(dists)
+        action_list = self.sample_action(dists)
+        sampled_actions = torch.stack(action_list, dim=-1)
         return (
             sampled_actions,
             dists[0].pdf(sampled_actions),

--- a/ml-agents/mlagents/trainers/models_torch.py
+++ b/ml-agents/mlagents/trainers/models_torch.py
@@ -384,11 +384,12 @@ class ActorCritic(nn.Module):
                 all_probs.append(action_dist.all_log_prob())
         log_probs = torch.stack(log_probs, dim=-1)
         entropies = torch.stack(entropies, dim=-1)
-        all_probs = torch.cat(all_probs, dim=-1)
         if self.act_type == ActionType.CONTINUOUS:
             log_probs = log_probs.squeeze(-1)
             entropies = entropies.squeeze(-1)
             all_probs = None
+        else:
+            all_probs = torch.cat(all_probs, dim=-1)
         return log_probs, entropies, all_probs
 
     def get_dist_and_value(

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -100,7 +100,6 @@ class TorchPolicy(Policy):
             torch.set_default_tensor_type(torch.cuda.FloatTensor)
         else:
             torch.set_default_tensor_type(torch.FloatTensor)
-        
 
         self.inference_dict: Dict[str, tf.Tensor] = {}
         self.update_dict: Dict[str, tf.Tensor] = {}
@@ -243,7 +242,6 @@ class TorchPolicy(Policy):
         run_out["learning_rate"] = 0.0
         if self.use_recurrent:
             run_out["memories"] = memories.detach().cpu().numpy()
-        self.actor_critic.update_normalization(vec_obs)
         return run_out
 
     def get_action(
@@ -291,14 +289,20 @@ class TorchPolicy(Policy):
 
     def export_model(self, step=0):
         try:
-            fake_vec_obs = [torch.zeros([1] + [self.brain.vector_observation_space_size])]
+            fake_vec_obs = [
+                torch.zeros([1] + [self.brain.vector_observation_space_size])
+            ]
             fake_vis_obs = [torch.zeros([1] + [84, 84, 3])]
             fake_masks = torch.ones([1] + self.actor_critic.act_size)
             # fake_memories = torch.zeros([1] + [self.m_size])
             export_path = "./model-" + str(step) + ".onnx"
             output_names = ["action", "action_probs"]
             input_names = ["vector_observation", "action_mask"]
-            dynamic_axes = {"vector_observation": [0], "action": [0], "action_probs": [0]}
+            dynamic_axes = {
+                "vector_observation": [0],
+                "action": [0],
+                "action_probs": [0],
+            }
             onnx.export(
                 self.actor_critic,
                 (fake_vec_obs, fake_vis_obs, fake_masks),

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -190,6 +190,8 @@ class TorchPolicy(Policy):
         dists, (value_heads, mean_value), _ = self.actor_critic.get_dist_and_value(
             vec_obs, vis_obs, masks, memories, seq_len
         )
+        if len(actions.shape) <= 2:
+            actions.unsqueeze_(-1)
         action_list = [actions[..., i] for i in range(actions.shape[2])]
         log_probs, entropies, _ = self.actor_critic.get_probs_and_entropy(
             action_list, dists

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -200,7 +200,7 @@ class TorchPolicy(Policy):
             vec_obs, vis_obs, masks, memories, seq_len
         )
         if len(actions.shape) <= 2:
-            actions.unsqueeze_(-1)
+            actions = actions.unsqueeze(-1)
         action_list = [actions[..., i] for i in range(actions.shape[2])]
         log_probs, entropies, _ = self.actor_critic.get_probs_and_entropy(
             action_list, dists

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -54,6 +54,7 @@ class TorchPolicy(Policy):
         self.global_step = 0
         self.m_size = 0
         self.model_path = model_path
+        self.network_settings = trainer_settings.network_settings
 
         self.act_size = brain.vector_action_space_size
         self.act_type = brain.vector_action_space_type
@@ -115,6 +116,7 @@ class TorchPolicy(Policy):
             vis_encode_type=trainer_settings.network_settings.vis_encode_type,
             stream_names=reward_signal_names,
             separate_critic=self.use_continuous_act,
+            conditional_sigma=self.condition_sigma_on_obs,
         )
 
     def split_decision_step(self, decision_requests):

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -117,6 +117,7 @@ class TorchPolicy(Policy):
             stream_names=reward_signal_names,
             separate_critic=self.use_continuous_act,
             conditional_sigma=self.condition_sigma_on_obs,
+            tanh_squash=tanh_squash,
         )
 
     def split_decision_step(self, decision_requests):

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -194,14 +194,6 @@ class PPOTrainer(RLTrainer):
         self._clear_update_buffer()
         return True
 
-    def create_policy(
-        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
-    ) -> Policy:
-        if self.framework == "torch":
-            return self.create_torch_policy(parsed_behavior_id, brain_parameters)
-        else:
-            return self.create_tf_policy(parsed_behavior_id, brain_parameters)
-
     def create_tf_policy(
         self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
     ) -> NNPolicy:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -2,12 +2,12 @@
 # ## ML-Agent Learning (PPO)
 # Contains an implementation of PPO as described in: https://arxiv.org/abs/1707.06347
 
+
 class TestingConfiguration:
-    use_torch = False
+    use_torch = True
     max_steps = 0
     env_name = ""
     device = "cpu"
-
 
 
 from collections import defaultdict
@@ -28,8 +28,6 @@ from mlagents.trainers.behavior_id_utils import BehaviorIdentifiers
 from mlagents.trainers.settings import TrainerSettings, PPOSettings
 
 logger = get_logger(__name__)
-
-
 
 
 class PPOTrainer(RLTrainer):

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -1,0 +1,370 @@
+import numpy as np
+from typing import Dict, List, Mapping, cast, Tuple
+import torch
+from torch import nn
+
+from mlagents_envs.logging_util import get_logger
+from mlagents.trainers.optimizer.torch_optimizer import TorchOptimizer
+from mlagents.trainers.policy.torch_policy import TorchPolicy
+from mlagents.trainers.settings import NetworkSettings
+from mlagents.trainers.brain import CameraResolution
+from mlagents.trainers.models_torch import Critic, ContinuousQNetwork, ActionType
+from mlagents.trainers.buffer import AgentBuffer
+from mlagents_envs.timers import timed
+from mlagents.trainers.exception import UnityTrainerException
+from mlagents.trainers.settings import TrainerSettings, SACSettings
+
+EPSILON = 1e-6  # Small value to avoid divide by zero
+
+logger = get_logger(__name__)
+
+POLICY_SCOPE = ""
+TARGET_SCOPE = "target_network"
+
+
+class TorchSACOptimizer(TorchOptimizer):
+    class PolicyValueNetwork(nn.Module):
+        def __init__(
+            self,
+            stream_names: List[str],
+            vector_sizes: List[int],
+            visual_sizes: List[CameraResolution],
+            network_settings: NetworkSettings,
+            act_type: ActionType,
+            act_size: List[int],
+        ):
+            super().__init__()
+            if act_type == ActionType.CONTINUOUS:
+                self.q1_network = ContinuousQNetwork(
+                    stream_names,
+                    vector_sizes,
+                    visual_sizes,
+                    network_settings,
+                    act_type,
+                    act_size,
+                )
+                self.q2_network = ContinuousQNetwork(
+                    stream_names,
+                    vector_sizes,
+                    visual_sizes,
+                    network_settings,
+                    act_type,
+                    act_size,
+                )
+            else:
+                raise UnityTrainerException("Not supported yet")
+
+        def forward(
+            self,
+            vec_inputs: List[torch.Tensor],
+            vis_inputs: List[torch.Tensor],
+            actions: torch.Tensor = None,
+        ) -> Tuple[
+            Dict[str, torch.Tensor], Dict[str, torch.Tensor], Dict[str, torch.Tensor]
+        ]:
+            if actions is not None:
+                assert isinstance(self.q1_network, ContinuousQNetwork)
+                q1_out, _ = self.q1_network(vec_inputs, vis_inputs, actions)
+                q2_out, _ = self.q2_network(vec_inputs, vis_inputs, actions)
+            return q1_out, q2_out
+
+    def __init__(self, policy: TorchPolicy, trainer_params: TrainerSettings):
+        super().__init__(policy, trainer_params)
+        hyperparameters: SACSettings = cast(SACSettings, trainer_params.hyperparameters)
+        lr = hyperparameters.learning_rate
+        # lr_schedule = hyperparameters.learning_rate_schedule
+        # max_step = trainer_params.max_steps
+        self.tau = hyperparameters.tau
+        self.init_entcoef = hyperparameters.init_entcoef
+
+        self.policy = policy
+        self.act_size = policy.act_size
+        policy_network_settings = policy.network_settings
+        # h_size = policy_network_settings.hidden_units
+        # num_layers = policy_network_settings.num_layers
+        # vis_encode_type = policy_network_settings.vis_encode_type
+
+        self.tau = hyperparameters.tau
+        self.burn_in_ratio = 0.0
+
+        # Non-exposed SAC parameters
+        self.discrete_target_entropy_scale = 0.2  # Roughly equal to e-greedy 0.05
+        self.continuous_target_entropy_scale = 1.0
+
+        self.stream_names = list(self.reward_signals.keys())
+        # Use to reduce "survivor bonus" when using Curiosity or GAIL.
+        self.gammas = [_val.gamma for _val in trainer_params.reward_signals.values()]
+        self.use_dones_in_backup = {
+            name: int(self.reward_signals[name].use_terminal_states)
+            for name in self.stream_names
+        }
+        # self.disable_use_dones = {
+        #     name: self.use_dones_in_backup[name].assign(0.0)
+        #     for name in stream_names
+        # }
+
+        brain = policy.brain
+        self.value_network = TorchSACOptimizer.PolicyValueNetwork(
+            self.stream_names,
+            [brain.vector_observation_space_size],
+            brain.camera_resolutions,
+            policy_network_settings,
+            ActionType.from_str(policy.act_type),
+            self.act_size,
+        )
+        self.target_network = Critic(
+            self.stream_names,
+            policy_network_settings.hidden_units,
+            [brain.vector_observation_space_size],
+            brain.camera_resolutions,
+            policy_network_settings.normalize,
+            policy_network_settings.num_layers,
+            policy_network_settings.memory.memory_sze
+            if policy_network_settings.memory is not None
+            else 0,
+            policy_network_settings.vis_encode_type,
+        )
+        self.soft_update(self.policy.actor_critic.critic, self.target_network, 1.0)
+
+        self._log_ent_coef = torch.tensor(
+            np.log([self.init_entcoef] * len(self.act_size)).astype(np.float32),
+            requires_grad=True,
+        )
+        self.target_entropy = torch.as_tensor(
+            -1
+            * self.continuous_target_entropy_scale
+            * np.prod(self.act_size[0]).astype(np.float32)
+        )
+
+        policy_params = list(self.policy.actor_critic.network_body.parameters()) + list(
+            self.policy.actor_critic.distribution.parameters()
+        )
+        print(self.policy.actor_critic.network_body.parameters())
+        value_params = list(self.value_network.parameters()) + list(
+            self.policy.actor_critic.critic.parameters()
+        )
+
+        self.policy_optimizer = torch.optim.Adam(policy_params, lr=lr)
+        self.value_optimizer = torch.optim.Adam(value_params, lr=lr)
+        self.entropy_optimizer = torch.optim.Adam([self._log_ent_coef], lr=lr)
+
+    def sac_q_loss(
+        self,
+        q1_out: Dict[str, torch.Tensor],
+        q2_out: Dict[str, torch.Tensor],
+        target_values: Dict[str, torch.Tensor],
+        dones: torch.Tensor,
+        rewards: Dict[str, torch.Tensor],
+        loss_masks: torch.Tensor,
+        discrete: bool = False,
+    ) -> None:
+        """
+        Creates training-specific Tensorflow ops for SAC models.
+        :param q1_streams: Q1 streams from policy network
+        :param q1_streams: Q2 streams from policy network
+        :param lr: Learning rate
+        :param max_step: Total number of training steps.
+        :param stream_names: List of reward stream names.
+        :param discrete: Whether or not to use discrete action losses.
+        """
+        q1_losses = []
+        q2_losses = []
+        # Multiple q losses per stream
+        for i, name in enumerate(q1_out.keys()):
+            q1_stream = q1_out[name]
+            q2_stream = q2_out[name]
+            with torch.no_grad():
+                q_backup = rewards[name] + (
+                    1.0
+                    - self.use_dones_in_backup[name]
+                    * dones
+                    * self.gammas[i]
+                    * target_values[name]
+                )
+
+            _q1_loss = 0.5 * torch.mean(
+                loss_masks * torch.pow((q_backup - q1_stream), 2)
+            )
+            _q2_loss = 0.5 * torch.mean(
+                loss_masks * torch.pow((q_backup - q2_stream), 2)
+            )
+
+            q1_losses.append(_q1_loss)
+            q2_losses.append(_q2_loss)
+        q1_loss = torch.mean(torch.stack(q1_losses))
+        q2_loss = torch.mean(torch.stack(q2_losses))
+        print(q1_loss)
+
+        return q1_loss + q2_loss
+
+    def soft_update(self, source: nn.Module, target: nn.Module, tau: float):
+        for source_param, target_param in zip(source.parameters(), target.parameters()):
+            target_param.data.copy_(
+                target_param.data * (1.0 - tau) + source_param.data * tau
+            )
+
+    def sac_value_loss(
+        self,
+        log_probs: torch.Tensor,
+        values: Dict[str, torch.Tensor],
+        q1p_out: Dict[str, torch.Tensor],
+        q2p_out: Dict[str, torch.Tensor],
+        loss_masks: torch.Tensor,
+        discrete: bool,
+    ):
+        min_policy_qs = {}
+
+        for name in values.keys():
+            if not discrete:
+                min_policy_qs[name] = torch.min(q1p_out[name], q2p_out[name])
+                _ent_coef = torch.exp(self._log_ent_coef)
+
+        if not discrete:
+            value_losses = []
+            for name in values.keys():
+                with torch.no_grad():
+                    v_backup = min_policy_qs[name] - torch.sum(
+                        _ent_coef * log_probs, dim=1
+                    )
+                value_loss = 0.5 * torch.mean(
+                    loss_masks * torch.pow((values[name] - v_backup), 2)
+                )
+                value_losses.append(value_loss)
+        value_loss = torch.mean(torch.stack(value_losses))
+        return value_loss
+
+    def sac_policy_loss(
+        self,
+        log_probs: torch.Tensor,
+        q1p_outs: Dict[str, torch.Tensor],
+        loss_masks: torch.Tensor,
+        discrete: bool,
+    ):
+        _ent_coef = torch.exp(self._log_ent_coef)
+        if not discrete:
+            mean_q1 = torch.mean(torch.stack(list(q1p_outs.values())))
+            batch_policy_loss = torch.mean(_ent_coef * log_probs - mean_q1, dim=1)
+            policy_loss = torch.mean(loss_masks * batch_policy_loss)
+        else:
+            policy_loss = 0
+        return policy_loss
+
+    def sac_entropy_loss(
+        self, log_probs: torch.Tensor, loss_masks: torch.Tensor, discrete: bool
+    ):
+        if not discrete:
+            with torch.no_grad():
+                inner_term = torch.sum(log_probs + self.target_entropy, dim=1)
+            entropy_loss = -torch.mean(self._log_ent_coef * loss_masks * inner_term)
+        else:
+            entropy_loss = 0
+        return entropy_loss
+
+    @timed
+    def update(self, batch: AgentBuffer, num_sequences: int) -> Dict[str, float]:
+        """
+        Updates model using buffer.
+        :param num_sequences: Number of trajectories in batch.
+        :param batch: Experience mini-batch.
+        :param update_target: Whether or not to update target value network
+        :param reward_signal_batches: Minibatches to use for updating the reward signals,
+            indexed by name. If none, don't update the reward signals.
+        :return: Output from update process.
+        """
+        rewards = {}
+        for name in self.reward_signals:
+            rewards[name] = torch.as_tensor(batch["{}_rewards".format(name)])
+
+        vec_obs = [torch.as_tensor(batch["vector_obs"])]
+        next_vec_obs = [torch.as_tensor(batch["next_vector_in"])]
+        act_masks = torch.as_tensor(batch["action_mask"])
+        if self.policy.use_continuous_act:
+            actions = torch.as_tensor(batch["actions"]).unsqueeze(-1)
+        else:
+            actions = torch.as_tensor(batch["actions"], dtype=torch.long)
+
+        memories = [
+            torch.as_tensor(batch["memory"][i])
+            for i in range(0, len(batch["memory"]), self.policy.sequence_length)
+        ]
+        if len(memories) > 0:
+            memories = torch.stack(memories).unsqueeze(0)
+
+        next_vis_obs = []
+        if self.policy.use_vis_obs:
+            vis_obs = []
+            next_vis_obs = []
+            for idx, _ in enumerate(
+                self.policy.actor_critic.network_body.visual_encoders
+            ):
+                vis_ob = torch.as_tensor(batch["visual_obs%d" % idx])
+                vis_obs.append(vis_ob)
+                next_vis_ob = torch.as_tensor(batch["next_visual_obs%d" % idx])
+                next_vis_obs.append(next_vis_ob)
+        else:
+            vis_obs = []
+        sampled_actions, log_probs, entropies, sampled_values, _ = self.policy.sample_actions(
+            vec_obs,
+            vis_obs,
+            masks=act_masks,
+            memories=memories,
+            seq_len=self.policy.sequence_length,
+        )
+        q1p_out, q2p_out = self.value_network(vec_obs, vis_obs, sampled_actions)
+        q1_out, q2_out = self.value_network(vec_obs, vis_obs, actions.squeeze(-1))
+
+        target_values, _ = self.target_network(next_vec_obs, next_vis_obs)
+        q_loss = self.sac_q_loss(
+            q1_out,
+            q2_out,
+            target_values,
+            torch.as_tensor(batch["done"]),
+            rewards,
+            torch.as_tensor(batch["masks"], dtype=torch.int32),
+            False,
+        )
+        value_loss = self.sac_value_loss(
+            log_probs,
+            sampled_values,
+            q1p_out,
+            q2p_out,
+            torch.as_tensor(batch["masks"], dtype=torch.int32),
+            False,
+        )
+        policy_loss = self.sac_policy_loss(
+            log_probs,
+            q1p_out,
+            torch.as_tensor(batch["masks"], dtype=torch.int32),
+            False,
+        )
+        entropy_loss = self.sac_entropy_loss(
+            log_probs, torch.as_tensor(batch["masks"], dtype=torch.int32), False
+        )
+        self.policy_optimizer.zero_grad()
+        policy_loss.backward()
+        self.policy_optimizer.step()
+
+        total_value_loss = q_loss + value_loss
+        self.value_optimizer.zero_grad()
+        total_value_loss.backward()
+        self.value_optimizer.step()
+
+        self.entropy_optimizer.zero_grad()
+        entropy_loss.backward
+        self.entropy_optimizer.step()
+
+        # Update Q network
+        self.soft_update(self.policy.actor_critic.critic, self.target_network, self.tau)
+
+        update_stats = {
+            "Losses/Policy Loss": abs(policy_loss.detach().numpy()),
+            "Losses/Value Loss": value_loss.detach().numpy(),
+            "Losses/Q Loss": q_loss.detach().numpy(),
+            "Policy/Entropy Coeff": torch.exp(self._log_ent_coef).detach().numpy(),
+        }
+        return update_stats
+
+    def update_reward_signals(
+        self, reward_signal_minibatches: Mapping[str, AgentBuffer], num_sequences: int
+    ) -> Dict[str, float]:
+        return {}

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -344,7 +344,7 @@ class TorchSACOptimizer(TorchOptimizer):
             branched_q = break_into_branches(item, self.act_size)
             only_action_qs = torch.stack(
                 [
-                    torch.sum(_act * _q * 0.0, dim=1, keepdim=True)
+                    torch.sum(_act * _q, dim=1, keepdim=True)
                     for _act, _q in zip(onehot_actions, branched_q)
                 ]
             )
@@ -420,8 +420,7 @@ class TorchSACOptimizer(TorchOptimizer):
             q1_out, q2_out = self.value_network(vec_obs, vis_obs, squeezed_actions)
             q1_stream, q2_stream = q1_out, q2_out
         else:
-            with torch.no_grad():
-                q1p_out, q2p_out = self.value_network(vec_obs, vis_obs)
+            q1p_out, q2p_out = self.value_network(vec_obs, vis_obs)
             q1_out, q2_out = self.value_network(vec_obs, vis_obs)
             q1_stream = self._condense_q_streams(q1_out, actions)
             q2_stream = self._condense_q_streams(q2_out, actions)

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -410,7 +410,7 @@ class TorchSACOptimizer(TorchOptimizer):
             masks=act_masks,
             memories=memories,
             seq_len=self.policy.sequence_length,
-            all_log_probs=True,
+            all_log_probs=not self.policy.use_continuous_act,
         )
         squeezed_actions = actions.squeeze(-1)
 

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -344,10 +344,11 @@ class TorchSACOptimizer(TorchOptimizer):
             branched_q = break_into_branches(item, self.act_size)
             only_action_qs = torch.stack(
                 [
-                    torch.sum(_act * _q, dim=1, keepdim=True)
+                    torch.sum(_act * _q * 0.0, dim=1, keepdim=True)
                     for _act, _q in zip(onehot_actions, branched_q)
                 ]
             )
+
             condensed_q_output[key] = torch.mean(only_action_qs, dim=0)
         return condensed_q_output
 
@@ -419,7 +420,8 @@ class TorchSACOptimizer(TorchOptimizer):
             q1_out, q2_out = self.value_network(vec_obs, vis_obs, squeezed_actions)
             q1_stream, q2_stream = q1_out, q2_out
         else:
-            q1p_out, q2p_out = self.value_network(vec_obs, vis_obs)
+            with torch.no_grad():
+                q1p_out, q2p_out = self.value_network(vec_obs, vis_obs)
             q1_out, q2_out = self.value_network(vec_obs, vis_obs)
             q1_stream = self._condense_q_streams(q1_out, actions)
             q2_stream = self._condense_q_streams(q2_out, actions)

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -455,11 +455,11 @@ class TorchSACOptimizer(TorchOptimizer):
         # Update target network
         self.soft_update(self.policy.actor_critic.critic, self.target_network, self.tau)
         update_stats = {
-            "Losses/Policy Loss": abs(policy_loss.detach().numpy()),
-            "Losses/Value Loss": value_loss.detach().numpy(),
-            "Losses/Q1 Loss": q1_loss.detach().numpy(),
-            "Losses/Q2 Loss": q2_loss.detach().numpy(),
-            "Policy/Entropy Coeff": torch.exp(self._log_ent_coef).detach().numpy(),
+            "Losses/Policy Loss": abs(policy_loss.detach().cpu().numpy()),
+            "Losses/Value Loss": value_loss.detach().cpu().numpy(),
+            "Losses/Q1 Loss": q1_loss.detach().cpu().numpy(),
+            "Losses/Q2 Loss": q2_loss.detach().cpu().numpy(),
+            "Policy/Entropy Coeff": torch.exp(self._log_ent_coef).detach().cpu().numpy(),
         }
         return update_stats
 

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -237,7 +237,8 @@ class SACTrainer(RLTrainer):
             self.trainer_settings,
             self.artifact_path,
             self.load,
-            condition_sigma_on_obs=True,  # Faster training for PPO
+            condition_sigma_on_obs=True,
+            tanh_squash=True,
         )
         return policy
 

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -213,7 +213,6 @@ class SACTrainer(RLTrainer):
             self.seed,
             brain_parameters,
             self.trainer_settings,
-            self.is_training,
             self.artifact_path,
             self.load,
             tanh_squash=True,
@@ -239,6 +238,7 @@ class SACTrainer(RLTrainer):
             self.load,
             condition_sigma_on_obs=True,
             tanh_squash=True,
+            separate_critic=True,
         )
         return policy
 

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -17,6 +17,8 @@ from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.stats import StatsPropertyType
 
+from mlagents.trainers.ppo.trainer import TestingConfiguration
+
 RewardSignalResults = Dict[str, RewardSignalResult]
 
 logger = get_logger(__name__)
@@ -40,7 +42,9 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         self._stats_reporter.add_property(
             StatsPropertyType.HYPERPARAMETERS, self.trainer_settings.as_dict()
         )
-        self.framework = "torch"
+        self.framework = "torch" if TestingConfiguration.use_torch else "tf"
+        if TestingConfiguration.max_steps > 0:
+            self.trainer_settings.max_steps = TestingConfiguration.max_steps
         self._next_save_step = 0
         self._next_summary_step = 0
 

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -10,6 +10,9 @@ from mlagents.trainers.buffer import AgentBuffer
 from mlagents.trainers.trainer import Trainer
 from mlagents.trainers.components.reward_signals import RewardSignalResult
 from mlagents_envs.timers import hierarchical_timer
+from mlagents.trainers.brain import BrainParameters
+from mlagents.trainers.policy.policy import Policy
+from mlagents.trainers.behavior_id_utils import BehaviorIdentifiers
 from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.stats import StatsPropertyType
@@ -37,6 +40,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         self._stats_reporter.add_property(
             StatsPropertyType.HYPERPARAMETERS, self.trainer_settings.as_dict()
         )
+        self.framework = "torch"
         self._next_save_step = 0
         self._next_summary_step = 0
 
@@ -79,6 +83,14 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         :return: A boolean corresponding to wether or not update_model() can be run
         """
         return False
+
+    def create_policy(
+        self, parsed_behavior_id: BehaviorIdentifiers, brain_parameters: BrainParameters
+    ) -> Policy:
+        if self.framework == "torch":
+            return self.create_torch_policy(parsed_behavior_id, brain_parameters)
+        else:
+            return self.create_tf_policy(parsed_behavior_id, brain_parameters)
 
     @abc.abstractmethod
     def _update_policy(self) -> bool:


### PR DESCRIPTION
### Proposed change(s)

Add both discrete and continuous SAC.

There's a bit of change in the policy/models to pass the action tensors directly, which allows the tanh caching to work (avoids numerical instability in inverse tanh). 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
