### PR TITLE
Don't call NotifyDone in Agent.OnDisable if Academy is shut down

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -49,6 +49,8 @@ your trainer configuration to do so. (#4448)
 #### com.unity.ml-agents (C#)
 - Previously, `com.unity.ml-agents` was not declaring built-in packages as
 dependencies in its package.json. The relevant dependencies are now listed. (#4384)
+- Agents no longer try to send observations when they become disabled if the
+Academy has been shut down. (#4489)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed the sample code in the custom SideChannel example. (#4466)
 - A bug in the observation normalizer that would cause rewards to decrease

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -491,8 +491,8 @@ namespace Unity.MLAgents
                 Academy.Instance.DecideAction -= DecideAction;
                 Academy.Instance.AgentAct -= AgentStep;
                 Academy.Instance.AgentForceReset -= _AgentReset;
+                NotifyAgentDone(DoneReason.Disabled);
             }
-            NotifyAgentDone(DoneReason.Disabled);
             m_Brain?.Dispose();
             m_Initialized = false;
         }

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -314,6 +314,10 @@ namespace Unity.MLAgents
         /// <param name="sensors">Sensors that will produce the observations</param>
         public void PutObservations(string behaviorName, AgentInfo info, List<ISensor> sensors)
         {
+            if (!m_IsOpen)
+            {
+                reutrn
+            }
 #if DEBUG
             if (!m_SensorShapeValidators.ContainsKey(behaviorName))
             {

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -314,10 +314,6 @@ namespace Unity.MLAgents
         /// <param name="sensors">Sensors that will produce the observations</param>
         public void PutObservations(string behaviorName, AgentInfo info, List<ISensor> sensors)
         {
-            if (!m_IsOpen)
-            {
-                reutrn
-            }
 #if DEBUG
             if (!m_SensorShapeValidators.ContainsKey(behaviorName))
             {


### PR DESCRIPTION
### Proposed change(s)
We currently get warnings when stopping training in the GridFoodCollector scene, because the AcademyFixedUpdateStepper is recreated. This happens because in Agent.OnDisable, we try to send the observations to the communicator (which has been shut down already). For the case of GridFoodCollector, this ends up calling Academy.Instance.TrainerCapabilities here
https://github.com/Unity-Technologies/ml-agents/blob/7c1cfab924b2301179ec76d8d7fef1abeb76f592/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs#L279
which recreates the Academy instance.

There are some narrower fixes, like checking Academy.IsInitialized in GetObservationProto, or make RpcCommunicator early out when it has been shutdown (checking `m_IsOpen`). But in general it feels like a bug if the Agent is trying to do any sort of "work" when everything is shut down.

I'm currently targeting the release branch but I'd be willing to wait and make it on master instead if you think it's too risky/too late in the process.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [x] Bug fix

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
