### PR TITLE
Fixing tensorboard command line params

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -211,7 +211,7 @@ directory. In order to observe the training process in more detail, you can use
 TensorBoard. From the command line run:
 
 ```sh
-tensorboard --logdir=results
+tensorboard --logdir results
 ```
 
 Then navigate to `localhost:6006` in your browser to view the TensorBoard

--- a/docs/Training-on-Microsoft-Azure.md
+++ b/docs/Training-on-Microsoft-Azure.md
@@ -101,7 +101,7 @@ Once you have started training, you can
 2. Unless you started the training as a background process, connect to your VM
    from another terminal instance.
 3. Run the following command from your terminal
-   `tensorboard --logdir=summaries --host 0.0.0.0`
+   `tensorboard --logdir results --host 0.0.0.0`
 4. You should now be able to open a browser and navigate to
    `<Your_VM_IP_Address>:6060` to view the TensorBoard report.
 

--- a/docs/Using-Docker.md
+++ b/docs/Using-Docker.md
@@ -150,13 +150,13 @@ You can run Tensorboard to monitor your training instance on
 http://localhost:6006:
 
 ```sh
-docker exec -it <container-name> tensorboard --logdir=/unity-volume/summaries --host=0.0.0.0
+docker exec -it <container-name> tensorboard --logdir /unity-volume/results --host 0.0.0.0
 ```
 
 With our previous 3DBall example, this command would look like this:
 
 ```sh
-docker exec -it 3DBallContainer.first.trial tensorboard --logdir=/unity-volume/summaries --host=0.0.0.0
+docker exec -it 3DBallContainer.first.trial tensorboard --logdir /unity-volume/results --host 0.0.0.0
 ```
 
 For more details on Tensorboard, check out the documentation about

--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -12,7 +12,7 @@ start TensorBoard:
 
 1. Open a terminal or console window:
 1. Navigate to the directory where the ML-Agents Toolkit is installed.
-1. From the command line run: `tensorboard --logdir=results --port=6006`
+1. From the command line run: `tensorboard --logdir results --port 6006`
 1. Open a browser window and navigate to
    [localhost:6006](http://localhost:6006).
 

--- a/docs/localized/zh-CN/docs/Getting-Started-with-Balance-Ball.md
+++ b/docs/localized/zh-CN/docs/Getting-Started-with-Balance-Ball.md
@@ -274,10 +274,10 @@ python3 python/learn.py <env_name> --run-id=<run-identifier> --train
 ### 观测训练进度
 
 开始使用 `learn.py` 按照前面部分所述的方式进行训练后，`ml-agents` 文件夹将
-包含一个 `summaries` 目录。为了更详细地观测训练过程，
+包含一个 `results` 目录。为了更详细地观测训练过程，
 您可以使用 TensorBoard。从命令行中运行：
 
-`tensorboard --logdir=summaries`
+`tensorboard --logdir results`
 
 然后导航至 `localhost:6006`。
 


### PR DESCRIPTION


### Proposed change(s)
"--logdir=results" is broken in newer versions of tensorboard; "logdir results" without the equal sign works. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
See https://github.com/tensorflow/tensorboard/issues/686 
This is also how they do it in updated docs https://www.tensorflow.org/tensorboard/scalars_and_keras

### Types of change(s)

- [x] Bug fix
