### PR TITLE
[MLA-1172] Reduce calls to training_behaviors

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 - The minimum supported python version for ml-agents-envs was changed to 3.6.1. (#4244)
 - The interaction between EnvManager and TrainerController was changed; EnvManager.advance() was split into to stages,
 and TrainerController now uses the results from the first stage to handle new behavior names. This change speeds up
-python training by approximately 5-10%. (#4259)
+Python training by approximately 5-10%. (#4259)
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to
 ### Major Changes
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-The minimum supported python version for ml-agents-envs was changed to 3.6.1. (#4244)
+- The minimum supported python version for ml-agents-envs was changed to 3.6.1. (#4244)
+- The interaction between EnvManager and TrainerController was changed; EnvManager.advance() was split into to stages,
+and TrainerController now uses the results from the first stage to handle new behavior names. This change speeds up
+python training by approximately 5-10%. (#4259)
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -84,14 +84,6 @@ class EnvManager(ABC):
     def close(self):
         pass
 
-    def advance(self) -> int:
-        """
-        Deprecated. Use get_steps() followed by process_steps().
-        :return:
-        """
-        new_step_infos = self.get_steps()
-        return self.process_steps(new_step_infos)
-
     def get_steps(self) -> List[EnvironmentStep]:
         """
         Updates the policies, steps the environments, and returns the step information from the environments.

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -85,6 +85,11 @@ class EnvManager(ABC):
         pass
 
     def advance(self):
+        raise RuntimeError("oops")
+        new_step_infos = self.get_steps()
+        return self.process_steps(new_step_infos)
+
+    def get_steps(self):
         # If we had just reset, process the first EnvironmentSteps.
         # Note that we do it here instead of in reset() so that on the very first reset(),
         # we can create the needed AgentManagers before calling advance() and processing the EnvironmentSteps.
@@ -92,7 +97,7 @@ class EnvManager(ABC):
             self._process_step_infos(self.first_step_infos)
             self.first_step_infos = None
         # Get new policies if found. Always get the latest policy.
-        for brain_name in self.training_behaviors:
+        for brain_name in self.agent_managers.keys():
             _policy = None
             try:
                 # We make sure to empty the policy queue before continuing to produce steps.
@@ -104,6 +109,9 @@ class EnvManager(ABC):
                     self.set_policy(brain_name, _policy)
         # Step the environment
         new_step_infos = self._step()
+        return new_step_infos
+
+    def process_steps(self, new_step_infos):
         # Add to AgentProcessor
         num_step_infos = self._process_step_infos(new_step_infos)
         return num_step_infos

--- a/ml-agents/mlagents/trainers/env_manager.py
+++ b/ml-agents/mlagents/trainers/env_manager.py
@@ -38,7 +38,7 @@ class EnvManager(ABC):
     def __init__(self):
         self.policies: Dict[BehaviorName, TFPolicy] = {}
         self.agent_managers: Dict[BehaviorName, AgentManager] = {}
-        self.first_step_infos: List[EnvironmentStep] = None
+        self.first_step_infos: List[EnvironmentStep] = []
 
     def set_policy(self, brain_name: BehaviorName, policy: TFPolicy) -> None:
         self.policies[brain_name] = policy
@@ -84,18 +84,26 @@ class EnvManager(ABC):
     def close(self):
         pass
 
-    def advance(self):
-        raise RuntimeError("oops")
+    def advance(self) -> int:
+        """
+        Deprecated. Use get_steps() followed by process_steps().
+        :return:
+        """
         new_step_infos = self.get_steps()
         return self.process_steps(new_step_infos)
 
-    def get_steps(self):
+    def get_steps(self) -> List[EnvironmentStep]:
+        """
+        Updates the policies, steps the environments, and returns the step information from the environments.
+        Calling code should pass the returned EnvironmentSteps to process_steps() after calling this.
+        :return: The list of EnvironmentSteps
+        """
         # If we had just reset, process the first EnvironmentSteps.
         # Note that we do it here instead of in reset() so that on the very first reset(),
         # we can create the needed AgentManagers before calling advance() and processing the EnvironmentSteps.
-        if self.first_step_infos is not None:
+        if self.first_step_infos:
             self._process_step_infos(self.first_step_infos)
-            self.first_step_infos = None
+            self.first_step_infos = []
         # Get new policies if found. Always get the latest policy.
         for brain_name in self.agent_managers.keys():
             _policy = None
@@ -106,12 +114,13 @@ class EnvManager(ABC):
                     _policy = self.agent_managers[brain_name].policy_queue.get_nowait()
             except AgentManagerQueue.Empty:
                 if _policy is not None:
-                    self.set_policy(brain_name, _policy)
-        # Step the environment
+                    # policy_queue contains Policy, but we need a TFPolicy here
+                    self.set_policy(brain_name, _policy)  # type: ignore
+        # Step the environments
         new_step_infos = self._step()
         return new_step_infos
 
-    def process_steps(self, new_step_infos):
+    def process_steps(self, new_step_infos: List[EnvironmentStep]) -> int:
         # Add to AgentProcessor
         num_step_infos = self._process_step_infos(new_step_infos)
         return num_step_infos

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -180,6 +180,9 @@ def worker(
         UnityTimeOutException,
         UnityEnvironmentException,
         UnityCommunicatorStoppedException,
+
+        # NOTE - any other exception will cause a deadlock
+        AssertionError
     ) as ex:
         logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
         step_queue.put(

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -180,9 +180,8 @@ def worker(
         UnityTimeOutException,
         UnityEnvironmentException,
         UnityCommunicatorStoppedException,
-
         # NOTE - any other exception will cause a deadlock
-        AssertionError
+        AssertionError,
     ) as ex:
         logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
         step_queue.put(

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -180,8 +180,6 @@ def worker(
         UnityTimeOutException,
         UnityEnvironmentException,
         UnityCommunicatorStoppedException,
-        # NOTE - any other exception will cause a deadlock
-        AssertionError,
     ) as ex:
         logger.info(f"UnityEnvironment worker {worker_id}: environment stopping.")
         step_queue.put(

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -166,7 +166,7 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         }
         step_info = EnvironmentStep(step_info_dict, 0, action_info_dict, env_stats)
         step_mock.return_value = [step_info]
-        env_manager.advance()
+        env_manager.process_steps(env_manager.get_steps())
 
         # Test add_experiences
         env_manager._step.assert_called_once()

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -183,7 +183,6 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         assert agent_manager_mock.policy == mock_policy
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize("num_envs", [1, 4])
 def test_subprocess_env_endtoend(num_envs):
     def simple_env_factory(worker_id, config):

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -183,6 +183,7 @@ class SubprocessEnvManagerTest(unittest.TestCase):
         assert agent_manager_mock.policy == mock_policy
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize("num_envs", [1, 4])
 def test_subprocess_env_endtoend(num_envs):
     def simple_env_factory(worker_id, config):

--- a/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
+++ b/ml-agents/mlagents/trainers/tests/test_trainer_controller.py
@@ -141,6 +141,7 @@ def test_advance_adds_experiences_to_trainer_and_trains(
     tc.advance(env_mock)
 
     env_mock.reset.assert_not_called()
-    env_mock.advance.assert_called_once()
+    env_mock.get_steps.assert_called_once()
+    env_mock.process_steps.assert_called_once()
     # May have been called many times due to thread
     trainer_mock.advance.call_count > 0

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -238,7 +238,9 @@ class TrainerController:
             external_brain_behavior_ids: Set[str] = set()
             for s in new_step_infos:
                 external_brain_behavior_ids |= set(s.name_behavior_ids)
-            new_behavior_ids = external_brain_behavior_ids - self.last_brain_behavior_ids
+            new_behavior_ids = (
+                external_brain_behavior_ids - self.last_brain_behavior_ids
+            )
             self._create_trainers_and_managers(env, new_behavior_ids)
 
             self.last_brain_behavior_ids |= external_brain_behavior_ids

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -11,7 +11,7 @@ import numpy as np
 from mlagents.tf_utils import tf
 
 from mlagents_envs.logging_util import get_logger
-from mlagents.trainers.env_manager import EnvManager
+from mlagents.trainers.env_manager import EnvManager, EnvironmentStep
 from mlagents_envs.exception import (
     UnityEnvironmentException,
     UnityCommunicationException,
@@ -59,7 +59,7 @@ class TrainerController:
         self.train_model = train
         self.param_manager = param_manager
         self.ghost_controller = self.trainer_factory.ghost_controller
-        self.last_brain_behavior_ids: Set[str] = set()  # TODO RENAME
+        self.registered_behavior_ids: Set[str] = set()
 
         self.trainer_threads: List[threading.Thread] = []
         self.kill_trainers = False
@@ -102,7 +102,7 @@ class TrainerController:
             )
 
     @timed
-    def _reset_env(self, env: EnvManager) -> None:
+    def _reset_env(self, env_manager: EnvManager) -> None:
         """Resets the environment.
 
         Returns:
@@ -110,7 +110,9 @@ class TrainerController:
             environment.
         """
         new_config = self.param_manager.get_current_samplers()
-        env.reset(config=new_config)
+        env_manager.reset(config=new_config)
+        # Register any new behavior ids that were generated on the reset.
+        self._register_new_behaviors(env_manager, env_manager.first_step_infos)
 
     def _not_done_training(self) -> bool:
         return (
@@ -229,23 +231,12 @@ class TrainerController:
             env.set_env_parameters(self.param_manager.get_current_samplers())
 
     @timed
-    def advance(self, env: EnvManager) -> int:
+    def advance(self, env_manager: EnvManager) -> int:
         # Get steps
         with hierarchical_timer("env_step"):
-            new_step_infos = env.get_steps()
-
-            # TODO helper method?
-            external_brain_behavior_ids: Set[str] = set()
-            for s in new_step_infos:
-                external_brain_behavior_ids |= set(s.name_behavior_ids)
-            new_behavior_ids = (
-                external_brain_behavior_ids - self.last_brain_behavior_ids
-            )
-            self._create_trainers_and_managers(env, new_behavior_ids)
-
-            self.last_brain_behavior_ids |= external_brain_behavior_ids
-
-            num_steps = env.process_steps(new_step_infos)
+            new_step_infos = env_manager.get_steps()
+            self._register_new_behaviors(env_manager, new_step_infos)
+            num_steps = env_manager.process_steps(new_step_infos)
 
         # Report current lesson for each environment parameter
         for (
@@ -263,6 +254,22 @@ class TrainerController:
                     trainer.advance()
 
         return num_steps
+
+    def _register_new_behaviors(
+        self, env_manager: EnvManager, step_infos: List[EnvironmentStep]
+    ) -> None:
+        """
+        Handle registration (adding trainers and managers) of new behaviors ids.
+        :param env_manager:
+        :param step_infos:
+        :return:
+        """
+        step_behavior_ids: Set[str] = set()
+        for s in step_infos:
+            step_behavior_ids |= set(s.name_behavior_ids)
+        new_behavior_ids = step_behavior_ids - self.registered_behavior_ids
+        self._create_trainers_and_managers(env_manager, new_behavior_ids)
+        self.registered_behavior_ids |= step_behavior_ids
 
     def join_threads(self, timeout_seconds: float = 1.0) -> None:
         """


### PR DESCRIPTION
### Proposed change(s)
Reduce the number of calls to the slow EnvMananger.training_behaviors(). In profiling, this took about 25% of the main thread time.

Before and after profiling coming soon.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1172


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
