### PR TITLE
[bug-fix] Fix crash with non-LSTM SeparateActorCritic

### DIFF
--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -188,7 +188,9 @@ def test_actor_critic(ac_type, lstm):
         )
     else:
         sample_obs = torch.ones((1, obs_size))
-        memories = None
+        memories = torch.tensor([])
+        # memories isn't always set to None, the network should be able to
+        # deal with that.
     # Test critic pass
     value_out = actor.critic_pass([sample_obs], [], memories=memories)
     for stream in stream_names:

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -428,7 +428,7 @@ class SeparateActorCritic(SimpleActor, ActorCritic):
         vis_inputs: List[torch.Tensor],
         memories: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
-        if memories is not None:
+        if self.use_lstm:
             # Use only the back half of memories for critic
             _, critic_mem = torch.split(memories, self.half_mem_size, -1)
         else:
@@ -446,7 +446,7 @@ class SeparateActorCritic(SimpleActor, ActorCritic):
         memories: Optional[torch.Tensor] = None,
         sequence_length: int = 1,
     ) -> Tuple[List[DistInstance], Dict[str, torch.Tensor], torch.Tensor]:
-        if memories is not None:
+        if self.use_lstm:
             # Use only the back half of memories for critic and actor
             actor_mem, critic_mem = torch.split(memories, self.half_mem_size, dim=-1)
         else:


### PR DESCRIPTION
### Proposed change(s)

Looks like `memories` isn't always `None` when not using LSTM. This PR uses the configuration rather than the parameter to determine whether to use `memories`

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
