### PR TITLE
split advance and process_steps

### DIFF
--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -84,7 +84,7 @@ class EnvManager(ABC):
     def close(self):
         pass
 
-    def advance(self):
+    def advance(self):  # TODO types
         # If we had just reset, process the first EnvironmentSteps.
         # Note that we do it here instead of in reset() so that on the very first reset(),
         # we can create the needed AgentManagers before calling advance() and processing the EnvironmentSteps.
@@ -92,7 +92,7 @@ class EnvManager(ABC):
             self._process_step_infos(self.first_step_infos)
             self.first_step_infos = None
         # Get new policies if found. Always get the latest policy.
-        for brain_name in self.training_behaviors:
+        for brain_name in self.agent_managers.keys():
             _policy = None
             try:
                 # We make sure to empty the policy queue before continuing to produce steps.
@@ -104,6 +104,9 @@ class EnvManager(ABC):
                     self.set_policy(brain_name, _policy)
         # Step the environment
         new_step_infos = self._step()
+        return new_step_infos
+
+    def process_steps(self, new_step_infos: List[EnvironmentStep]) -> int:
         # Add to AgentProcessor
         num_step_infos = self._process_step_infos(new_step_infos)
         return num_step_infos

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -59,6 +59,7 @@ class TrainerController:
         self.train_model = train
         self.param_manager = param_manager
         self.ghost_controller = self.trainer_factory.ghost_controller
+        self.last_brain_behavior_ids: Set[str] = set()
 
         self.trainer_threads: List[threading.Thread] = []
         self.kill_trainers = False
@@ -169,15 +170,10 @@ class TrainerController:
     def start_learning(self, env_manager: EnvManager) -> None:
         self._create_output_path(self.output_path)
         tf.reset_default_graph()
-        last_brain_behavior_ids: Set[str] = set()
         try:
             # Initial reset
             self._reset_env(env_manager)
             while self._not_done_training():
-                external_brain_behavior_ids = set(env_manager.training_behaviors.keys())
-                new_behavior_ids = external_brain_behavior_ids - last_brain_behavior_ids
-                self._create_trainers_and_managers(env_manager, new_behavior_ids)
-                last_brain_behavior_ids = external_brain_behavior_ids
                 n_steps = self.advance(env_manager)
                 for _ in range(n_steps):
                     self.reset_env_if_ready(env_manager)
@@ -236,7 +232,18 @@ class TrainerController:
     def advance(self, env: EnvManager) -> int:
         # Get steps
         with hierarchical_timer("env_step"):
-            num_steps = env.advance()
+            steps = env.advance()
+
+            external_brain_behavior_ids: Set[str] = set()
+            for s in steps:
+                external_brain_behavior_ids |= set(s.name_behavior_ids)
+            new_behavior_ids = (
+                external_brain_behavior_ids - self.last_brain_behavior_ids
+            )
+            self._create_trainers_and_managers(env, new_behavior_ids)
+            self.last_brain_behavior_ids = external_brain_behavior_ids
+
+            num_steps = env.process_steps(steps)
 
         # Report current lesson for each environment parameter
         for (


### PR DESCRIPTION
### Proposed change(s)
Alternative approach to https://github.com/Unity-Technologies/ml-agents/pull/4248
Changes the EnvManager interface behavior, but breaks the circular dependency.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
