### PR TITLE
[add-fire] Fix ONNX import for continuous

### DIFF
--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -26,7 +26,7 @@ class ModelSerializer:
         self.input_names = [
             "vector_observation",
             "visual_observation",
-            "action_mask",
+            "action_masks",
             "memories",
         ]
         self.output_names = [
@@ -40,7 +40,7 @@ class ModelSerializer:
         self.dynamic_axes = {
             "vector_observation": [0],
             "visual_observation": [0],
-            "action_mask": [0],
+            "action_masks": [0],
             "memories": [0],
             "action": [0],
             "action_probs": [0],

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -71,34 +71,29 @@ class NetworkBody(nn.Module):
         memories: Optional[torch.Tensor] = None,
         sequence_length: int = 1,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        vec_encodes = []
+        encodes = []
         for idx, encoder in enumerate(self.vector_encoders):
             vec_input = vec_inputs[idx]
             if actions is not None:
                 hidden = encoder(vec_input, actions)
             else:
                 hidden = encoder(vec_input)
-            vec_encodes.append(hidden)
+            encodes.append(hidden)
 
-        vis_encodes = []
         for idx, encoder in enumerate(self.visual_encoders):
             vis_input = vis_inputs[idx]
             vis_input = vis_input.permute([0, 3, 1, 2])
             hidden = encoder(vis_input)
-            vis_encodes.append(hidden)
+            encodes.append(hidden)
 
-        if len(vec_encodes) > 0 and len(vis_encodes) > 0:
-            vec_encodes_tensor = torch.stack(vec_encodes, dim=-1).sum(dim=-1)
-            vis_encodes_tensor = torch.stack(vis_encodes, dim=-1).sum(dim=-1)
-            encoding = torch.stack(
-                [vec_encodes_tensor, vis_encodes_tensor], dim=-1
-            ).sum(dim=-1)
-        elif len(vec_encodes) > 0:
-            encoding = torch.stack(vec_encodes, dim=-1).sum(dim=-1)
-        elif len(vis_encodes) > 0:
-            encoding = torch.stack(vis_encodes, dim=-1).sum(dim=-1)
-        else:
+        if len(encodes) == 0:
             raise Exception("No valid inputs to network.")
+
+        # Constants don't work in Barracuda
+        encoding = encodes[0]
+        if len(encodes) > 1:
+            for _enc in encodes[1:]:
+                encoding += _enc
 
         if self.use_lstm:
             encoding = encoding.view([sequence_length, -1, self.h_size])
@@ -323,9 +318,13 @@ class SimpleActor(nn.Module, Actor):
         )
         action_list = self.sample_action(dists)
         sampled_actions = torch.stack(action_list, dim=-1)
+        if self.act_type == ActionType.CONTINUOUS:
+            log_probs = dists[0].log_prob(sampled_actions)
+        else:
+            log_probs = dists[0].all_log_prob()
         return (
             sampled_actions,
-            dists[0].pdf(sampled_actions),
+            log_probs,
             self.version_number,
             self.memory_size,
             self.is_continuous_int,

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -152,7 +152,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
     def create_saver(
         framework: str, trainer_settings: TrainerSettings, model_path: str, load: bool
     ) -> BaseSaver:
-        if framework == "torch":
+        if framework == FrameworkType.PYTORCH:
             saver = TorchSaver(  # type: ignore
                 trainer_settings, model_path, load
             )


### PR DESCRIPTION
### Proposed change(s)

Fix ONNX export and Barrcuda import compatibility. Remove the stack followed by sum, and change the log prob export. NOTE: Discrete still doesn't work properly. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
