### PR TITLE
docstrings and cleanup around actuators

### DIFF
--- a/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
@@ -139,12 +139,6 @@ namespace Unity.MLAgents.Actuators
     public interface IActionReceiver
     {
         /// <summary>
-        /// The specification of the Action space for this IActionReceiver.
-        /// </summary>
-        /// <seealso cref="ActionSpec"/>
-        ActionSpec ActionSpec { get; }
-
-        /// <summary>
         /// Method called in order too allow object to execute actions based on the
         /// <see cref="ActionBuffers"/> contents.  The structure of the contents in the <see cref="ActionBuffers"/>
         /// are defined by the <see cref="ActionSpec"/>.
@@ -170,21 +164,5 @@ namespace Unity.MLAgents.Actuators
         /// </remarks>
         /// <seealso cref="IActionReceiver.OnActionReceived"/>
         void WriteDiscreteActionMask(IDiscreteActionMask actionMask);
-    }
-
-    /// <summary>
-    /// Helper methods to be shared by all classes that implement <see cref="IActionReceiver"/>.
-    /// </summary>
-    public static class ActionReceiverExtensions
-    {
-        /// <summary>
-        /// Returns the number of discrete branches + the number of continuous actions.
-        /// </summary>
-        /// <param name="actionReceiver"></param>
-        /// <returns></returns>
-        public static int TotalNumberOfActions(this IActionReceiver actionReceiver)
-        {
-            return actionReceiver.ActionSpec.NumContinuousActions + actionReceiver.ActionSpec.NumDiscreteActions;
-        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
@@ -36,10 +36,16 @@ namespace Unity.MLAgents.Actuators
         public static ActionBuffers FromDiscreteActions(float[] discreteActions)
         {
             return new ActionBuffers(ActionSegment<float>.Empty, discreteActions == null ? ActionSegment<int>.Empty
-                                : new ActionSegment<int>(Array.ConvertAll(discreteActions,
-                                    x => (int)x)));
+                : new ActionSegment<int>(Array.ConvertAll(discreteActions,
+                    x => (int)x)));
         }
 
+        /// <summary>
+        /// Construct an <see cref="ActionBuffers"/> instance with the continuous and discrete actions that will
+        /// be used.
+        /// /// </summary>
+        /// <param name="continuousActions">The continuous actions to send to an <see cref="IActionReceiver"/>.</param>
+        /// <param name="discreteActions">The discrete actions to send to an <see cref="IActionReceiver"/>.</param>
         public ActionBuffers(float[] continuousActions, int[] discreteActions)
             : this(new ActionSegment<float>(continuousActions), new ActionSegment<int>(discreteActions)) { }
 
@@ -132,7 +138,6 @@ namespace Unity.MLAgents.Actuators
     /// </summary>
     public interface IActionReceiver
     {
-
         /// <summary>
         /// The specification of the Action space for this IActionReceiver.
         /// </summary>

--- a/com.unity.ml-agents/Runtime/Actuators/IActuator.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActuator.cs
@@ -14,6 +14,10 @@ namespace Unity.MLAgents.Actuators
         /// <returns></returns>
         string Name { get; }
 
+        /// <summary>
+        /// Resets the internal state of the actuator. This is called at the end of an Agent's episode.
+        /// Most implementations can leave this empty.
+        /// </summary>
         void ResetData();
     }
 }

--- a/com.unity.ml-agents/Runtime/Actuators/IActuator.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActuator.cs
@@ -1,6 +1,3 @@
-using System;
-using UnityEngine;
-
 namespace Unity.MLAgents.Actuators
 {
     /// <summary>
@@ -8,6 +5,12 @@ namespace Unity.MLAgents.Actuators
     /// </summary>
     public interface IActuator : IActionReceiver
     {
+        /// <summary>
+        /// The specification of the Action space for this IActuator.
+        /// </summary>
+        /// <seealso cref="ActionSpec"/>
+        ActionSpec ActionSpec { get; }
+
         /// <summary>
         /// Gets the name of this IActuator which will be used to sort it.
         /// </summary>
@@ -19,5 +22,21 @@ namespace Unity.MLAgents.Actuators
         /// Most implementations can leave this empty.
         /// </summary>
         void ResetData();
+    }
+
+    /// <summary>
+    /// Helper methods to be shared by all classes that implement <see cref="IActuator"/>.
+    /// </summary>
+    public static class IActuatorExtensions
+    {
+        /// <summary>
+        /// Returns the number of discrete branches + the number of continuous actions.
+        /// </summary>
+        /// <param name="actuator"></param>
+        /// <returns></returns>
+        public static int TotalNumberOfActions(this IActuator actuator)
+        {
+            return actuator.ActionSpec.NumContinuousActions + actuator.ActionSpec.NumDiscreteActions;
+        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Actuators/VectorActuator.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/VectorActuator.cs
@@ -4,7 +4,10 @@ using Unity.MLAgents.Policies;
 
 namespace Unity.MLAgents.Actuators
 {
-    public class VectorActuator : IActuator
+    /// <summary>
+    /// IActuator implementation that forwards to an <see cref="IActionReceiver"/>.
+    /// </summary>
+    internal class VectorActuator : IActuator
     {
         IActionReceiver m_ActionReceiver;
 
@@ -15,6 +18,15 @@ namespace Unity.MLAgents.Actuators
             private set => m_ActionBuffers = value;
         }
 
+        /// <summary>
+        /// Create a VectorActuator that forwards to the provided IActionReceiver.
+        /// </summary>
+        /// <param name="actionReceiver">The <see cref="IActionReceiver"/> used for OnActionReceived and WriteDiscreteActionMask.</param>
+        /// <param name="vectorActionSize">For discrete action spaces, the branch sizes for each action.
+        /// For continuous action spaces, the number of actions is the 0th element.</param>
+        /// <param name="spaceType"></param>
+        /// <param name="name"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown for invalid <see cref="SpaceType"/></exception>
         public VectorActuator(IActionReceiver actionReceiver,
                               int[] vectorActionSize,
                               SpaceType spaceType,

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -718,7 +718,6 @@ namespace Unity.MLAgents
             EndEpisodeAndReset(DoneReason.MaxStepReached);
         }
 
-
         /// <summary>
         /// Internal method to end the episode and reset the Agent.
         /// </summary>
@@ -1131,7 +1130,10 @@ namespace Unity.MLAgents
             CollectDiscreteActionMasks(m_ActionMasker);
         }
 
-        ActionSpec IActionReceiver.ActionSpec { get; }
+        ActionSpec IActionReceiver.ActionSpec
+        {
+            get { throw new NotImplementedException(); }
+        }
 
         /// <summary>
         /// Implement `OnActionReceived()` to specify agent behavior at every step, based

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1130,11 +1130,6 @@ namespace Unity.MLAgents
             CollectDiscreteActionMasks(m_ActionMasker);
         }
 
-        ActionSpec IActionReceiver.ActionSpec
-        {
-            get { throw new NotImplementedException(); }
-        }
-
         /// <summary>
         /// Implement `OnActionReceived()` to specify agent behavior at every step, based
         /// on the provided action.

--- a/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
@@ -52,7 +52,7 @@ namespace Unity.MLAgents.Sensors
         void Update();
 
         /// <summary>
-        /// Resets the internal states of the sensor. This is called at the end of an Agent's episode.
+        /// Resets the internal state of the sensor. This is called at the end of an Agent's episode.
         /// Most implementations can leave this empty.
         /// </summary>
         void Reset();


### PR DESCRIPTION
### Proposed change(s)
This fixes all the documentation warnings we were getting from package validation.

I changed VectorActuator to internal because
1) I'm not sure it's useful except for wrapping Agent.
2) I'm not sure it's a good name

I also moved the ActionSpec property out of IActionReceiver and into IActuator. Agent wasn't using this correctly (it never set its ActionSpec) which made me think it's not a good interface design. I'm willing to change this back and make Agent throw if its ActionSpec is used.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
