### PR TITLE
allow ending the episode for MaxStepsReached

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to
 - Enabled C# formatting using `dotnet-format`. (#4362)
 - GridSensor was added to the com.unity.ml-agents.extensions package. Thank you
 to Jaden Travnik from Eidos Montreal for the contribution! (#4399)
-- Added `Agent.EpisodeMaxStepReached()` to reset the agent when it has reached
-a user-determined maximum number of steps. This behaves similarly to
-`Agent.EndEpsiode()` but has a slightly different effect on training (#4453).
+- Added `Agent.EpisodeInterrupted()`, which can be used to reset the agent when
+it has reached a user-determined maximum number of steps. This behaves similarly
+to `Agent.EndEpsiode()` but has a slightly different effect on training (#4453).
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Experimental PyTorch support has been added. Use `--torch` when running `mlagents-learn`, or add
 `framework: pytorch` to your trainer configuration (under the behavior name) to enable it.

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 - Enabled C# formatting using `dotnet-format`. (#4362)
 - GridSensor was added to the com.unity.ml-agents.extensions package. Thank you
 to Jaden Travnik from Eidos Montreal for the contribution! (#4399)
+- Added `Agent.EpisodeMaxStepReached()` to reset the agent when it has reached
+a user-determined maximum number of steps. This behaves similarly to
+`Agent.EndEpsiode()` but has a slightly different effect on training (#4453).
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Experimental PyTorch support has been added. Use `--torch` when running `mlagents-learn`, or add
 `framework: pytorch` to your trainer configuration (under the behavior name) to enable it.

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -445,7 +445,7 @@ namespace Unity.MLAgents
         enum DoneReason
         {
             /// <summary>
-            /// The <see cref="EndEpisode"/> method was called.
+            /// The episode was ended manually by calling <see cref="EndEpisode"/>.
             /// </summary>
             DoneCalled,
 
@@ -691,10 +691,41 @@ namespace Unity.MLAgents
         /// <summary>
         /// Sets the done flag to true and resets the agent.
         /// </summary>
+        /// <remarks>
+        /// This should be used when the episode can no longer continue, such as when the Agent
+        /// reaches the goal or fails at the task.
+        /// </remarks>
         /// <seealso cref="OnEpisodeBegin"/>
+        /// <seealso cref="EpisodeMaxStepReached"/>
         public void EndEpisode()
         {
-            NotifyAgentDone(DoneReason.DoneCalled);
+            EndEpisodeAndReset(DoneReason.DoneCalled);
+        }
+
+        /// <summary>
+        /// Indicate that the episode has reached a maximum number of steps.
+        /// This has the same end result as calling <see cref="EndEpisode"/>, but has a
+        /// slightly different effect on training.
+        /// </summary>
+        /// <remarks>
+        /// This should be used when the episode could continue, but has gone on for
+        /// a sufficient number of steps.
+        /// </remarks>
+        /// <seealso cref="OnEpisodeBegin"/>
+        /// <seealso cref="EndEpisode"/>
+        public void EpisodeMaxStepReached()
+        {
+            EndEpisodeAndReset(DoneReason.MaxStepReached);
+        }
+
+
+        /// <summary>
+        /// Internal method to end the episode and reset the Agent.
+        /// </summary>
+        /// <param name="reason"></param>
+        void EndEpisodeAndReset(DoneReason reason)
+        {
+            NotifyAgentDone(reason);
             _AgentReset();
         }
 

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -696,14 +696,14 @@ namespace Unity.MLAgents
         /// reaches the goal or fails at the task.
         /// </remarks>
         /// <seealso cref="OnEpisodeBegin"/>
-        /// <seealso cref="EpisodeMaxStepReached"/>
+        /// <seealso cref="EpisodeInterrupted"/>
         public void EndEpisode()
         {
             EndEpisodeAndReset(DoneReason.DoneCalled);
         }
 
         /// <summary>
-        /// Indicate that the episode has reached a maximum number of steps.
+        /// Indicate that the episode is over but not due to the "fault" of the Agent.
         /// This has the same end result as calling <see cref="EndEpisode"/>, but has a
         /// slightly different effect on training.
         /// </summary>
@@ -713,7 +713,7 @@ namespace Unity.MLAgents
         /// </remarks>
         /// <seealso cref="OnEpisodeBegin"/>
         /// <seealso cref="EndEpisode"/>
-        public void EpisodeMaxStepReached()
+        public void EpisodeInterrupted()
         {
             EndEpisodeAndReset(DoneReason.MaxStepReached);
         }


### PR DESCRIPTION
### Proposed change(s)
This came up when trying to use MaxSteps on the match-3 sample. If you have multiple Agents in the scene using on-demand decisions, their step count will get incremented whenever the Academy steps, even if they're not doing anything. For training, you can work around this by requesting a decision each step, but for inference or heuristic mode when you might want to show animations of the Agent "boards", the decision request frames get out of sync and you end up hitting MaxSteps too soon.

I think this is the best solution without breaking existing behavior (a better approach would be to only count decision or action steps towards MaxSteps, but that's a breaking change). An alternative would be to make DoneReason public and allow that as an optional parameter to EndEpisode.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1345


### Types of change(s)
- [x] New feature

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
