### PR TITLE
add to_string for samplers

### DIFF
--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -128,10 +128,11 @@ class EnvironmentParameterManager:
             lesson_num = GlobalTrainingStatus.get_parameter_state(
                 param_name, StatusType.LESSON_NUM
             )
+            next_lesson_num = lesson_num + 1
             lesson = settings.curriculum[lesson_num]
             if (
                 lesson.completion_criteria is not None
-                and len(settings.curriculum) > lesson_num + 1
+                and len(settings.curriculum) > next_lesson_num
             ):
                 behavior_to_consider = lesson.completion_criteria.behavior
                 if behavior_to_consider in trainer_steps:
@@ -144,11 +145,16 @@ class EnvironmentParameterManager:
                     self._smoothed_values[param_name] = new_smoothing
                     if must_increment:
                         GlobalTrainingStatus.set_parameter_state(
-                            param_name, StatusType.LESSON_NUM, lesson_num + 1
+                            param_name, StatusType.LESSON_NUM, next_lesson_num
                         )
-                        new_lesson_name = settings.curriculum[lesson_num + 1].name
+                        new_lesson_name = settings.curriculum[next_lesson_num].name
+                        new_lesson_value = settings.curriculum[
+                            next_lesson_num
+                        ].value.to_string()
+
                         logger.info(
-                            f"Parameter '{param_name}' has changed. Now in lesson '{new_lesson_name}'"
+                            f"Parameter '{param_name}' has been updated with {new_lesson_value}."
+                            + f" Now in lesson '{new_lesson_name}'"
                         )
                         updated = True
                         if lesson.completion_criteria.require_reset:

--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -148,9 +148,7 @@ class EnvironmentParameterManager:
                             param_name, StatusType.LESSON_NUM, next_lesson_num
                         )
                         new_lesson_name = settings.curriculum[next_lesson_num].name
-                        new_lesson_value = settings.curriculum[
-                            next_lesson_num
-                        ].value.to_string()
+                        new_lesson_value = settings.curriculum[next_lesson_num].value
 
                         logger.info(
                             f"Parameter '{param_name}' has been updated with {new_lesson_value}."

--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -151,7 +151,7 @@ class EnvironmentParameterManager:
                         new_lesson_value = settings.curriculum[next_lesson_num].value
 
                         logger.info(
-                            f"Parameter '{param_name}' has been updated with {new_lesson_value}."
+                            f"Parameter '{param_name}' has been updated to {new_lesson_value}."
                             + f" Now in lesson '{new_lesson_name}'"
                         )
                         updated = True

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -292,6 +292,13 @@ class ParameterRandomizationSettings(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def to_string(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        pass
+
 
 @attr.s(auto_attribs=True)
 class ConstantSettings(ParameterRandomizationSettings):
@@ -305,6 +312,12 @@ class ConstantSettings(ParameterRandomizationSettings):
         :param env_channel: The EnvironmentParametersChannel to communicate sampler settings to environment
         """
         env_channel.set_float_parameter(key, self.value)
+
+    def to_string(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Float: value={self.value}"
 
 
 @attr.s(auto_attribs=True)
@@ -334,6 +347,12 @@ class UniformSettings(ParameterRandomizationSettings):
             key, self.min_value, self.max_value, self.seed
         )
 
+    def to_string(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Uniform sampler: min={self.min_value}, max={self.max_value}"
+
 
 @attr.s(auto_attribs=True)
 class GaussianSettings(ParameterRandomizationSettings):
@@ -350,6 +369,12 @@ class GaussianSettings(ParameterRandomizationSettings):
         env_channel.set_gaussian_sampler_parameters(
             key, self.mean, self.st_dev, self.seed
         )
+
+    def to_string(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Gaussian sampler: mean={self.mean}, stddev={self.st_dev}"
 
 
 @attr.s(auto_attribs=True)
@@ -383,6 +408,12 @@ class MultiRangeUniformSettings(ParameterRandomizationSettings):
         env_channel.set_multirangeuniform_sampler_parameters(
             key, self.intervals, self.seed
         )
+
+    def to_string(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"MultiRangeUniform sampler: intervals={self.intervals}"
 
 
 # ENVIRONMENT PARAMETERS ###############################################################

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -236,6 +236,12 @@ class ParameterRandomizationType(Enum):
 class ParameterRandomizationSettings(abc.ABC):
     seed: int = parser.get_default("seed")
 
+    def __str__(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        raise TrainerConfigError(f"__str__ not implemented for type {self.__class__}.")
+
     @staticmethod
     def structure(
         d: Union[Mapping, float], t: type
@@ -292,17 +298,16 @@ class ParameterRandomizationSettings(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def to_string(self) -> str:
-        """
-        Helper method to output sampler stats to console.
-        """
-        pass
-
 
 @attr.s(auto_attribs=True)
 class ConstantSettings(ParameterRandomizationSettings):
     value: float = 0.0
+
+    def __str__(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Float: value={self.value}"
 
     def apply(self, key: str, env_channel: EnvironmentParametersChannel) -> None:
         """
@@ -313,17 +318,17 @@ class ConstantSettings(ParameterRandomizationSettings):
         """
         env_channel.set_float_parameter(key, self.value)
 
-    def to_string(self) -> str:
-        """
-        Helper method to output sampler stats to console.
-        """
-        return f"Float: value={self.value}"
-
 
 @attr.s(auto_attribs=True)
 class UniformSettings(ParameterRandomizationSettings):
     min_value: float = attr.ib()
     max_value: float = 1.0
+
+    def __str__(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Uniform sampler: min={self.min_value}, max={self.max_value}"
 
     @min_value.default
     def _min_value_default(self):
@@ -347,17 +352,17 @@ class UniformSettings(ParameterRandomizationSettings):
             key, self.min_value, self.max_value, self.seed
         )
 
-    def to_string(self) -> str:
-        """
-        Helper method to output sampler stats to console.
-        """
-        return f"Uniform sampler: min={self.min_value}, max={self.max_value}"
-
 
 @attr.s(auto_attribs=True)
 class GaussianSettings(ParameterRandomizationSettings):
     mean: float = 1.0
     st_dev: float = 1.0
+
+    def __str__(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"Gaussian sampler: mean={self.mean}, stddev={self.st_dev}"
 
     def apply(self, key: str, env_channel: EnvironmentParametersChannel) -> None:
         """
@@ -370,16 +375,16 @@ class GaussianSettings(ParameterRandomizationSettings):
             key, self.mean, self.st_dev, self.seed
         )
 
-    def to_string(self) -> str:
-        """
-        Helper method to output sampler stats to console.
-        """
-        return f"Gaussian sampler: mean={self.mean}, stddev={self.st_dev}"
-
 
 @attr.s(auto_attribs=True)
 class MultiRangeUniformSettings(ParameterRandomizationSettings):
     intervals: List[Tuple[float, float]] = attr.ib()
+
+    def __str__(self) -> str:
+        """
+        Helper method to output sampler stats to console.
+        """
+        return f"MultiRangeUniform sampler: intervals={self.intervals}"
 
     @intervals.default
     def _intervals_default(self):
@@ -408,12 +413,6 @@ class MultiRangeUniformSettings(ParameterRandomizationSettings):
         env_channel.set_multirangeuniform_sampler_parameters(
             key, self.intervals, self.seed
         )
-
-    def to_string(self) -> str:
-        """
-        Helper method to output sampler stats to console.
-        """
-        return f"MultiRangeUniform sampler: intervals={self.intervals}"
 
 
 # ENVIRONMENT PARAMETERS ###############################################################

--- a/ml-agents/mlagents/trainers/tests/test_settings.py
+++ b/ml-agents/mlagents/trainers/tests/test_settings.py
@@ -244,6 +244,22 @@ def test_env_parameter_structure():
     assert isinstance(
         env_param_settings["length"].curriculum[0].value, MultiRangeUniformSettings
     )
+
+    # Check __str__ is correct
+    assert (
+        str(env_param_settings["mass"].curriculum[0].value)
+        == "Uniform sampler: min=1.0, max=2.0"
+    )
+    assert (
+        str(env_param_settings["scale"].curriculum[0].value)
+        == "Gaussian sampler: mean=1.0, stddev=2.0"
+    )
+    assert (
+        str(env_param_settings["length"].curriculum[0].value)
+        == "MultiRangeUniform sampler: intervals=[(1.0, 2.0), (3.0, 4.0)]"
+    )
+    assert str(env_param_settings["gravity"].curriculum[0].value) == "Float: value=1"
+
     assert isinstance(
         env_param_settings["wall_height"].curriculum[0].value, ConstantSettings
     )


### PR DESCRIPTION
### Proposed change(s)

This increases the verbosity of the curriculum lesson changes by adding to_strings to the sampler classes.  The lesson updates would now output the sampler stats in addition to the lesson and parameter name to the console. See below for sample.

<img width="1120" alt="Screen Shot 2020-09-14 at 2 58 41 PM" src="https://user-images.githubusercontent.com/54679309/93142591-2f2c0800-f69b-11ea-8e04-8c2ad5030616.png">

This was done to address a request here https://github.com/Unity-Technologies/ml-agents/issues/4464

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
