### PR TITLE
Rename saver to model_saver

### DIFF
--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -319,7 +319,7 @@ class GhostTrainer(Trainer):
         policy = self.trainer.create_policy(
             parsed_behavior_id, behavior_spec, create_graph=True
         )
-        self.trainer.saver.initialize_or_load(policy)
+        self.trainer.model_saver.initialize_or_load(policy)
         team_id = parsed_behavior_id.team_id
         self.controller.subscribe_team_id(team_id, self)
 

--- a/ml-agents/mlagents/trainers/model_saver/model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/model_saver.py
@@ -3,8 +3,8 @@ import abc
 from typing import Any
 
 
-class BaseSaver(abc.ABC):
-    """This class is the base class for the Saver"""
+class BaseModelSaver(abc.ABC):
+    """This class is the base class for the ModelSaver"""
 
     def __init__(self):
         pass
@@ -12,8 +12,8 @@ class BaseSaver(abc.ABC):
     @abc.abstractmethod
     def register(self, module: Any) -> None:
         """
-        Register the modules to the Saver.
-        The Saver will store the module and include it in the saved files
+        Register the modules to the ModelSaver.
+        The ModelSaver will store the module and include it in the saved files
         when saving checkpoint/exporting graph.
         :param module: the module to be registered
         """
@@ -21,14 +21,14 @@ class BaseSaver(abc.ABC):
 
     def _register_policy(self, policy):
         """
-        Helper function for registering policy to the Saver.
+        Helper function for registering policy to the ModelSaver.
         :param policy: the policy to be registered
         """
         pass
 
     def _register_optimizer(self, optimizer):
         """
-        Helper function for registering optimizer to the Saver.
+        Helper function for registering optimizer to the ModelSaver.
         :param optimizer: the optimizer to be registered
         """
         pass

--- a/ml-agents/mlagents/trainers/model_saver/tf_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/tf_model_saver.py
@@ -4,7 +4,7 @@ from typing import Optional, Union, cast
 from mlagents_envs.exception import UnityPolicyException
 from mlagents_envs.logging_util import get_logger
 from mlagents.tf_utils import tf
-from mlagents.trainers.saver.saver import BaseSaver
+from mlagents.trainers.model_saver.model_saver import BaseModelSaver
 from mlagents.trainers.tf.model_serialization import export_policy_model
 from mlagents.trainers.settings import TrainerSettings, SerializationSettings
 from mlagents.trainers.policy.tf_policy import TFPolicy
@@ -15,9 +15,9 @@ from mlagents.trainers import __version__
 logger = get_logger(__name__)
 
 
-class TFSaver(BaseSaver):
+class TFModelSaver(BaseModelSaver):
     """
-    Saver class for TensorFlow
+    ModelSaver class for TensorFlow
     """
 
     def __init__(

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -4,7 +4,7 @@ import torch
 from typing import Dict, Union, Optional, cast
 from mlagents_envs.exception import UnityPolicyException
 from mlagents_envs.logging_util import get_logger
-from mlagents.trainers.saver.saver import BaseSaver
+from mlagents.trainers.model_saver.model_saver import BaseModelSaver
 from mlagents.trainers.settings import TrainerSettings, SerializationSettings
 from mlagents.trainers.policy.torch_policy import TorchPolicy
 from mlagents.trainers.optimizer.torch_optimizer import TorchOptimizer
@@ -14,9 +14,9 @@ from mlagents.trainers.torch.model_serialization import ModelSerializer
 logger = get_logger(__name__)
 
 
-class TorchSaver(BaseSaver):
+class TorchModelSaver(BaseModelSaver):
     """
-    Saver class for PyTorch
+    ModelSaver class for PyTorch
     """
 
     def __init__(
@@ -37,7 +37,7 @@ class TorchSaver(BaseSaver):
             self.modules.update(module.get_modules())  # type: ignore
         else:
             raise UnityPolicyException(
-                "Registering Object of unsupported type {} to Saver ".format(
+                "Registering Object of unsupported type {} to ModelSaver ".format(
                     type(module)
                 )
             )

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -281,9 +281,9 @@ class PPOTrainer(RLTrainer):
         for _reward_signal in self.optimizer.reward_signals.keys():
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
 
-        self.saver.register(self.policy)
-        self.saver.register(self.optimizer)
-        self.saver.initialize_or_load()
+        self.model_saver.register(self.policy)
+        self.model_saver.register(self.optimizer)
+        self.model_saver.initialize_or_load()
 
         # Needed to resume loads properly
         self.step = policy.get_current_step()

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -395,9 +395,9 @@ class SACTrainer(RLTrainer):
         for _reward_signal in self.optimizer.reward_signals.keys():
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
 
-        self.saver.register(self.policy)
-        self.saver.register(self.optimizer)
-        self.saver.initialize_or_load()
+        self.model_saver.register(self.policy)
+        self.model_saver.register(self.optimizer)
+        self.model_saver.initialize_or_load()
 
         # Needed to resume loads properly
         self.step = policy.get_current_step()

--- a/ml-agents/mlagents/trainers/tests/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/test_ppo.py
@@ -197,9 +197,9 @@ def test_rl_functions():
     )
 
 
-@mock.patch.object(RLTrainer, "create_saver")
+@mock.patch.object(RLTrainer, "create_model_saver")
 @mock.patch("mlagents.trainers.ppo.trainer.PPOOptimizer")
-def test_trainer_increment_step(ppo_optimizer, mock_create_saver):
+def test_trainer_increment_step(ppo_optimizer, mock_create_model_saver):
     trainer_params = PPO_CONFIG
     mock_optimizer = mock.Mock()
     mock_optimizer.reward_signals = {}
@@ -315,9 +315,9 @@ def test_process_trajectory(dummy_config):
     assert trainer.stats_reporter.get_stats_summaries("Policy/Extrinsic Reward").num > 0
 
 
-@mock.patch.object(RLTrainer, "create_saver")
+@mock.patch.object(RLTrainer, "create_model_saver")
 @mock.patch("mlagents.trainers.ppo.trainer.PPOOptimizer")
-def test_add_get_policy(ppo_optimizer, mock_create_saver, dummy_config):
+def test_add_get_policy(ppo_optimizer, mock_create_model_saver, dummy_config):
     mock_optimizer = mock.Mock()
     mock_optimizer.reward_signals = {}
     ppo_optimizer.return_value = mock_optimizer

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -25,13 +25,13 @@ class FakeTrainer(RLTrainer):
 
     def add_policy(self, mock_behavior_id, mock_policy):
         def checkpoint_path(brain_name, step):
-            return os.path.join(self.saver.model_path, f"{brain_name}-{step}")
+            return os.path.join(self.model_saver.model_path, f"{brain_name}-{step}")
 
         self.policies[mock_behavior_id] = mock_policy
-        mock_saver = mock.Mock()
-        mock_saver.model_path = self.artifact_path
-        mock_saver.save_checkpoint.side_effect = checkpoint_path
-        self.saver = mock_saver
+        mock_model_saver = mock.Mock()
+        mock_model_saver.model_path = self.artifact_path
+        mock_model_saver.save_checkpoint.side_effect = checkpoint_path
+        self.model_saver = mock_model_saver
 
     def create_tf_policy(self, parsed_behavior_id, behavior_spec):
         return mock.Mock()
@@ -158,14 +158,14 @@ def test_summary_checkpoint(mock_add_checkpoint, mock_write_summary):
         checkpoint_interval, num_trajectories * time_horizon, checkpoint_interval
     )
     calls = [mock.call(trainer.brain_name, step) for step in checkpoint_range]
-    trainer.saver.save_checkpoint.assert_has_calls(calls, any_order=True)
+    trainer.model_saver.save_checkpoint.assert_has_calls(calls, any_order=True)
 
     add_checkpoint_calls = [
         mock.call(
             trainer.brain_name,
             NNCheckpoint(
                 step,
-                f"{trainer.saver.model_path}/{trainer.brain_name}-{step}.nn",
+                f"{trainer.model_saver.model_path}/{trainer.brain_name}-{step}.nn",
                 None,
                 mock.ANY,
             ),

--- a/ml-agents/mlagents/trainers/tests/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/test_sac.py
@@ -129,9 +129,9 @@ def test_sac_save_load_buffer(tmpdir, dummy_config):
     assert trainer2.update_buffer.num_experiences == buffer_len
 
 
-@mock.patch.object(RLTrainer, "create_saver")
+@mock.patch.object(RLTrainer, "create_model_saver")
 @mock.patch("mlagents.trainers.sac.trainer.SACOptimizer")
-def test_add_get_policy(sac_optimizer, mock_create_saver, dummy_config):
+def test_add_get_policy(sac_optimizer, mock_create_model_saver, dummy_config):
     mock_optimizer = mock.Mock()
     mock_optimizer.reward_signals = {}
     sac_optimizer.return_value = mock_optimizer
@@ -226,9 +226,8 @@ def test_advance(dummy_config):
     policy = trainer.create_policy(behavior_id, specs)
     policy.get_current_step = lambda: 200
     trainer.add_policy(behavior_id, policy)
-    trainer.saver.initialize_or_load(policy)
     trainer.optimizer.update = mock.Mock()
-    trainer.saver.initialize_or_load(policy)
+    trainer.model_saver.initialize_or_load(policy)
     trainer.optimizer.update_reward_signals = mock.Mock()
     trainer.optimizer.update_reward_signals.return_value = {}
     trainer.optimizer.update.return_value = {}

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -23,13 +23,13 @@ from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.settings import TrainerSettings, FrameworkType
 from mlagents.trainers.stats import StatsPropertyType
-from mlagents.trainers.saver.saver import BaseSaver
-from mlagents.trainers.saver.tf_saver import TFSaver
+from mlagents.trainers.model_saver.model_saver import BaseModelSaver
+from mlagents.trainers.model_saver.tf_model_saver import TFModelSaver
 from mlagents.trainers.exception import UnityTrainerException
 
 try:
     from mlagents.trainers.policy.torch_policy import TorchPolicy
-    from mlagents.trainers.saver.torch_saver import TorchSaver
+    from mlagents.trainers.model_saver.torch_model_saver import TorchModelSaver
 except ModuleNotFoundError:
     TorchPolicy = None  # type: ignore
 
@@ -61,7 +61,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
 
         self._next_save_step = 0
         self._next_summary_step = 0
-        self.saver = self.create_saver(
+        self.model_saver = self.create_model_saver(
             self.framework, self.trainer_settings, self.artifact_path, self.load
         )
 
@@ -151,18 +151,18 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
         pass
 
     @staticmethod
-    def create_saver(
+    def create_model_saver(
         framework: str, trainer_settings: TrainerSettings, model_path: str, load: bool
-    ) -> BaseSaver:
+    ) -> BaseModelSaver:
         if framework == FrameworkType.PYTORCH:
-            saver = TorchSaver(  # type: ignore
+            model_saver = TorchModelSaver(  # type: ignore
                 trainer_settings, model_path, load
             )
         else:
-            saver = TFSaver(  # type: ignore
+            model_saver = TFModelSaver(  # type: ignore
                 trainer_settings, model_path, load
             )
-        return saver
+        return model_saver
 
     def _policy_mean_reward(self) -> Optional[float]:
         """ Returns the mean episode reward for the current policy. """
@@ -182,7 +182,7 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
             logger.warning(
                 "Trainer has multiple policies, but default behavior only saves the first."
             )
-        checkpoint_path = self.saver.save_checkpoint(self.brain_name, self.step)
+        checkpoint_path = self.model_saver.save_checkpoint(self.brain_name, self.step)
         new_checkpoint = NNCheckpoint(
             int(self.step),
             f"{checkpoint_path}.nn",
@@ -208,9 +208,9 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
             return
 
         model_checkpoint = self._checkpoint()
-        self.saver.copy_final_model(model_checkpoint.file_path)
+        self.model_saver.copy_final_model(model_checkpoint.file_path)
         final_checkpoint = attr.evolve(
-            model_checkpoint, file_path=f"{self.saver.model_path}.nn"
+            model_checkpoint, file_path=f"{self.model_saver.model_path}.nn"
         )
         NNCheckpointManager.track_final_checkpoint(self.brain_name, final_checkpoint)
 


### PR DESCRIPTION
### Proposed change(s)

Rename saver to model_saver to avoid confusion between the original TFSaver and the Saver class from Tensorflow.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
