### PR TITLE
Don't save model twice, copy instead

### DIFF
--- a/ml-agents/mlagents/model_serialization.py
+++ b/ml-agents/mlagents/model_serialization.py
@@ -243,5 +243,5 @@ def copy_model_files(source_nn_path: str, destination_nn_path: str) -> None:
     try:
         shutil.copyfile(source_onnx_path, destination_onnx_path)
         logger.info(f"Copied {source_onnx_path} to {destination_onnx_path}.")
-    except Exception:
+    except OSError:
         pass

--- a/ml-agents/mlagents/model_serialization.py
+++ b/ml-agents/mlagents/model_serialization.py
@@ -1,5 +1,6 @@
 from distutils.util import strtobool
 import os
+import shutil
 from typing import Any, List, Set, NamedTuple
 from distutils.version import LooseVersion
 
@@ -227,3 +228,20 @@ def _enforce_onnx_conversion() -> bool:
         return strtobool(val)
     except Exception:
         return False
+
+
+def copy_model_files(source_nn_path: str, destination_nn_path: str) -> None:
+    """
+    Copy the .nn file at the given source to the destination.
+    Also copies the corresponding .onnx file if it exists.
+    """
+    shutil.copyfile(source_nn_path, destination_nn_path)
+    logger.info(f"Copied {source_nn_path} to {destination_nn_path}.")
+    # Copy the onnx file if it exists
+    source_onnx_path = os.path.splitext(source_nn_path)[0] + ".onnx"
+    destination_onnx_path = os.path.splitext(destination_nn_path)[0] + ".onnx"
+    try:
+        shutil.copyfile(source_onnx_path, destination_onnx_path)
+        logger.info(f"Copied {source_onnx_path} to {destination_onnx_path}.")
+    except Exception:
+        pass

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import abc
 import time
 import attr
-from mlagents.model_serialization import SerializationSettings
+from mlagents.model_serialization import SerializationSettings, copy_model_files
 from mlagents.trainers.policy.checkpoint_manager import (
     NNCheckpoint,
     NNCheckpointManager,
@@ -131,12 +131,14 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
                 "Trainer has multiple policies, but default behavior only saves the first."
             )
         policy = list(self.policies.values())[0]
-        settings = SerializationSettings(policy.model_path, self.brain_name)
         model_checkpoint = self._checkpoint()
+
+        # Copy the checkpointed model files to the final output location
+        copy_model_files(model_checkpoint.file_path, f"{policy.model_path}.nn")
+
         final_checkpoint = attr.evolve(
             model_checkpoint, file_path=f"{policy.model_path}.nn"
         )
-        policy.save(policy.model_path, settings)
         NNCheckpointManager.track_final_checkpoint(self.brain_name, final_checkpoint)
 
     @abc.abstractmethod


### PR DESCRIPTION
### Proposed change(s)
Followup from https://github.com/Unity-Technologies/ml-agents/pull/4127, retrying from https://github.com/Unity-Technologies/ml-agents/pull/4298

After that PR, exiting during training would save twice, once when the checkpoint is saved, and once for the "final" model.

The bypasses the "final" save and just copies the checkpointed .nn file (and possibly .onnx too, if it exists).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/pull/4127


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
