### PR TITLE
Revert "use old yamato test config"

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -65,7 +65,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --package-filter {{ package.name }} {{ editor.coverageOptions }}
 
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
@@ -107,7 +107,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --package-filter {{ package.name }} {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -29,6 +29,9 @@ test_platforms:
     type: Unity::VM
     image: package-ci/ubuntu:stable
     flavor: b1.medium
+packages:
+  - name: com.unity.ml-agents
+  - name: com.unity.ml-agents.extensions
 ---
 
 all_package_tests:
@@ -36,13 +39,13 @@ all_package_tests:
   dependencies:
   {% for editor in test_editors %}
     {% for platform in test_platforms %}
-  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+  - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
   {% endfor %}
 
   {% for editor in trunk_editor %}
     {% for platform in test_platforms %}
-  - .yamato/com.unity.ml-agents-test.yml#test_{{ platform.name }}_{{ editor.version }}
+  - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
   {% endfor %}
   triggers:
@@ -51,18 +54,23 @@ all_package_tests:
       - branch: master
         frequency: daily
 
-{% for editor in test_editors %}
-  {% for platform in test_platforms %}
-test_{{ platform.name }}_{{ editor.version }}:
-  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+{% for package in packages %}
+  {% for editor in test_editors %}
+    {% for platform in test_platforms %}
+test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
+  name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+
+    {% if package.name == "com.unity.ml-agents" %}
+    # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+    {% endif %}
   artifacts:
     logs:
       paths:
@@ -77,15 +85,20 @@ test_{{ platform.name }}_{{ editor.version }}:
       pull_request.target match "release.+") AND
       NOT pull_request.draft AND
       (pull_request.changes.any match "com.unity.ml-agents/**" OR
+      {% if package.name == "com.unity.ml-agents.extensions" %}
+        pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
+      {% endif %}
       pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
     {% endif %}
+    {% endfor %}
   {% endfor %}
 {% endfor %}
 
-{% for editor in trunk_editor %}
-  {% for platform in test_platforms %}
-test_{{ platform.name }}_trunk:
-  name : com.unity.ml-agents test {{ editor.version }} on {{ platform.name }}
+{% for package in packages %}
+  {% for editor in trunk_editor %}
+    {% for platform in test_platforms %}
+test_{{ package.name }}_{{ platform.name }}_trunk:
+  name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
@@ -94,8 +107,11 @@ test_{{ platform.name }}_trunk:
     - python -m pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
     - unity-downloader-cli -u trunk -c editor --wait --fast
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci package test -u {{ editor.version }} --package-path com.unity.ml-agents {{ editor.coverageOptions }}
+    - upm-ci project test -u {{ editor.version }} --project-path Project --type package-tests --package-filter {{ package.name }} {{ editor.coverageOptions }}
+    {% if package.name == "com.unity.ml-agents" %}
+    # TODO get coverage tests running for extensions too
     - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+    {% endif %}
   artifacts:
     logs:
       paths:
@@ -106,3 +122,4 @@ test_{{ platform.name }}_trunk:
     cancel_old_ci: true
     {% endfor %}
   {% endfor %}
+{% endfor %}


### PR DESCRIPTION
* Reverts Unity-Technologies/ml-agents#4231
* Applies the fix for https://github.com/Unity-Technologies/ml-agents/pull/4232 (TODO)
