### PR TITLE
Fix NNCheckpointManager for Torch

### DIFF
--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -6,7 +6,7 @@ from mlagents.trainers.policy.checkpoint_manager import NNCheckpoint
 from mlagents.trainers.trainer.rl_trainer import RLTrainer
 from mlagents.trainers.tests.test_buffer import construct_fake_buffer
 from mlagents.trainers.agent_processor import AgentManagerQueue
-from mlagents.trainers.settings import TrainerSettings
+from mlagents.trainers.settings import TrainerSettings, FrameworkType
 
 
 # Add concrete implementations of abstract methods
@@ -43,10 +43,12 @@ class FakeTrainer(RLTrainer):
         super()._process_trajectory(trajectory)
 
 
-def create_rl_trainer():
+def create_rl_trainer(framework=FrameworkType.TENSORFLOW):
     trainer = FakeTrainer(
         "test_trainer",
-        TrainerSettings(max_steps=100, checkpoint_interval=10, summary_freq=20),
+        TrainerSettings(
+            max_steps=100, checkpoint_interval=10, summary_freq=20, framework=framework
+        ),
         True,
         False,
         "mock_model_path",
@@ -120,10 +122,13 @@ def test_advance(mocked_clear_update_buffer, mocked_save_model):
     assert mocked_save_model.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "framework", [FrameworkType.TENSORFLOW, FrameworkType.PYTORCH], ids=["tf", "torch"]
+)
 @mock.patch("mlagents.trainers.trainer.trainer.StatsReporter.write_stats")
 @mock.patch("mlagents.trainers.trainer.rl_trainer.NNCheckpointManager.add_checkpoint")
-def test_summary_checkpoint(mock_add_checkpoint, mock_write_summary):
-    trainer = create_rl_trainer()
+def test_summary_checkpoint(mock_add_checkpoint, mock_write_summary, framework):
+    trainer = create_rl_trainer(framework)
     mock_policy = mock.Mock()
     trainer.add_policy("TestBrain", mock_policy)
     trajectory_queue = AgentManagerQueue("testbrain")
@@ -159,13 +164,14 @@ def test_summary_checkpoint(mock_add_checkpoint, mock_write_summary):
     )
     calls = [mock.call(trainer.brain_name, step) for step in checkpoint_range]
     trainer.saver.save_checkpoint.assert_has_calls(calls, any_order=True)
+    export_ext = "nn" if trainer.framework == FrameworkType.TENSORFLOW else "onnx"
 
     add_checkpoint_calls = [
         mock.call(
             trainer.brain_name,
             NNCheckpoint(
                 step,
-                f"{trainer.saver.model_path}/{trainer.brain_name}-{step}.nn",
+                f"{trainer.saver.model_path}/{trainer.brain_name}-{step}.{export_ext}",
                 None,
                 mock.ANY,
             ),

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -183,9 +183,10 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
                 "Trainer has multiple policies, but default behavior only saves the first."
             )
         checkpoint_path = self.saver.save_checkpoint(self.brain_name, self.step)
+        export_ext = "nn" if self.framework == FrameworkType.TENSORFLOW else "onnx"
         new_checkpoint = NNCheckpoint(
             int(self.step),
-            f"{checkpoint_path}.nn",
+            f"{checkpoint_path}.{export_ext}",
             self._policy_mean_reward(),
             time.time(),
         )
@@ -209,8 +210,9 @@ class RLTrainer(Trainer):  # pylint: disable=abstract-method
 
         model_checkpoint = self._checkpoint()
         self.saver.copy_final_model(model_checkpoint.file_path)
+        export_ext = "nn" if self.framework == FrameworkType.TENSORFLOW else "onnx"
         final_checkpoint = attr.evolve(
-            model_checkpoint, file_path=f"{self.saver.model_path}.nn"
+            model_checkpoint, file_path=f"{self.saver.model_path}.{export_ext}"
         )
         NNCheckpointManager.track_final_checkpoint(self.brain_name, final_checkpoint)
 


### PR DESCRIPTION
### Proposed change(s)

Currently NNCheckpointManager only tracks .nn files while in PyTorch the exported file is .onnx.
Fix it to track .onnx files when using PyTorch.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
