### PR TITLE
WallJump - handle Agent starting before ModelOverrider

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
-    - uses: actions/setup-dotnet@v1.6.0
+    - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
     - run: dotnet tool install -g dotnet-format --version 4.1.131201

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v1.6.0
       with:
         dotnet-version: '3.1.x'
     - run: dotnet tool install -g dotnet-format --version 4.1.131201


### PR DESCRIPTION
### Proposed change(s)
Overriding WallJump behaviors wasn't working on CI (although it was working in the editor) because the Agent.OnEnabled() would be called first, before the ModelOverrider.OnEnable() could process the commandline arguments. This changes the code to process the commandline args lazily, and also does a bit of cleanup.

Additionally, do some future proofing and allow the extension of the override to be specified multiple times. The extensions will be tried in that order, and if no extension is specified, we’ll try .nn then .onnx (basically current behavior).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-855


### Types of change(s)

- [x] Bug fix
