### PR TITLE
don't run pytest on doc or C# changes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,10 @@ name: pytest
 
 on:
   pull_request:
+    paths:  # This action will only run if the PR modifies a file in one of these directories
+    - 'ml-agents/**'
+    - 'ml-agents-envs/**'
+    - 'gym-unity/**'
   push:
     branches: [master]
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,8 @@ on:
     - 'ml-agents/**'
     - 'ml-agents-envs/**'
     - 'gym-unity/**'
+    - 'test_constraints*.txt'
+    - 'test_requirements.txt'
   push:
     branches: [master]
 


### PR DESCRIPTION
### Proposed change(s)
Try to avoid running pytest on e.g. C#-only or doc changes. Any changes in these folders will still trigger the changes (and it always runs on master).

Alternatively, we could do this by `**.py` and `**.demo` files, but I wasn't sure if there were any other extensions we use in the tests.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
