### PR TITLE
add fire clean up docstrings in create policies

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -216,9 +216,10 @@ class PPOTrainer(RLTrainer):
         create_graph: bool = False,
     ) -> TFPolicy:
         """
-        Creates a PPO policy to trainers list of policies.
+        Creates a policy with a Tensorflow backend and PPO hyperparameters
+        :param parsed_behavior_id:
         :param behavior_spec: specifications for policy construction
-        :param create_graph: whether to create the graph when policy is constructed
+        :param create_graph: whether to create the tensorflow graph on construction
         :return policy
         """
         policy = TFPolicy(
@@ -234,9 +235,9 @@ class PPOTrainer(RLTrainer):
         self, parsed_behavior_id: BehaviorIdentifiers, behavior_spec: BehaviorSpec
     ) -> TorchPolicy:
         """
-        Creates a PPO policy to trainers list of policies.
+        Creates a policy with a PyTorch backend and PPO hyperparameters
         :param parsed_behavior_id:
-        :param brain_parameters: specifications for policy construction
+        :param behavior_spec: specifications for policy construction
         :return policy
         """
         policy = TorchPolicy(

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -219,7 +219,7 @@ class PPOTrainer(RLTrainer):
         Creates a policy with a Tensorflow backend and PPO hyperparameters
         :param parsed_behavior_id:
         :param behavior_spec: specifications for policy construction
-        :param create_graph: whether to create the tensorflow graph on construction
+        :param create_graph: whether to create the Tensorflow graph on construction
         :return policy
         """
         policy = TFPolicy(

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -233,6 +233,13 @@ class SACTrainer(RLTrainer):
         behavior_spec: BehaviorSpec,
         create_graph: bool = False,
     ) -> TFPolicy:
+        """
+        Creates a policy with a Tensorflow backend and SAC hyperparameters
+        :param parsed_behavior_id:
+        :param behavior_spec: specifications for policy construction
+        :param create_graph: whether to create the tensorflow graph on construction
+        :return policy
+        """
         policy = TFPolicy(
             self.seed,
             behavior_spec,
@@ -248,7 +255,7 @@ class SACTrainer(RLTrainer):
         self, parsed_behavior_id: BehaviorIdentifiers, behavior_spec: BehaviorSpec
     ) -> TorchPolicy:
         """
-        Creates a PPO policy to trainers list of policies.
+        Creates a policy with a PyTorch backend and SAC hyperparameters
         :param parsed_behavior_id:
         :param behavior_spec: specifications for policy construction
         :return policy

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -237,7 +237,7 @@ class SACTrainer(RLTrainer):
         Creates a policy with a Tensorflow backend and SAC hyperparameters
         :param parsed_behavior_id:
         :param behavior_spec: specifications for policy construction
-        :param create_graph: whether to create the tensorflow graph on construction
+        :param create_graph: whether to create the Tensorflow graph on construction
         :return policy
         """
         policy = TFPolicy(


### PR DESCRIPTION
### Proposed change(s)

Cleans up docstrings for policy creator functions.  We could also merge these things in rl_trainer.py but would need to expand the argument list (not sure if we want to do this).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
