### PR TITLE
Run coverage checks with python3

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -110,7 +110,7 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
     - upm-ci project test -u {{ editor.version }} --project-path Project --package-filter {{ package.name }} {{ editor.coverageOptions }}
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
-    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+    - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
     {% endif %}
   artifacts:
     logs:

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -69,7 +69,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
 
     {% if package.name == "com.unity.ml-agents" %}
     # TODO get coverage tests running for extensions too
-    - python ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
+    - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ editor.minCoveragePct }}
     {% endif %}
   artifacts:
     logs:

--- a/ml-agents/tests/yamato/check_coverage_percent.py
+++ b/ml-agents/tests/yamato/check_coverage_percent.py
@@ -3,8 +3,6 @@ import os
 
 SUMMARY_XML_FILENAME = "Summary.xml"
 
-# Note that this is python2 compatible, since that's currently what's installed on most CI images.
-
 
 def check_coverage(root_dir, min_percentage):
     # Walk the root directory looking for the summary file that
@@ -30,16 +28,12 @@ def check_coverage(root_dir, min_percentage):
                 pct = float(pct)
                 if pct < min_percentage:
                     print(
-                        "Coverage {} is below the min percentage of {}.".format(
-                            pct, min_percentage
-                        )
+                        f"Coverage {pct} is below the min percentage of {min_percentage}."
                     )
                     sys.exit(1)
                 else:
                     print(
-                        "Coverage {} is above the min percentage of {}.".format(
-                            pct, min_percentage
-                        )
+                        f"Coverage {pct} is above the min percentage of {min_percentage}."
                     )
                     sys.exit(0)
 


### PR DESCRIPTION
### Proposed change(s)
A previous PR (https://github.com/Unity-Technologies/ml-agents/pull/4244/) changed to use f-strings. This broke some yamato tests, because they're running on python2.

Explicitly calling `python3` should fix this.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://unity.slack.com/archives/C26EP4SUQ/p1595003873316900


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
