### PR TITLE
disable email checks on markdown-link-check

### DIFF
--- a/markdown-link-check.fast.json
+++ b/markdown-link-check.fast.json
@@ -11,6 +11,10 @@
         {
             "pattern": "^https?://",
             "comment": "Skip external links for fast runs."
+        },
+        {
+            "pattern": "mailto:",
+            "comment": "mailto checking broken"
         }
     ]
 }

--- a/markdown-link-check.full.json
+++ b/markdown-link-check.full.json
@@ -15,6 +15,10 @@
         {
             "pattern": "https://forum.unity.com/forums/ml-agents.453/",
             "comment": "Not reachable from github action"
+        },
+        {
+            "pattern": "mailto:",
+            "comment": "mailto checking broken"
         }
     ]
 }


### PR DESCRIPTION
### Proposed change(s)
https://github.com/tcort/markdown-link-check recently added an "feature" to check email addresses but it appears broken. This PR disables validation of "mailto" links.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/tcort/markdown-link-check/issues/105
