### PR TITLE
[bug-fix] Fix visual PyTorch threaded export (2nd option)

### DIFF
--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -60,7 +60,7 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
             ):
                 visual_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 # Make sure to permute visual obs, as PyTorch uses NCHW
-                visual_obs.append(visual_ob.permute([0, 3, 1, 2]))
+                visual_obs.append(ModelUtils.nhwc_to_nchw(visual_ob))
         else:
             visual_obs = []
 
@@ -71,7 +71,7 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
             ModelUtils.list_to_tensor(vec_vis_obs.vector_observations).unsqueeze(0)
         ]
         next_vis_obs = [
-            ModelUtils.list_to_tensor(_vis_ob).unsqueeze(0).permute([0, 3, 1, 2])
+            ModelUtils.nhwc_to_nchw(ModelUtils.list_to_tensor(_vis_ob).unsqueeze(0))
             for _vis_ob in vec_vis_obs.visual_observations
         ]
 

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -59,7 +59,8 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
                 self.policy.actor_critic.network_body.visual_processors
             ):
                 visual_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
-                visual_obs.append(visual_ob)
+                # Make sure to permute visual obs, as PyTorch uses NCHW
+                visual_obs.append(visual_ob.permute([0, 3, 1, 2]))
         else:
             visual_obs = []
 
@@ -70,7 +71,7 @@ class TorchOptimizer(Optimizer):  # pylint: disable=W0223
             ModelUtils.list_to_tensor(vec_vis_obs.vector_observations).unsqueeze(0)
         ]
         next_vis_obs = [
-            ModelUtils.list_to_tensor(_vis_ob).unsqueeze(0)
+            ModelUtils.list_to_tensor(_vis_ob).unsqueeze(0).permute([0, 3, 1, 2])
             for _vis_ob in vec_vis_obs.visual_observations
         ]
 

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -180,8 +180,10 @@ class TorchPolicy(Policy):
         """
         vec_vis_obs, masks = self._split_decision_step(decision_requests)
         vec_obs = [torch.as_tensor(vec_vis_obs.vector_observations)]
+        # Make sure to permute visual obs, as PyTorch uses NCHW
         vis_obs = [
-            torch.as_tensor(vis_ob) for vis_ob in vec_vis_obs.visual_observations
+            torch.as_tensor(vis_ob).permute([0, 3, 1, 2])
+            for vis_ob in vec_vis_obs.visual_observations
         ]
         memories = torch.as_tensor(self.retrieve_memories(global_agent_ids)).unsqueeze(
             0

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -182,7 +182,7 @@ class TorchPolicy(Policy):
         vec_obs = [torch.as_tensor(vec_vis_obs.vector_observations)]
         # Make sure to permute visual obs, as PyTorch uses NCHW
         vis_obs = [
-            torch.as_tensor(vis_ob).permute([0, 3, 1, 2])
+            ModelUtils.nhwc_to_nchw(torch.as_tensor(vis_ob))
             for vis_ob in vec_vis_obs.visual_observations
         ]
         memories = torch.as_tensor(self.retrieve_memories(global_agent_ids)).unsqueeze(

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -154,7 +154,7 @@ class TorchPPOOptimizer(TorchOptimizer):
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 # Make sure to permute visual obs, as PyTorch uses NCHW
-                vis_obs.append(vis_ob.permute([0, 3, 1, 2]))
+                vis_obs.append(ModelUtils.nhwc_to_nchw(vis_ob))
         else:
             vis_obs = []
         log_probs, entropy, values = self.policy.evaluate_actions(

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -153,7 +153,8 @@ class TorchPPOOptimizer(TorchOptimizer):
                 self.policy.actor_critic.network_body.visual_processors
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
-                vis_obs.append(vis_ob)
+                # Make sure to permute visual obs, as PyTorch uses NCHW
+                vis_obs.append(vis_ob.permute([0, 3, 1, 2]))
         else:
             vis_obs = []
         log_probs, entropy, values = self.policy.evaluate_actions(

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -420,11 +420,11 @@ class TorchSACOptimizer(TorchOptimizer):
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
                 # Make sure to permute visual obs, as PyTorch uses NCHW
-                vis_obs.append(vis_ob.permute([0, 3, 1, 2]))
+                vis_obs.append(ModelUtils.nhwc_to_nchw(vis_ob))
                 next_vis_ob = ModelUtils.list_to_tensor(
                     batch["next_visual_obs%d" % idx]
                 )
-                next_vis_obs.append(next_vis_ob)
+                next_vis_obs.append(ModelUtils.nhwc_to_nchw(next_vis_ob))
 
         # Copy normalizers from policy
         self.value_network.q1_network.network_body.copy_normalization(

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -419,7 +419,8 @@ class TorchSACOptimizer(TorchOptimizer):
                 self.policy.actor_critic.network_body.visual_processors
             ):
                 vis_ob = ModelUtils.list_to_tensor(batch["visual_obs%d" % idx])
-                vis_obs.append(vis_ob)
+                # Make sure to permute visual obs, as PyTorch uses NCHW
+                vis_obs.append(vis_ob.permute([0, 3, 1, 2]))
                 next_vis_ob = ModelUtils.list_to_tensor(
                     batch["next_visual_obs%d" % idx]
                 )

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -160,7 +160,7 @@ class BCModule:
                 vis_ob = ModelUtils.list_to_tensor(
                     mini_batch_demo["visual_obs%d" % idx]
                 )
-                vis_obs.append(vis_ob)
+                vis_obs.append(ModelUtils.nhwc_to_nchw(vis_ob))
         else:
             vis_obs = []
 

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/curiosity_reward_provider.py
@@ -97,8 +97,10 @@ class CuriosityNetwork(torch.nn.Module):
                 ModelUtils.list_to_tensor(mini_batch["vector_obs"], dtype=torch.float)
             ],
             vis_inputs=[
-                ModelUtils.list_to_tensor(
-                    mini_batch["visual_obs%d" % i], dtype=torch.float
+                ModelUtils.nhwc_to_nchw(
+                    ModelUtils.list_to_tensor(
+                        mini_batch["visual_obs%d" % i], dtype=torch.float
+                    )
                 )
                 for i in range(n_vis)
             ],
@@ -117,8 +119,10 @@ class CuriosityNetwork(torch.nn.Module):
                 )
             ],
             vis_inputs=[
-                ModelUtils.list_to_tensor(
-                    mini_batch["next_visual_obs%d" % i], dtype=torch.float
+                ModelUtils.nhwc_to_nchw(
+                    ModelUtils.list_to_tensor(
+                        mini_batch["next_visual_obs%d" % i], dtype=torch.float
+                    )
                 )
                 for i in range(n_vis)
             ],

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -128,7 +128,11 @@ class DiscriminatorNetwork(torch.nn.Module):
             else []
         )
         vis_inputs = [
-            ModelUtils.list_to_tensor(mini_batch["visual_obs%d" % i], dtype=torch.float)
+            ModelUtils.nhwc_to_nchw(
+                ModelUtils.list_to_tensor(
+                    mini_batch["visual_obs%d" % i], dtype=torch.float
+                )
+            )
             for i in range(n_vis)
         ]
         return vec_inputs, vis_inputs

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -84,8 +84,6 @@ class NetworkBody(nn.Module):
 
         for idx, processor in enumerate(self.visual_processors):
             vis_input = vis_inputs[idx]
-            if not torch.onnx.is_in_onnx_export():
-                vis_input = vis_input.permute([0, 3, 1, 2])
             processed_vis = processor(vis_input)
             encodes.append(processed_vis)
 

--- a/ml-agents/mlagents/trainers/torch/utils.py
+++ b/ml-agents/mlagents/trainers/torch/utils.py
@@ -301,3 +301,7 @@ class ModelUtils:
         return (tensor.T * masks).sum() / torch.clamp(
             (torch.ones_like(tensor.T) * masks).float().sum(), min=1.0
         )
+
+    @staticmethod
+    def nhwc_to_nchw(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.permute([0, 3, 1, 2])


### PR DESCRIPTION
### Proposed change(s)

PyTorch and ONNX requires visual observations to be structured as NCHW, whereas TF and the LL-API uses NHWC. Before we were checking to see if we were exporting, and if not, we permute inputs to NCHW; otherwise, we don't. However this causes a race condition if exporting on a different thread. 

Fixes the ONNX export check race condition by not doing permute/check inside the network, instead doing the permute before data is fed into PyTorch networks. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Alternative to #4494 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
