### PR TITLE
Fixed the reporting of the discriminator loss

### DIFF
--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -185,7 +185,7 @@ class DiscriminatorNetwork(torch.nn.Module):
             torch.log(expert_estimate + self.EPSILON)
             + torch.log(1.0 - policy_estimate + self.EPSILON)
         ).mean()
-        stats_dict["Losses/GAIL Discriminator Loss"] = (
+        stats_dict["Losses/GAIL Loss"] = (
             discriminator_loss.detach().cpu().numpy()
         )
         total_loss += discriminator_loss

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -185,9 +185,7 @@ class DiscriminatorNetwork(torch.nn.Module):
             torch.log(expert_estimate + self.EPSILON)
             + torch.log(1.0 - policy_estimate + self.EPSILON)
         ).mean()
-        stats_dict["Losses/GAIL Loss"] = (
-            discriminator_loss.detach().cpu().numpy()
-        )
+        stats_dict["Losses/GAIL Loss"] = discriminator_loss.detach().cpu().numpy()
         total_loss += discriminator_loss
         if self._settings.use_vail:
             # KL divergence loss (encourage latent representation to be normal)


### PR DESCRIPTION
### Proposed change(s)

Modify what is reported under GAIL Discriminator Loss.

The inconsistencies between TF and torch are due to our reporting
The loss will still be different between torch and tf since tf reports the discriminator loss + gradient magnitude loss.
The gradient magnitude loss is not identical between torch and tf but there seems to be little difference in training

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
