### PR TITLE
add numpy version to timer metadata, log random seed

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -274,9 +274,11 @@ def run_cli(options: RunOptions) -> None:
     add_timer_metadata("mlagents_envs_version", mlagents_envs.__version__)
     add_timer_metadata("communication_protocol_version", UnityEnvironment.API_VERSION)
     add_timer_metadata("tensorflow_version", tf_utils.tf.__version__)
+    add_timer_metadata("numpy_version", np.__version__)
 
     if options.env_settings.seed == -1:
         run_seed = np.random.randint(0, 10000)
+        logger.info(f"run_seed set to {run_seed}")
     run_training(run_seed, options)
 
 


### PR DESCRIPTION
### Proposed change(s)
* add numpy version to timer metadata
* log random seed if it's not specified, to make reproducing random failures easier
