### PR TITLE
[bug-fix] Set number of threads based on allocated CPU count in Docker containers

### DIFF
--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -9,11 +9,11 @@ def get_num_threads_to_use() -> Optional[int]:
     need, but for smaller machines, we'd like to scale to less than that.
     By default, PyTorch uses 1/2 of the available cores.
     """
-    num_cpus = _get_num_cpus()
+    num_cpus = _get_num_available_cpus()
     return max(min(num_cpus // 2, 4), 1) if num_cpus is not None else None
 
 
-def _get_num_cpus() -> Optional[int]:
+def _get_num_available_cpus() -> Optional[int]:
     """
     Returns number of CPUs using cgroups if possible. This accounts
     for Docker containers that are limited in cores.

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -29,6 +29,6 @@ def _get_num_cpus() -> Optional[int]:
 def _read_in_integer_file(filename: str) -> int:
     try:
         with open(filename) as f:
-            return int(f.readlines()[0])
+            return int(f.read().rstrip())
     except FileNotFoundError:
         return -1

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -18,17 +18,17 @@ def _get_num_cpus() -> Optional[int]:
     Returns number of CPUs using cgroups if possible. This accounts
     for Docker containers that are limited in cores.
     """
-    try:
-        period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
-        quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
-        num_cpus = quota // period
-        if num_cpus > 0:
-            return num_cpus
-    except FileNotFoundError:
-        pass
-    return os.cpu_count()
+    period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    if period > 0 and quota > 0:
+        return int(quota // period)
+    else:
+        return os.cpu_count()
 
 
 def _read_in_integer_file(filename: str) -> int:
-    with open(filename) as f:
-        return int(f.readlines()[0])
+    try:
+        with open(filename) as f:
+            return int(f.readlines()[0])
+    except FileNotFoundError:
+        return -1

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+import os
+
+
+def get_num_threads_to_use() -> Optional[int]:
+    """
+    Gets the number of threads to use. For most problems, 4 is all you
+    need, but for smaller machines, we'd like to scale to less than that.
+    By default, PyTorch uses 1/2 of the available cores.
+    """
+    num_cpus = _get_num_cpus()
+    return max(min(num_cpus // 2, 4), 1) if num_cpus is not None else None
+
+
+def _get_num_cpus() -> Optional[int]:
+    """
+    Returns number of CPUs using cgroups if possible. This accounts
+    for Docker containers that are limited in cores.
+    """
+    try:
+        period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+        quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+        num_cpus = quota // period
+        if num_cpus > 0:
+            return num_cpus
+    except FileNotFoundError:
+        pass
+    return os.cpu_count()
+
+
+def _read_in_integer_file(filename: str) -> int:
+    with open(filename) as f:
+        return int(f.readlines()[0])

--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -1,5 +1,7 @@
 import os
 
+from mlagents.torch_utils import cpu_utils
+
 # Detect availability of torch package here.
 # NOTE: this try/except is temporary until torch is required for ML-Agents.
 try:
@@ -7,7 +9,7 @@ try:
     # Everywhere else is caught by the banned-modules setting for flake8
     import torch  # noqa I201
 
-    torch.set_num_interop_threads(2)
+    torch.set_num_threads(cpu_utils.get_num_threads_to_use())
     os.environ["KMP_BLOCKTIME"] = "0"
 
     # Known PyLint compatibility with PyTorch https://github.com/pytorch/pytorch/issues/701


### PR DESCRIPTION
### Proposed change(s)

PyTorch by default sets number of threads to 1/2 available cores. However, in Docker containers, the built-in Python methods return the number of cores of the host machine, not the container. This PR reads the allocated CPU count from `cgroup` and uses that to set the num threads. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
