### PR TITLE
update Yamato tests to run on 2019.4

### DIFF
--- a/.yamato/com.unity.ml-agents-performance.yml
+++ b/.yamato/com.unity.ml-agents-performance.yml
@@ -1,6 +1,7 @@
 test_editors:
-  - version: 2019.3
+  - version: 2019.4
   - version: 2020.1
+  - version: 2020.2
 ---
 {% for editor in test_editors %}
 Run_Mac_Perfomance_Tests{{ editor.version }}:

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -2,7 +2,7 @@ test_editors:
   - version: 2018.4
     # 2018.4 doesn't support code-coverage
     enableCodeCoverage: !!bool false
-  - version: 2019.3
+  - version: 2019.4
     enableCodeCoverage: !!bool true
   - version: 2020.1
     enableCodeCoverage: !!bool true

--- a/.yamato/gym-interface-test.yml
+++ b/.yamato/gym-interface-test.yml
@@ -1,5 +1,5 @@
 test_editors:
-  - version: 2019.3
+  - version: 2019.4
 ---
 {% for editor in test_editors %}
 test_gym_interface_{{ editor.version }}:

--- a/.yamato/python-ll-api-test.yml
+++ b/.yamato/python-ll-api-test.yml
@@ -1,5 +1,5 @@
 test_editors:
-  - version: 2019.3
+  - version: 2019.4
 ---
 {% for editor in test_editors %}
 test_mac_ll_api_{{ editor.version }}:

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -1,6 +1,7 @@
 test_editors:
   - version: 2018.4
-  - version: 2019.3
+  - version: 2019.4
+  - version: 2020.1
 ---
 {% for editor in test_editors %}
 test_mac_training_int_{{ editor.version }}:


### PR DESCRIPTION
### Proposed change(s)
Update the yamato test versions: Replace 2019.3 with 2019.4, and add 2020.x versions where relevant

