### PR TITLE
[Release 7] Improve environment finding logic on windows

### DIFF
--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -69,7 +69,15 @@ def validate_environment_path(env_path: str) -> Optional[str]:
         if len(candidates) == 0:
             candidates = glob.glob(env_path + ".exe")
         if len(candidates) == 0:
-            candidates = glob.glob(os.path.join(cwd, env_path, "*.exe"))
+            # Look for e.g. 3DBall\UnityEnvironment.exe
+            crash_handlers = set(
+                glob.glob(os.path.join(cwd, env_path, "UnityCrashHandler*.exe"))
+            )
+            candidates = [
+                c
+                for c in glob.glob(os.path.join(cwd, env_path, "*.exe"))
+                if c not in crash_handlers
+            ]
         if len(candidates) > 0:
             launch_string = candidates[0]
     return launch_string

--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -68,6 +68,8 @@ def validate_environment_path(env_path: str) -> Optional[str]:
         candidates = glob.glob(os.path.join(cwd, env_path + ".exe"))
         if len(candidates) == 0:
             candidates = glob.glob(env_path + ".exe")
+        if len(candidates) == 0:
+            candidates = glob.glob(os.path.join(cwd, env_path, "*.exe"))
         if len(candidates) > 0:
             launch_string = candidates[0]
     return launch_string


### PR DESCRIPTION
### Proposed change(s)
Followup from a discussion with @zookae - On Windows, saving e.g. 3DBall would put the executable at `3DBall\UnityEnvironment.exe`. That would mean running with `--env=3DBall` would not fix the executable. This improves the logic by adding an extra check if the existing one fails: search for `*.exe` under the env directory, and exclude `UnityCrashHandler*.exe`


### Types of change(s)
- [x] Other (Small improvement)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
