### PR TITLE
clarify support for external trainers or inference

### DIFF
--- a/docs/Unity-Inference-Engine.md
+++ b/docs/Unity-Inference-Engine.md
@@ -43,7 +43,7 @@ use for Inference.
 be faster than GPU. You should use the GPU only if you use the ResNet visual
 encoder or have a large number of agents with visual observations.
 
-# Unsupported systems
+# Unsupported use cases
 ## Externally trained models
 The ML-Agents Toolkit only supports the models created with our trainers. Model
 loading expects certain conventions for constants and tensor names. While it is

--- a/docs/Unity-Inference-Engine.md
+++ b/docs/Unity-Inference-Engine.md
@@ -7,9 +7,6 @@ your Unity games. This support is possible thanks to the
 [compute shaders](https://docs.unity3d.com/Manual/class-ComputeShader.html) to
 run the neural network within Unity.
 
-**Note**: The ML-Agents Toolkit only supports the models created with our
-trainers.
-
 ## Supported devices
 
 See the Unity Inference Engine documentation for a list of the
@@ -45,3 +42,22 @@ use for Inference.
 **Note:** For most of the models generated with the ML-Agents Toolkit, CPU will
 be faster than GPU. You should use the GPU only if you use the ResNet visual
 encoder or have a large number of agents with visual observations.
+
+# Unsupported systems
+## Externally trained models
+The ML-Agents Toolkit only supports the models created with our trainers. Model
+loading expects certain conventions for constants and tensor names. While it is
+possible to construct a model that follows these conventions, we don't provide
+any additional help for this. More details can be found in
+[TensorNames.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_4_docs/com.unity.ml-agents/Runtime/Inference/TensorNames.cs)
+and
+[BarracudaModelParamLoader.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_4_docs/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs).
+
+If you wish to run inference on an externally trained model, you should use
+Barracuda directly, instead of trying to run it through ML-Agents.
+
+## Model inference outside of Unity
+We do not provide support for inference anywhere outside of Unity. The
+`frozen_graph_def.pb` and `.onnx` files produced by training are open formats
+for TensorFlow and ONNX respectively; if you wish to convert these to another
+format or run inference with them, refer to their documentation.


### PR DESCRIPTION
### Proposed change(s)
Update docs to clarify that we don't provide support for externally trained models, and we don't provide support for running our models outside of Unity.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
