### PR TITLE
DemonstrationRecorder: Add numStepsToRecord feature.

### DIFF
--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -35,7 +35,8 @@ namespace Unity.MLAgents.Demonstrations
         /// <summary>
         /// Number of steps to record. Editor will stop playing when it hits this threshold.
         /// </summary>
-        public int numStepsToRecord = 5000;
+        [Tooltip("Number of steps to record. Editor will stop playing when it hits this threshold.")]
+        public int NumStepsToRecord = 5000;
 
         /// <summary>
         /// Base demonstration file name. If multiple files are saved, the additional filenames
@@ -76,9 +77,12 @@ namespace Unity.MLAgents.Demonstrations
                 LazyInitialize();
             }
 
-            if (m_DemoWriter.NumSteps >= numStepsToRecord)
+            if (m_DemoWriter.NumSteps > 0 && m_DemoWriter.NumSteps  >= NumStepsToRecord)
             {
+                Application.Quit(0);
+#if UNITY_EDITOR
                 UnityEditor.EditorApplication.isPlaying = false;
+#endif
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -33,6 +33,11 @@ namespace Unity.MLAgents.Demonstrations
         public bool Record;
 
         /// <summary>
+        /// Number of steps to record. Editor will stop playing when it hits this threshold.
+        /// </summary>
+        public int numStepsToRecord = 5000;
+
+        /// <summary>
         /// Base demonstration file name. If multiple files are saved, the additional filenames
         /// will have a sequence of unique numbers appended.
         /// </summary>
@@ -69,6 +74,11 @@ namespace Unity.MLAgents.Demonstrations
             if (Record)
             {
                 LazyInitialize();
+            }
+
+            if (m_DemoWriter.NumSteps >= numStepsToRecord)
+            {
+                UnityEditor.EditorApplication.isPlaying = false;
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -33,10 +33,12 @@ namespace Unity.MLAgents.Demonstrations
         public bool Record;
 
         /// <summary>
-        /// Number of steps to record. Editor will stop playing when it hits this threshold.
+        /// Number of steps to record. If this number is higher than zero, the editor will stop
+        /// playing when it reaches this threshold.
         /// </summary>
-        [Tooltip("Number of steps to record. Editor will stop playing when it hits this threshold.")]
-        public int NumStepsToRecord = 5000;
+        [Tooltip("Number of steps to record. If this number is higher than zero, the editor will stop " +
+                 "playing when it reaches this threshold.")]
+        public int NumStepsToRecord = 0;
 
         /// <summary>
         /// Base demonstration file name. If multiple files are saved, the additional filenames
@@ -77,7 +79,7 @@ namespace Unity.MLAgents.Demonstrations
                 LazyInitialize();
             }
 
-            if (m_DemoWriter.NumSteps > 0 && m_DemoWriter.NumSteps  >= NumStepsToRecord)
+            if (NumStepsToRecord > 0 && m_DemoWriter.NumSteps >= NumStepsToRecord)
             {
                 Application.Quit(0);
 #if UNITY_EDITOR

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -33,11 +33,11 @@ namespace Unity.MLAgents.Demonstrations
         public bool Record;
 
         /// <summary>
-        /// Number of steps to record. If this number is higher than zero, the editor will stop
-        /// playing when it reaches this threshold.
+        /// Number of steps to record. The editor will stop playing when it reaches this threshold.
+        /// Set to zero to record indefinitely.
         /// </summary>
-        [Tooltip("Number of steps to record. If this number is higher than zero, the editor will stop " +
-                 "playing when it reaches this threshold.")]
+        [Tooltip("Number of steps to record. The editor will stop playing when it reaches this threshold. " +
+                 "Set to zero to record indefinitely.")]
         public int NumStepsToRecord = 0;
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationWriter.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationWriter.cs
@@ -33,6 +33,14 @@ namespace Unity.MLAgents.Demonstrations
         }
 
         /// <summary>
+        /// Number of steps written so far.
+        /// </summary>
+        internal int NumSteps
+        {
+            get { return m_MetaData.numberSteps; }
+        }
+
+        /// <summary>
         /// Writes the initial data to the stream.
         /// </summary>
         /// <param name="demonstrationName">Base name of the demonstration file(s).</param>


### PR DESCRIPTION
### Proposed change(s)

Updates the DemonstrationRecorder so that you can specify the number of steps to record. When this number is reached, the editor will stop and save the demo file.


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
