### PR TITLE
Throw if Academy.EnvironmentStep() is called recursively

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to
 ### Minor Changes
 
 ### Bug Fixes
-`mlagents-learn` will now raise an error immediately if `--num-envs` is greater than 1 without setting the `--env`
-argument. (#4203)
+#### com.unity.ml-agents (C#)
+- Academy.EnvironmentStep() will now throw an exception if it is called
+recursively (for example, by an Agent's CollectObservations method).
+Previously, this would result in an infinite loop and cause the editor to hang.
+(#4226)
 
 ## [1.2.0-preview] - 2020-07-15
 

--- a/com.unity.ml-agents/Tests/Editor/AcademyTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/AcademyTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Unity.MLAgents.Sensors;
 using UnityEngine;
 #if UNITY_2019_3_OR_NEWER
 using System.Reflection;
@@ -20,6 +21,37 @@ namespace Unity.MLAgents.Tests
             Assert.AreEqual("com.unity.ml-agents", packageInfo.name);
             Assert.AreEqual(Academy.k_PackageVersion, packageInfo.version);
 #endif
+        }
+
+        class RecursiveAgent : Agent
+        {
+            int m_collectObsCount;
+            public override void CollectObservations(VectorSensor sensor)
+            {
+                m_collectObsCount++;
+                if (m_collectObsCount == 1)
+                {
+                    // NEVER DO THIS IN REAL CODE!
+                    Academy.Instance.EnvironmentStep();
+                }
+            }
+        }
+
+        [Test]
+        public void TestRecursiveStepThrows()
+        {
+            var gameObj = new GameObject();
+            var agent = gameObj.AddComponent<RecursiveAgent>();
+            agent.LazyInitialize();
+            agent.RequestDecision();
+
+            Assert.Throws<UnityAgentsException>(() =>
+            {
+                Academy.Instance.EnvironmentStep();
+            });
+
+            // Make sure the Academy reset to a good state and is still steppable.
+            Academy.Instance.EnvironmentStep();
         }
 
 


### PR DESCRIPTION
### Proposed change(s)
Alternative (or possibly in addition to) https://github.com/Unity-Technologies/ml-agents/pull/4226

Check if Academy.EnvironmentStep is being called from itself, and raise an exception if it is.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
