### PR TITLE
Don't try/except for control flow

### DIFF
--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -1,7 +1,8 @@
 # # Unity ML-Agents Toolkit
 # ## ML-Agent Learning (Ghost Trainer)
 
-from typing import Deque, Dict, List, cast
+from collections import defaultdict
+from typing import Deque, Dict, DefaultDict, List, cast
 
 import numpy as np
 
@@ -68,9 +69,9 @@ class GhostTrainer(Trainer):
         self._internal_trajectory_queues: Dict[str, AgentManagerQueue[Trajectory]] = {}
         self._internal_policy_queues: Dict[str, AgentManagerQueue[Policy]] = {}
 
-        self._team_to_name_to_policy_queue: Dict[
+        self._team_to_name_to_policy_queue: DefaultDict[
             int, Dict[str, AgentManagerQueue[Policy]]
-        ] = {}
+        ] = defaultdict(dict)
 
         self._name_to_parsed_behavior_id: Dict[str, BehaviorIdentifiers] = {}
 
@@ -413,14 +414,9 @@ class GhostTrainer(Trainer):
         """
         super().publish_policy_queue(policy_queue)
         parsed_behavior_id = self._name_to_parsed_behavior_id[policy_queue.behavior_id]
-        try:
-            self._team_to_name_to_policy_queue[parsed_behavior_id.team_id][
-                parsed_behavior_id.brain_name
-            ] = policy_queue
-        except KeyError:
-            self._team_to_name_to_policy_queue[parsed_behavior_id.team_id] = {
-                parsed_behavior_id.brain_name: policy_queue
-            }
+        self._team_to_name_to_policy_queue[parsed_behavior_id.team_id][
+            parsed_behavior_id.brain_name
+        ] = policy_queue
         if parsed_behavior_id.team_id == self.wrapped_trainer_team:
             # With a future multiagent trainer, this will be indexed by 'role'
             internal_policy_queue: AgentManagerQueue[Policy] = AgentManagerQueue(

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -124,9 +124,9 @@ class TrainerController:
         parsed_behavior_id = BehaviorIdentifiers.from_name_behavior_id(name_behavior_id)
         brain_name = parsed_behavior_id.brain_name
         trainerthread = None
-        try:
+        if brain_name in self.trainers:
             trainer = self.trainers[brain_name]
-        except KeyError:
+        else:
             trainer = self.trainer_factory.generate(brain_name)
             self.trainers[brain_name] = trainer
             if trainer.threaded:


### PR DESCRIPTION
### Proposed change(s)
Replace the two cases where we're using try/except on key errors. This makes error logging in trainer_controller.py cleaner, and uses an even-more-pythonic defaultdict in the ghost trainer.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
