### PR TITLE
speedup accessing actions one agent at a time

### DIFF
--- a/ml-agents/mlagents/trainers/agent_processor.py
+++ b/ml-agents/mlagents/trainers/agent_processor.py
@@ -137,7 +137,7 @@ class AgentProcessor:
                 action_pre = None
             action_probs = stored_take_action_outputs["log_probs"][idx]
             action_mask = stored_decision_step.action_mask
-            prev_action = self.policy.retrieve_previous_action([global_id])[0, :]
+            prev_action = self.policy.retrieve_previous_action_single(global_id)
             experience = AgentExperience(
                 obs=obs,
                 reward=step.reward,

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -353,6 +353,16 @@ class TFPolicy(Policy):
                 action_matrix[index, :] = self.previous_action_dict[agent_id]
         return action_matrix
 
+    def retrieve_previous_action_single(self, agent_id: str) -> np.ndarray:
+        """
+        A more efficient version of retrieve_previous_action() for a single
+        agent at a time.
+        """
+        prev_action = self.previous_action_dict.get(agent_id)
+        if prev_action is not None:
+            return prev_action
+        return np.zeros(self.num_branches, dtype=np.int)
+
     def remove_previous_action(self, agent_ids):
         for agent_id in agent_ids:
             if agent_id in self.previous_action_dict:


### PR DESCRIPTION
### Proposed change(s)
This showed up as a non-trivial portion of time (14s / 204s) when profiling with cprofile. 

Real-life profiling with 3Dball:

```
master
2020-07-22 13:27:45 INFO [stats.py:112] 3DBall: Step: 492000. Time Elapsed: 193.277 s Mean Reward: 100.000. Std of Reward: 0.000. Training.

optimized
2020-07-22 14:56:14 INFO [stats.py:112] 3DBall: Step: 492000. Time Elapsed: 187.601 s Mean Reward: 100.000. Std of Reward: 0.000. Training.
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
