### PR TITLE
don't save model twice on exit

### DIFF
--- a/ml-agents/mlagents/trainers/policy/policy.py
+++ b/ml-agents/mlagents/trainers/policy/policy.py
@@ -152,7 +152,9 @@ class Policy:
         pass
 
     @abstractmethod
-    def checkpoint(self, checkpoint_path: str, settings: SerializationSettings) -> None:
+    def checkpoint(
+        self, checkpoint_path: str, settings: Optional[SerializationSettings]
+    ) -> None:
         pass
 
     @abstractmethod

--- a/ml-agents/mlagents/trainers/policy/tf_policy.py
+++ b/ml-agents/mlagents/trainers/policy/tf_policy.py
@@ -417,12 +417,15 @@ class TFPolicy(Policy):
         """
         return list(self.update_dict.keys())
 
-    def checkpoint(self, checkpoint_path: str, settings: SerializationSettings) -> None:
+    def checkpoint(
+        self, checkpoint_path: str, settings: Optional[SerializationSettings]
+    ) -> None:
         """
         Checkpoints the policy on disk.
 
         :param checkpoint_path: filepath to write the checkpoint
-        :param settings: SerializationSettings for exporting the model.
+        :param settings: SerializationSettings for exporting the model. If None,
+          the model will not be saved.
         """
         # Save the TF checkpoint and graph definition
         with self.graph.as_default():
@@ -431,8 +434,9 @@ class TFPolicy(Policy):
             tf.train.write_graph(
                 self.graph, self.model_path, "raw_graph_def.pb", as_text=False
             )
-        # also save the policy so we have optimized model files for each checkpoint
-        self.save(checkpoint_path, settings)
+        if settings is not None:
+            # also save the policy so we have optimized model files for each checkpoint
+            self.save(checkpoint_path, settings)
 
     def save(self, output_filepath: str, settings: SerializationSettings) -> None:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -76,12 +76,12 @@ class SACTrainer(RLTrainer):
 
         self.checkpoint_replay_buffer = self.hyperparameters.save_replay_buffer
 
-    def _checkpoint(self) -> NNCheckpoint:
+    def _checkpoint(self, save_model: bool) -> NNCheckpoint:
         """
         Writes a checkpoint model to memory
         Overrides the default to save the replay buffer.
         """
-        ckpt = super()._checkpoint()
+        ckpt = super()._checkpoint(save_model)
         if self.checkpoint_replay_buffer:
             self.save_replay_buffer()
         return ckpt

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -107,9 +107,8 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
             )
         policy = list(self.policies.values())[0]
         model_path = policy.model_path
-        settings = SerializationSettings(model_path, self.brain_name)
         checkpoint_path = os.path.join(model_path, f"{self.brain_name}-{self.step}")
-        policy.checkpoint(checkpoint_path, settings)
+        policy.checkpoint(checkpoint_path, None)
         new_checkpoint = NNCheckpoint(
             int(self.step),
             f"{checkpoint_path}.nn",


### PR DESCRIPTION
### Proposed change(s)
Followup from https://github.com/Unity-Technologies/ml-agents/pull/4127

After that PR, exiting during training would save twice, once when the checkpoint is saved, and once for the "final" model.

This tweaks the logic so that RLTrainer.save_model() doesn't call the model when calling _checkpoint().

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/pull/4127


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
