### PR TITLE
[examples] Behavior Name correction

### DIFF
--- a/Project/Assets/ML-Agents/Examples/PushBlock/Prefabs/PushBlockVisualArea.prefab
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Prefabs/PushBlockVisualArea.prefab
@@ -859,17 +859,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_BrainParameters:
-    vectorObservationSize: 0
-    numStackedVectorObservations: 1
-    vectorActionSize: 07000000
-    vectorActionDescriptions: []
-    vectorActionSpaceType: 0
+    VectorObservationSize: 0
+    NumStackedVectorObservations: 1
+    VectorActionSize: 07000000
+    VectorActionDescriptions: []
+    VectorActionSpaceType: 0
   m_Model: {fileID: 0}
   m_InferenceDevice: 0
   m_BehaviorType: 0
-  m_BehaviorName: VisualHallway
-  m_TeamID: 0
-  m_useChildSensors: 1
+  m_BehaviorName: VisualPushBlock
+  TeamId: 0
+  m_UseChildSensors: 1
+  m_ObservableAttributeHandling: 0
 --- !u!114 &114812843792483960
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -882,7 +883,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dea8c4f2604b947e6b7b97750dde87ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxStep: 5000
+  agentParameters:
+    maxStep: 0
+  hasUpgradedFromAgentParameters: 1
+  MaxStep: 5000
   ground: {fileID: 1913379827958244}
   area: {fileID: 1632733799967290}
   areaBounds:
@@ -917,12 +921,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 282f342c2ab144bf38be65d4d0c4e07d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  camera: {fileID: 20961401228419460}
-  sensorName: CameraSensor
-  width: 84
-  height: 84
-  grayscale: 0
-  compression: 1
+  m_Camera: {fileID: 20961401228419460}
+  m_SensorName: CameraSensor
+  m_Width: 84
+  m_Height: 84
+  m_Grayscale: 0
+  m_Compression: 1
 --- !u!114 &9049837659352187721
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -936,8 +940,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   DecisionPeriod: 5
-  RepeatAction: 1
-  offsetStep: 0
+  TakeActionsBetweenDecisions: 1
 --- !u!1 &1626651094211584
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Proposed change(s)

Stumbled across this one when testing file sizes with the parameter `save_replay_buffer` to `true` for the VisualPushBlock environment. Wondered that a folder named 'VisualHallway' was created and in there was no buffer file.

Occurred because it searched for the 'VisualHallway' config which logically couldn't be found in the VisualPushBlock yaml file. So it used default values.

So the important change is the one in line 870. When I opened the prefab it automatically updated some other stuff. I think this is because some scripts were updated in the last months without opening the prefab to update it as well. So when I opened it, it just updated a bunch of variable names that seems to have changed. I am quite sure its save to commit, but you can also just see this as a bug report with a suggested fix and do it yourself, or update my commit.


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
