### PR TITLE
fix extension

### DIFF
--- a/docs/Using-Virtual-Environment.md
+++ b/docs/Using-Virtual-Environment.md
@@ -58,7 +58,7 @@ then python3-distutils needs to be installed. Install python3-distutils using
 1. Create a folder where the virtual environments will reside `md python-envs`
 1. To create a new environment named `sample-env` execute
    `python -m venv python-envs\sample-env`
-1. To activate the environment execute `python-envs\sample-env\Scripts\activate`
+1. To activate the environment execute `python-envs\sample-env\Scripts\activate.bat`
 1. Upgrade to the latest pip version using `pip install --upgrade pip`
 1. To deactivate the environment execute `deactivate` (you can reactivate the
    environment using the same `activate` command listed above)


### PR DESCRIPTION
Added .bat extension to windows command to activate the virtual environment otherwise it won't work

### Proposed change(s)

I noticed that the command as listed isn't working because you need to add the .bat extension

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [X ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [X ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
