### PR TITLE
[bugfix] summary writer no longer crashes if Hyperparameters could not be written 

### DIFF
--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -211,14 +211,14 @@ class TensorboardWriter(StatsWriter):
     ) -> None:
         if property_type == StatsPropertyType.HYPERPARAMETERS:
             assert isinstance(value, dict)
-            text = self._dict_to_tensorboard("Hyperparameters", value)
+            summary = self._dict_to_tensorboard("Hyperparameters", value)
             self._maybe_create_summary_writer(category)
-            if text is not None:
-                self.summary_writers[category].add_summary(text, 0)
+            if summary is not None:
+                self.summary_writers[category].add_summary(summary, 0)
 
     def _dict_to_tensorboard(
         self, name: str, input_dict: Dict[str, Any]
-    ) -> Optional[str]:
+    ) -> Optional[bytes]:
         """
         Convert a dict to a Tensorboard-encoded string.
         :param name: The name of the text.
@@ -235,7 +235,9 @@ class TensorboardWriter(StatsWriter):
                 s = sess.run(s_op)
                 return s
         except Exception:
-            logger.warning(f"Could not write {name} summary for Tensorboard.")
+            logger.warning(
+                f"Could not write {name} summary for Tensorboard: {input_dict}"
+            )
             return None
 
 

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import List, Dict, NamedTuple, Any
+from typing import List, Dict, NamedTuple, Any, Optional
 import numpy as np
 import abc
 import csv
@@ -213,9 +213,12 @@ class TensorboardWriter(StatsWriter):
             assert isinstance(value, dict)
             text = self._dict_to_tensorboard("Hyperparameters", value)
             self._maybe_create_summary_writer(category)
-            self.summary_writers[category].add_summary(text, 0)
+            if text is not None:
+                self.summary_writers[category].add_summary(text, 0)
 
-    def _dict_to_tensorboard(self, name: str, input_dict: Dict[str, Any]) -> str:
+    def _dict_to_tensorboard(
+        self, name: str, input_dict: Dict[str, Any]
+    ) -> Optional[str]:
         """
         Convert a dict to a Tensorboard-encoded string.
         :param name: The name of the text.
@@ -232,8 +235,8 @@ class TensorboardWriter(StatsWriter):
                 s = sess.run(s_op)
                 return s
         except Exception:
-            logger.warning("Could not write text summary for Tensorboard.")
-            return ""
+            logger.warning(f"Could not write {name} summary for Tensorboard.")
+            return None
 
 
 class CSVWriter(StatsWriter):


### PR DESCRIPTION
### Proposed change(s)

Bug fix, returning an empty string in case of error breaks the summary writer

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

#4250 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
