### PR TITLE
Correct access modifier

### DIFF
--- a/docs/Custom-SideChannels.md
+++ b/docs/Custom-SideChannels.md
@@ -87,7 +87,7 @@ public class StringLogSideChannel : SideChannel
         ChannelId = new Guid("621f0a70-4f87-11ea-a6bf-784f4387d1f7");
     }
 
-    public override void OnMessageReceived(IncomingMessage msg)
+    protected override void OnMessageReceived(IncomingMessage msg)
     {
         var receivedString = msg.ReadString();
         Debug.Log("From Python : " + receivedString);


### PR DESCRIPTION
### Proposed change(s)

Correcting the access modifier for SideChannel.OnMessageReceived.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://docs.unity3d.com/Packages/com.unity.ml-agents@1.0/api/Unity.MLAgents.SideChannels.SideChannel.html

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
