### PR TITLE
[torch] Restructure PyTorch encoders 

### DIFF
--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -56,7 +56,7 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
         if self.policy.use_vis_obs:
             visual_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_inputs
+                self.policy.actor_critic.network_body.visual_processors
             ):
                 visual_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 visual_obs.append(visual_ob)

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -56,7 +56,7 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
         if self.policy.use_vis_obs:
             visual_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_encoders
+                self.policy.actor_critic.network_body.visual_inputs
             ):
                 visual_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 visual_obs.append(visual_ob)

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -150,7 +150,7 @@ class TorchPPOOptimizer(TorchOptimizer):
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_encoders
+                self.policy.actor_critic.network_body.visual_inputs
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 vis_obs.append(vis_ob)

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -150,7 +150,7 @@ class TorchPPOOptimizer(TorchOptimizer):
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_inputs
+                self.policy.actor_critic.network_body.visual_processors
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 vis_obs.append(vis_ob)

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -422,7 +422,7 @@ class TorchSACOptimizer(TorchOptimizer):
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_inputs
+                self.policy.actor_critic.network_body.visual_processors
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 vis_obs.append(vis_ob)

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -422,7 +422,7 @@ class TorchSACOptimizer(TorchOptimizer):
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_encoders
+                self.policy.actor_critic.network_body.visual_inputs
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 vis_obs.append(vis_ob)

--- a/ml-agents/mlagents/trainers/tests/torch/test_encoders.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_encoders.py
@@ -3,8 +3,7 @@ from unittest import mock
 import pytest
 
 from mlagents.trainers.torch.encoders import (
-    VectorEncoder,
-    VectorAndUnnormalizedInputEncoder,
+    VectorInput,
     Normalizer,
     SimpleVisualEncoder,
     ResNetVisualEncoder,
@@ -54,47 +53,22 @@ def test_vector_encoder(mock_normalizer):
     mock_normalizer_inst = mock.Mock()
     mock_normalizer.return_value = mock_normalizer_inst
     input_size = 64
-    hidden_size = 128
-    num_layers = 3
     normalize = False
-    vector_encoder = VectorEncoder(input_size, hidden_size, num_layers, normalize)
+    vector_encoder = VectorInput(input_size, normalize)
     output = vector_encoder(torch.ones((1, input_size)))
-    assert output.shape == (1, hidden_size)
+    assert output.shape == (1, input_size)
 
     normalize = True
-    vector_encoder = VectorEncoder(input_size, hidden_size, num_layers, normalize)
+    vector_encoder = VectorInput(input_size, normalize)
     new_vec = torch.ones((1, input_size))
     vector_encoder.update_normalization(new_vec)
 
     mock_normalizer.assert_called_with(input_size)
     mock_normalizer_inst.update.assert_called_with(new_vec)
 
-    vector_encoder2 = VectorEncoder(input_size, hidden_size, num_layers, normalize)
+    vector_encoder2 = VectorInput(input_size, normalize)
     vector_encoder.copy_normalization(vector_encoder2)
     mock_normalizer_inst.copy_from.assert_called_with(mock_normalizer_inst)
-
-
-@mock.patch("mlagents.trainers.torch.encoders.Normalizer")
-def test_vector_and_unnormalized_encoder(mock_normalizer):
-    mock_normalizer_inst = mock.Mock()
-    mock_normalizer.return_value = mock_normalizer_inst
-    input_size = 64
-    unnormalized_size = 32
-    hidden_size = 128
-    num_layers = 3
-    normalize = True
-    mock_normalizer_inst.return_value = torch.ones((1, input_size))
-    vector_encoder = VectorAndUnnormalizedInputEncoder(
-        input_size, hidden_size, unnormalized_size, num_layers, normalize
-    )
-    # Make sure normalizer is only called on input_size
-    mock_normalizer.assert_called_with(input_size)
-    normal_input = torch.ones((1, input_size))
-
-    unnormalized_input = torch.ones((1, 32))
-    output = vector_encoder(normal_input, unnormalized_input)
-    mock_normalizer_inst.assert_called_with(normal_input)
-    assert output.shape == (1, hidden_size)
 
 
 @pytest.mark.parametrize("image_size", [(36, 36, 3), (84, 84, 4), (256, 256, 5)])

--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -71,14 +71,13 @@ def test_networkbody_visual():
     obs_size = (84, 84, 3)
     network_settings = NetworkSettings()
     obs_shapes = [(vec_obs_size,), obs_size]
-    torch.random.manual_seed(0)
 
     networkbody = NetworkBody(obs_shapes, network_settings)
     optimizer = torch.optim.Adam(networkbody.parameters(), lr=3e-3)
-    sample_obs = torch.ones((1, 84, 84, 3))
+    sample_obs = 0.1 * torch.ones((1, 84, 84, 3))
     sample_vec_obs = torch.ones((1, vec_obs_size))
 
-    for _ in range(1000):
+    for _ in range(150):
         encoded, _ = networkbody([sample_vec_obs], [sample_obs])
         assert encoded.shape == (1, network_settings.hidden_units)
         # Try to force output to 1
@@ -87,7 +86,8 @@ def test_networkbody_visual():
         loss.backward()
         optimizer.step()
     # In the last step, values should be close to 1
-    assert torch.mean(encoded) == pytest.approx(1.0, abs=0.1)
+    for _enc in encoded.flatten():
+        assert _enc == pytest.approx(1.0, abs=0.1)
 
 
 def test_valuenetwork():

--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -78,7 +78,7 @@ def test_networkbody_visual():
     sample_obs = torch.ones((1, 84, 84, 3))
     sample_vec_obs = torch.ones((1, vec_obs_size))
 
-    for _ in range(150):
+    for _ in range(1000):
         encoded, _ = networkbody([sample_vec_obs], [sample_obs])
         assert encoded.shape == (1, network_settings.hidden_units)
         # Try to force output to 1
@@ -87,8 +87,7 @@ def test_networkbody_visual():
         loss.backward()
         optimizer.step()
     # In the last step, values should be close to 1
-    for _enc in encoded.flatten():
-        assert _enc == pytest.approx(1.0, abs=0.1)
+    assert torch.mean(encoded) == pytest.approx(1.0, abs=0.1)
 
 
 def test_valuenetwork():

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -73,7 +73,7 @@ def test_evaluate_actions(rnn, visual, discrete):
     else:
         actions = ModelUtils.list_to_tensor(buffer["actions"], dtype=torch.long)
     vis_obs = []
-    for idx, _ in enumerate(policy.actor_critic.network_body.visual_inputs):
+    for idx, _ in enumerate(policy.actor_critic.network_body.visual_processors):
         vis_ob = ModelUtils.list_to_tensor(buffer["visual_obs%d" % idx])
         vis_obs.append(vis_ob)
 
@@ -110,7 +110,7 @@ def test_sample_actions(rnn, visual, discrete):
     act_masks = ModelUtils.list_to_tensor(buffer["action_mask"])
 
     vis_obs = []
-    for idx, _ in enumerate(policy.actor_critic.network_body.visual_inputs):
+    for idx, _ in enumerate(policy.actor_critic.network_body.visual_processors):
         vis_ob = ModelUtils.list_to_tensor(buffer["visual_obs%d" % idx])
         vis_obs.append(vis_ob)
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -73,7 +73,7 @@ def test_evaluate_actions(rnn, visual, discrete):
     else:
         actions = ModelUtils.list_to_tensor(buffer["actions"], dtype=torch.long)
     vis_obs = []
-    for idx, _ in enumerate(policy.actor_critic.network_body.visual_encoders):
+    for idx, _ in enumerate(policy.actor_critic.network_body.visual_inputs):
         vis_ob = ModelUtils.list_to_tensor(buffer["visual_obs%d" % idx])
         vis_obs.append(vis_ob)
 
@@ -110,7 +110,7 @@ def test_sample_actions(rnn, visual, discrete):
     act_masks = ModelUtils.list_to_tensor(buffer["action_mask"])
 
     vis_obs = []
-    for idx, _ in enumerate(policy.actor_critic.network_body.visual_encoders):
+    for idx, _ in enumerate(policy.actor_critic.network_body.visual_inputs):
         vis_ob = ModelUtils.list_to_tensor(buffer["visual_obs%d" % idx])
         vis_obs.append(vis_ob)
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_curiosity.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_curiosity.py
@@ -67,8 +67,7 @@ def test_reward_decreases(behavior_spec: BehaviorSpec, seed: int) -> None:
     for _ in range(10):
         curiosity_rp.update(buffer)
         reward_new = curiosity_rp.evaluate(buffer)[0]
-        assert reward_new < reward_old
-        reward_old = reward_new
+    assert reward_new < reward_old
 
 
 @pytest.mark.parametrize("seed", SEED)

--- a/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_gail.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_gail.py
@@ -70,7 +70,7 @@ def test_reward_decreases(
     buffer_policy = create_agent_buffer(behavior_spec, 1000)
     demo_to_buffer.return_value = None, buffer_expert
     gail_settings = GAILSettings(
-        demo_path="", learning_rate=0.05, use_vail=False, use_actions=use_actions
+        demo_path="", learning_rate=0.005, use_vail=False, use_actions=use_actions
     )
     gail_rp = create_reward_provider(
         RewardSignalType.GAIL, behavior_spec, gail_settings

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -210,7 +210,7 @@ def test_visual_advanced_ppo(vis_encode_type, num_visual):
         PPO_CONFIG,
         hyperparameters=new_hyperparams,
         network_settings=new_networksettings,
-        max_steps=500,
+        max_steps=700,
         summary_freq=100,
     )
     # The number of steps is pretty small for these encoders

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -72,6 +72,7 @@ SAC_CONFIG = TrainerSettings(
     summary_freq=100,
     max_steps=1000,
     threaded=False,
+    framework=FrameworkType.PYTORCH,
 )
 
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -72,7 +72,6 @@ SAC_CONFIG = TrainerSettings(
     summary_freq=100,
     max_steps=1000,
     threaded=False,
-    framework=FrameworkType.PYTORCH,
 )
 
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_utils.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_utils.py
@@ -5,10 +5,7 @@ import numpy as np
 from mlagents.trainers.settings import EncoderType, ScheduleType
 from mlagents.trainers.torch.utils import ModelUtils
 from mlagents.trainers.exception import UnityTrainerException
-from mlagents.trainers.torch.encoders import (
-    VectorEncoder,
-    VectorAndUnnormalizedInputEncoder,
-)
+from mlagents.trainers.torch.encoders import VectorInput
 from mlagents.trainers.torch.distributions import (
     CategoricalDistInstance,
     GaussianDistInstance,
@@ -42,14 +39,11 @@ def test_min_visual_size():
             enc.forward(vis_input)
 
 
-@pytest.mark.parametrize("unnormalized_inputs", [0, 1])
 @pytest.mark.parametrize("num_visual", [0, 1, 2])
 @pytest.mark.parametrize("num_vector", [0, 1, 2])
 @pytest.mark.parametrize("normalize", [True, False])
 @pytest.mark.parametrize("encoder_type", [EncoderType.SIMPLE, EncoderType.NATURE_CNN])
-def test_create_encoders(
-    encoder_type, normalize, num_vector, num_visual, unnormalized_inputs
-):
+def test_create_inputs(encoder_type, normalize, num_vector, num_visual):
     vec_obs_shape = (5,)
     vis_obs_shape = (84, 84, 3)
     obs_shapes = []
@@ -58,22 +52,16 @@ def test_create_encoders(
     for _ in range(num_visual):
         obs_shapes.append(vis_obs_shape)
     h_size = 128
-    num_layers = 3
-    unnormalized_inputs = 1
-    vis_enc, vec_enc = ModelUtils.create_encoders(
-        obs_shapes, h_size, num_layers, encoder_type, unnormalized_inputs, normalize
+    vis_enc, vec_enc, total_output = ModelUtils.create_input_processors(
+        obs_shapes, h_size, encoder_type, normalize
     )
     vec_enc = list(vec_enc)
     vis_enc = list(vis_enc)
-    assert len(vec_enc) == (
-        1 if unnormalized_inputs + num_vector > 0 else 0
-    )  # There's always at most one vector encoder.
+    assert len(vec_enc) == (1 if num_vector >= 1 else 0)
     assert len(vis_enc) == num_visual
-
-    if unnormalized_inputs > 0:
-        assert isinstance(vec_enc[0], VectorAndUnnormalizedInputEncoder)
-    elif num_vector > 0:
-        assert isinstance(vec_enc[0], VectorEncoder)
+    assert total_output == int(num_visual * h_size + vec_obs_shape[0] * num_vector)
+    if num_vector > 0:
+        assert isinstance(vec_enc[0], VectorInput)
 
     for enc in vis_enc:
         assert isinstance(enc, ModelUtils.get_encoder_for_type(encoder_type))

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -155,7 +155,7 @@ class BCModule:
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_encoders
+                self.policy.actor_critic.network_body.visual_inputs
             ):
                 vis_ob = ModelUtils.list_to_tensor(
                     mini_batch_demo["visual_obs%d" % idx]

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -155,7 +155,7 @@ class BCModule:
         if self.policy.use_vis_obs:
             vis_obs = []
             for idx, _ in enumerate(
-                self.policy.actor_critic.network_body.visual_inputs
+                self.policy.actor_critic.network_body.visual_processors
             ):
                 vis_ob = ModelUtils.list_to_tensor(
                     mini_batch_demo["visual_obs%d" % idx]

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
@@ -91,7 +91,7 @@ class CuriosityNetwork(torch.nn.Module):
         """
         Extracts the current state embedding from a mini_batch.
         """
-        n_vis = len(self._state_encoder.visual_inputs)
+        n_vis = len(self._state_encoder.visual_processors)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[
                 ModelUtils.list_to_tensor(mini_batch["vector_obs"], dtype=torch.float)
@@ -109,7 +109,7 @@ class CuriosityNetwork(torch.nn.Module):
         """
         Extracts the next state embedding from a mini_batch.
         """
-        n_vis = len(self._state_encoder.visual_inputs)
+        n_vis = len(self._state_encoder.visual_processors)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[
                 ModelUtils.list_to_tensor(

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
@@ -91,7 +91,7 @@ class CuriosityNetwork(torch.nn.Module):
         """
         Extracts the current state embedding from a mini_batch.
         """
-        n_vis = len(self._state_encoder.visual_encoders)
+        n_vis = len(self._state_encoder.visual_inputs)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[
                 ModelUtils.list_to_tensor(mini_batch["vector_obs"], dtype=torch.float)
@@ -109,7 +109,7 @@ class CuriosityNetwork(torch.nn.Module):
         """
         Extracts the next state embedding from a mini_batch.
         """
-        n_vis = len(self._state_encoder.visual_encoders)
+        n_vis = len(self._state_encoder.visual_inputs)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[
                 ModelUtils.list_to_tensor(

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -128,7 +128,7 @@ class DiscriminatorNetwork(torch.nn.Module):
         """
         Creates the observation input.
         """
-        n_vis = len(self._state_encoder.visual_encoders)
+        n_vis = len(self._state_encoder.visual_inputs)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[torch.as_tensor(mini_batch["vector_obs"], dtype=torch.float)],
             vis_inputs=[

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -128,7 +128,7 @@ class DiscriminatorNetwork(torch.nn.Module):
         """
         Creates the observation input.
         """
-        n_vis = len(self._state_encoder.visual_inputs)
+        n_vis = len(self._state_encoder.visual_processors)
         hidden, _ = self._state_encoder.forward(
             vec_inputs=[torch.as_tensor(mini_batch["vector_obs"], dtype=torch.float)],
             vis_inputs=[

--- a/ml-agents/mlagents/trainers/torch/encoders.py
+++ b/ml-agents/mlagents/trainers/torch/encoders.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Optional, Union
 
-from mlagents.trainers.torch.layers import linear_layer, Initialization, Swish
+from mlagents.trainers.torch.layers import Swish
 
 
 import torch
@@ -92,8 +92,6 @@ class VectorInput(nn.Module):
     def __init__(self, input_size: int, normalize: bool = False):
         self.normalizer: Optional[Normalizer] = None
         super().__init__()
-        self.normalizer: Optional[Normalizer] = None
-        super().__init__()
         if normalize:
             self.normalizer = Normalizer(input_size)
 
@@ -109,7 +107,6 @@ class VectorInput(nn.Module):
     def update_normalization(self, inputs: torch.Tensor) -> None:
         if self.normalizer is not None:
             self.normalizer.update(inputs)
-
 
 
 class SimpleVisualEncoder(nn.Module):

--- a/ml-agents/mlagents/trainers/torch/encoders.py
+++ b/ml-agents/mlagents/trainers/torch/encoders.py
@@ -90,10 +90,15 @@ def pool_out_shape(h_w: Tuple[int, int], kernel_size: int) -> Tuple[int, int]:
 
 class VectorInput(nn.Module):
     def __init__(self, input_size: int, normalize: bool = False):
-        self.normalizer: Optional[Normalizer] = None
         super().__init__()
+        self.normalizer: Optional[Normalizer] = None
+        self._output_size = input_size
         if normalize:
             self.normalizer = Normalizer(input_size)
+
+    @property
+    def output_size(self) -> int:
+        return self._output_size
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         if self.normalizer is not None:
@@ -126,6 +131,7 @@ class SimpleVisualEncoder(nn.Module):
             nn.LeakyReLU(),
         )
 
+    @property
     def output_size(self) -> int:
         return self.final_flat
 
@@ -155,6 +161,7 @@ class NatureVisualEncoder(nn.Module):
             nn.LeakyReLU(),
         )
 
+    @property
     def output_size(self) -> int:
         return self.final_flat
 
@@ -201,6 +208,7 @@ class ResNetVisualEncoder(nn.Module):
         self._output_size = n_channels[-1] * height * width
         self.sequential = nn.Sequential(*layers)
 
+    @property
     def output_size(self) -> int:
         return self._output_size
 

--- a/ml-agents/mlagents/trainers/torch/layers.py
+++ b/ml-agents/mlagents/trainers/torch/layers.py
@@ -113,6 +113,7 @@ class LinearEncoder(torch.nn.Module):
     """
 
     def __init__(self, input_size: int, num_layers: int, hidden_size: int):
+        super().__init__()
         self.layers = [
             linear_layer(
                 input_size,

--- a/ml-agents/mlagents/trainers/torch/layers.py
+++ b/ml-agents/mlagents/trainers/torch/layers.py
@@ -107,6 +107,37 @@ class MemoryModule(torch.nn.Module):
         pass
 
 
+class LinearEncoder(torch.nn.Module):
+    """
+    Linear layers.
+    """
+
+    def __init__(self, input_size: int, num_layers: int, hidden_size: int):
+        self.layers = [
+            linear_layer(
+                input_size,
+                hidden_size,
+                kernel_init=Initialization.KaimingHeNormal,
+                kernel_gain=1.0,
+            )
+        ]
+        self.layers.append(Swish())
+        for _ in range(num_layers - 1):
+            self.layers.append(
+                linear_layer(
+                    hidden_size,
+                    hidden_size,
+                    kernel_init=Initialization.KaimingHeNormal,
+                    kernel_gain=1.0,
+                )
+            )
+            self.layers.append(Swish())
+        self.seq_layers = torch.nn.Sequential(*self.layers)
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        return self.seq_layers(input_tensor)
+
+
 class LSTM(MemoryModule):
     """
     Memory module that implements LSTM.

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -40,13 +40,13 @@ class NetworkBody(nn.Module):
             else 0
         )
 
-        self.visual_inputs, self.vector_inputs, total_input_size = ModelUtils.create_input_processors(
+        self.visual_inputs, self.vector_inputs, encoder_input_size = ModelUtils.create_input_processors(
             observation_shapes,
             self.h_size,
             network_settings.vis_encode_type,
             normalize=self.normalize,
         )
-        total_enc_size = total_input_size + encoded_act_size
+        total_enc_size = encoder_input_size + encoded_act_size
         self.linear_encoder = LinearEncoder(
             total_enc_size, network_settings.num_layers, self.h_size
         )

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -40,17 +40,15 @@ class NetworkBody(nn.Module):
             else 0
         )
 
-        self.visual_inputs, self.vector_inputs = ModelUtils.create_input_processors(
+        self.visual_inputs, self.vector_inputs, total_input_size = ModelUtils.create_input_processors(
             observation_shapes,
             self.h_size,
             network_settings.vis_encode_type,
             normalize=self.normalize,
         )
-        vector_input_size = sum(_input.output_size for _input in self.vector_inputs)
-        visual_encoded_size = sum(_input.output_size for _input in self.visual_inputs)
-        input_size = vector_input_size + visual_encoded_size + encoded_act_size
+        total_enc_size = total_input_size + encoded_act_size
         self.linear_encoder = LinearEncoder(
-            input_size, network_settings.num_layers, self.h_size
+            total_enc_size, network_settings.num_layers, self.h_size
         )
 
         if self.use_lstm:

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -98,11 +98,11 @@ class NetworkBody(nn.Module):
 
         # Constants don't work in Barracuda
         if actions is not None:
-            input = torch.cat(encodes + [actions], dim=-1)
+            inputs = torch.cat(encodes + [actions], dim=-1)
         else:
-            input = torch.cat(encodes, dim=-1)
-            
-        # HIDDEN LAYERS
+            inputs = torch.cat(encodes, dim=-1)
+        encoding = self.linear_encoder(inputs)
+
         if self.use_lstm:
             # Resize to (batch, sequence length, encoding size)
             encoding = encoding.reshape([-1, sequence_length, self.h_size])

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -40,7 +40,7 @@ class NetworkBody(nn.Module):
             else 0
         )
 
-        self.visual_inputs, self.vector_inputs, encoder_input_size = ModelUtils.create_input_processors(
+        self.visual_processors, self.vector_processors, encoder_input_size = ModelUtils.create_input_processors(
             observation_shapes,
             self.h_size,
             network_settings.vis_encode_type,
@@ -57,12 +57,12 @@ class NetworkBody(nn.Module):
             self.lstm = None  # type: ignore
 
     def update_normalization(self, vec_inputs: List[torch.Tensor]) -> None:
-        for vec_input, vec_enc in zip(vec_inputs, self.vector_inputs):
+        for vec_input, vec_enc in zip(vec_inputs, self.vector_processors):
             vec_enc.update_normalization(vec_input)
 
     def copy_normalization(self, other_network: "NetworkBody") -> None:
         if self.normalize:
-            for n1, n2 in zip(self.vector_inputs, other_network.vector_inputs):
+            for n1, n2 in zip(self.vector_processors, other_network.vector_processors):
                 n1.copy_normalization(n2)
 
     @property
@@ -79,12 +79,12 @@ class NetworkBody(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         encodes = []
 
-        for idx, processor in enumerate(self.vector_inputs):
+        for idx, processor in enumerate(self.vector_processors):
             vec_input = vec_inputs[idx]
             processed_vec = processor(vec_input)
             encodes.append(processed_vec)
 
-        for idx, processor in enumerate(self.visual_inputs):
+        for idx, processor in enumerate(self.visual_processors):
             vis_input = vis_inputs[idx]
             if not torch.onnx.is_in_onnx_export():
                 vis_input = vis_input.permute([0, 3, 1, 2])

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -46,9 +46,9 @@ class NetworkBody(nn.Module):
             network_settings.vis_encode_type,
             normalize=self.normalize,
         )
-        input_size = sum(
-            _input.size for _input in self.visual_inputs + self.vector_inputs
-        )
+        vector_input_size = sum(_input.output_size for _input in self.vector_inputs)
+        visual_encoded_size = sum(_input.output_size for _input in self.visual_inputs)
+        input_size = vector_input_size + visual_encoded_size + encoded_act_size
         self.linear_encoder = LinearEncoder(
             input_size, network_settings.num_layers, self.h_size
         )

--- a/ml-agents/mlagents/trainers/torch/utils.py
+++ b/ml-agents/mlagents/trainers/torch/utils.py
@@ -7,8 +7,7 @@ from mlagents.trainers.torch.encoders import (
     SimpleVisualEncoder,
     ResNetVisualEncoder,
     NatureVisualEncoder,
-    VectorEncoder,
-    VectorAndUnnormalizedInputEncoder,
+    VectorInput,
 )
 from mlagents.trainers.settings import EncoderType, ScheduleType
 from mlagents.trainers.exception import UnityTrainerException
@@ -140,12 +139,10 @@ class ModelUtils:
             )
 
     @staticmethod
-    def create_encoders(
+    def create_input_processors(
         observation_shapes: List[Tuple[int, ...]],
         h_size: int,
-        num_layers: int,
         vis_encode_type: EncoderType,
-        unnormalized_inputs: int = 0,
         normalize: bool = False,
     ) -> Tuple[nn.ModuleList, nn.ModuleList]:
         """
@@ -154,7 +151,6 @@ class ModelUtils:
         :param action_size: Number of additional un-normalized inputs to each vector encoder. Used for
             conditioining network on other values (e.g. actions for a Q function)
         :param h_size: Number of hidden units per layer.
-        :param num_layers: Depth of MLP per encoder.
         :param vis_encode_type: Type of visual encoder to use.
         :param unnormalized_inputs: Vector inputs that should not be normalized, and added to the vector
             obs.
@@ -182,17 +178,8 @@ class ModelUtils:
                 raise UnityTrainerException(
                     f"Unsupported shape of {dimension} for observation {i}"
                 )
-        if vector_size + unnormalized_inputs > 0:
-            if unnormalized_inputs > 0:
-                vector_encoders.append(
-                    VectorAndUnnormalizedInputEncoder(
-                        vector_size, h_size, unnormalized_inputs, num_layers, normalize
-                    )
-                )
-            else:
-                vector_encoders.append(
-                    VectorEncoder(vector_size, h_size, num_layers, normalize)
-                )
+        if vector_size > 0:
+            vector_encoders.append(VectorInput(vector_size, normalize))
         return nn.ModuleList(visual_encoders), nn.ModuleList(vector_encoders)
 
     @staticmethod


### PR DESCRIPTION
### Proposed change(s)

The architecture of the SAC Q functions in PyTorch and TF are below. In the PyTorch version, we combine all the encodings of all the encoders (vector, visual, etc.) and apply a single linear layer to get the output. In TF, we encode the CNN and concatenate the vector to that encoding, and then apply the num_layers linear layers before the output. Note this is only true in the Q function, the TF Policy uses the "PyTorch" architecture. 

![Untitled drawing](https://user-images.githubusercontent.com/5085265/91244996-47df7880-e702-11ea-993e-3bf54feb3eba.png)

The issue is that a single linear layer is not sufficient to map several encodings to the output, and especially the action plus the CNN encoding (which causes training on visual SAC continuous to fail).  I do think if we happen to have visual + vector environments (e.g. OTC) we’ll run into the same issue in the Policy as well (as is probably already happening in the TF policy when running OTC). 

This PR moves everything to the 2nd architecture, and refactors the encoders a bit to make it happen. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
