### PR TITLE
add build-in module dependencies

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,26 +14,13 @@ and this project adheres to
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-
-### Bug Fixes
-#### com.unity.ml-agents (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-
-## [1.3.0-preview] - 2020-08-12
-
-### Major Changes
-#### com.unity.ml-agents (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-
-### Minor Changes
-#### com.unity.ml-agents (C#)
 - Update Barracuda to 1.0.2.
 - Enabled C# formatting using `dotnet-format`.
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
+- The package dependencies were updated to include the built-in packages that are used also. (#4384)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ## [1.3.0-preview] - 2020-08-12

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,6 +5,10 @@
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.barracuda": "1.0.2"
+    "com.unity.barracuda": "1.0.2",
+    "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0"
   }
 }


### PR DESCRIPTION
### Proposed change(s)
Add dependencies on built-in modules.
* physics packages for raycasting
* imageconversion for PNG compression on visual observations
* jsonserialize for timers

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1273
https://unity.slack.com/archives/C26EP4SUQ/p1597860403107900
https://docs.unity3d.com/2020.2/Documentation/Manual/pack-build.html

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
