### PR TITLE
[feature] Enable default settings for TrainerSettings

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -24,6 +24,8 @@ Note that PyTorch 1.6.0 or greater should be installed to use this feature; see
 - The minimum supported version of TensorFlow was increased to 1.14.0. (#4411)
 - A CNN (`vis_encode_type: match3`) for smaller grids, e.g. board games, has been added.
 (#4434)
+- You can now again specify a default configuration for your behaviors. Specify `default_settings` in
+your trainer configuration to do so. (#4448)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -337,6 +337,24 @@ each of these parameters mean and provide guidelines on how to set them. See
 description of all the configurations listed above, along with their defaults.
 Unless otherwise specified, omitting a configuration will revert it to its default.
 
+### Default Behavior Settings
+
+In some cases, you may want to specify a set of default configurations for your Behaviors.
+This may be useful, for instance, if your Behavior names are generated procedurally by
+the environment and not known before runtime, or if you have many Behaviors with very similar
+settings. To specify a default configuraton, insert a `default_settings` section in your YAML.
+This section should be formatted exactly like a configuration for a Behavior.
+
+```yaml
+default_settings:
+  # < Same as Behavior configuration >
+behaviors:
+  # < Same as above >
+```
+
+Behaviors found in the environment that aren't secified in the YAML will now use the `default_settings`,
+and unspecified settings in behavior configurations will default to the values in `default_settings` if
+specified there.
 
 ### Environment Parameters
 

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -352,7 +352,7 @@ behaviors:
   # < Same as above >
 ```
 
-Behaviors found in the environment that aren't secified in the YAML will now use the `default_settings`,
+Behaviors found in the environment that aren't specified in the YAML will now use the `default_settings`,
 and unspecified settings in behavior configurations will default to the values in `default_settings` if
 specified there.
 

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -605,6 +605,9 @@ class TrainerSettings(ExportableSettings):
             raise TrainerConfigError(f"Unsupported config {d} for {t.__name__}.")
 
         d_copy: Dict[str, Any] = {}
+
+        # Check if a default_settings was specified. If so, used those as the default
+        # rather than an empty dict.
         if TrainerSettings.default_override is not None:
             d_copy.update(cattr.unstructure(TrainerSettings.default_override))
 
@@ -743,7 +746,7 @@ class RunOptions(ExportableSettings):
                     )
                 )
 
-        # If a default settings was specified, set the TrainerSettings override
+        # If a default settings was specified, set the TrainerSettings class override
         if "default_settings" in configured_dict.keys():
             TrainerSettings.default_override = cattr.structure(
                 configured_dict["default_settings"], TrainerSettings

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -720,9 +720,7 @@ class RunOptions(ExportableSettings):
     cattr.register_unstructure_hook(
         ParameterRandomizationSettings, ParameterRandomizationSettings.unstructure
     )
-
     cattr.register_structure_hook(TrainerSettings, TrainerSettings.structure)
-
     cattr.register_structure_hook(
         DefaultDict[str, TrainerSettings], TrainerSettings.dict_to_defaultdict
     )
@@ -758,7 +756,6 @@ class RunOptions(ExportableSettings):
                         key
                     )
                 )
-
         # Override with CLI args
         # Keep deprecated --load working, TODO: remove
         argparse_args["resume"] = argparse_args["resume"] or argparse_args["load_model"]

--- a/ml-agents/mlagents/trainers/tests/test_settings.py
+++ b/ml-agents/mlagents/trainers/tests/test_settings.py
@@ -1,4 +1,5 @@
 import attr
+import cattr
 import pytest
 import yaml
 
@@ -20,6 +21,7 @@ from mlagents.trainers.settings import (
     GaussianSettings,
     MultiRangeUniformSettings,
     TrainerType,
+    deep_update_dict,
     strict_to_cls,
 )
 from mlagents.trainers.exception import TrainerConfigError
@@ -102,6 +104,14 @@ def test_strict_to_cls():
 
     with pytest.raises(TrainerConfigError):
         strict_to_cls("non_dict_input", TestAttrsClass)
+
+
+def test_deep_update_dict():
+    dict1 = {"a": 1, "b": 2, "c": {"d": 3}}
+    dict2 = {"a": 2, "c": {"d": 4, "e": 5}}
+
+    deep_update_dict(dict1, dict2)
+    assert dict1 == {"a": 2, "b": 2, "c": {"d": 4, "e": 5}}
 
 
 def test_trainersettings_structure():
@@ -468,3 +478,25 @@ def test_environment_settings():
     # Multiple environments with no env_path is an error
     with pytest.raises(ValueError):
         EnvironmentSettings(num_envs=2)
+
+
+def test_default_settings():
+    # Make default settings, one nested and one not.
+    default_settings = {"max_steps": 1, "network_settings": {"num_layers": 1000}}
+    behaviors = {"test1": {"max_steps": 2, "network_settings": {"hidden_units": 2000}}}
+    run_options_dict = {"default_settings": default_settings, "behaviors": behaviors}
+    run_options = RunOptions.from_dict(run_options_dict)
+
+    # Check that a new behavior has the default settings
+    default_settings_cls = cattr.structure(default_settings, TrainerSettings)
+    check_if_different(default_settings_cls, run_options.behaviors["test2"])
+
+    # Check that an existing beehavior overrides the defaults in specified fields
+    test1_settings = run_options.behaviors["test1"]
+    assert test1_settings.max_steps == 2
+    assert test1_settings.network_settings.hidden_units == 2000
+    assert test1_settings.network_settings.num_layers == 1000
+    # Change the overridden fields back, and check if the rest are equal.
+    test1_settings.max_steps = 1
+    test1_settings.network_settings.hidden_units == default_settings_cls.network_settings.hidden_units
+    check_if_different(test1_settings, default_settings_cls)


### PR DESCRIPTION
### Proposed change(s)

Based on feedback from CarryCastle. Enables specifying a default TrainerSettings for all behaviors. The default is specified using the same structure as the others under a new header `default_settings`. These are now used as the default values for all behaviors, including those not found in the settings YAML. 

```
default_settings:
    trainer_type: ppo
    ... etc.
behaviors:
    CrawlerStatic:
```

For behavior names that are defined in the YAML, any missing fields will be filled first from the `default_settings`, then those defined in the TrainerSettings class in`settings.py`. 

WIP: Tests, documentation

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)
