### PR TITLE
Add action_out function to distributions

### DIFF
--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -153,11 +153,7 @@ def test_simple_actor(action_type):
         [sample_obs], [], masks=masks
     )
     for act in actions:
-        # This is different from above for ONNX export
-        if action_type == ActionType.CONTINUOUS:
-            assert act.shape == (act_size[0], 1)
-        else:
-            assert act.shape == tuple(act_size)
+        assert act.shape == tuple(act_size)
 
     assert mem_size == 0
     assert is_cont == int(action_type == ActionType.CONTINUOUS)

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -33,7 +33,7 @@ class DistInstance(nn.Module, abc.ABC):
         pass
 
     @abc.abstractmethod
-    def action_out(self) -> torch.Tensor:
+    def exported_model_output(self) -> torch.Tensor:
         """
         Returns the tensor to be exported to ONNX for the distribution
         """
@@ -75,7 +75,7 @@ class GaussianDistInstance(DistInstance):
     def entropy(self):
         return 0.5 * torch.log(2 * math.pi * math.e * self.std + EPSILON)
 
-    def action_out(self):
+    def exported_model_output(self):
         return self.sample()
 
 
@@ -126,7 +126,7 @@ class CategoricalDistInstance(DiscreteDistInstance):
     def entropy(self):
         return -torch.sum(self.probs * torch.log(self.probs), dim=-1)
 
-    def action_out(self):
+    def exported_model_output(self):
         return self.all_log_prob()
 
 

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -32,6 +32,13 @@ class DistInstance(nn.Module, abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def action_out(self) -> torch.Tensor:
+        """
+        Returns the tensor to be exported to ONNX for the distribution
+        """
+        pass
+
 
 class DiscreteDistInstance(DistInstance):
     @abc.abstractmethod

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -68,6 +68,9 @@ class GaussianDistInstance(DistInstance):
     def entropy(self):
         return 0.5 * torch.log(2 * math.pi * math.e * self.std + EPSILON)
 
+    def action_out(self):
+        return self.sample()
+
 
 class TanhGaussianDistInstance(GaussianDistInstance):
     def __init__(self, mean, std):
@@ -115,6 +118,9 @@ class CategoricalDistInstance(DiscreteDistInstance):
 
     def entropy(self):
         return -torch.sum(self.probs * torch.log(self.probs), dim=-1)
+
+    def action_out(self):
+        return self.all_log_prob()
 
 
 class GaussianDistribution(nn.Module):

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -332,11 +332,7 @@ class SimpleActor(nn.Module, Actor):
         Note: This forward() method is required for exporting to ONNX. Don't modify the inputs and outputs.
         """
         dists, _ = self.get_dists(vec_inputs, vis_inputs, masks, memories, 1)
-        if self.act_type == ActionType.CONTINUOUS:
-            action_list = self.sample_action(dists)
-            action_out = torch.stack(action_list, dim=-1)
-        else:
-            action_out = torch.cat([dist.all_log_prob() for dist in dists], dim=1)
+        action_out = torch.cat([dist.action_out() for dist in dists], dim=1)
         return (
             action_out,
             self.version_number,

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -332,7 +332,7 @@ class SimpleActor(nn.Module, Actor):
         Note: This forward() method is required for exporting to ONNX. Don't modify the inputs and outputs.
         """
         dists, _ = self.get_dists(vec_inputs, vis_inputs, masks, memories, 1)
-        action_out = torch.cat([dist.action_out() for dist in dists], dim=1)
+        action_out = torch.cat([dist.exported_model_output() for dist in dists], dim=1)
         return (
             action_out,
             self.version_number,


### PR DESCRIPTION
### Proposed change(s)

Adds `action_out` to distributions so that the SimpleActor class does not need to know if the actions come from a continuous or discrete distribution in the forward pass. This is a slight refactor to clean up code and also facilitate hybrid action spaces.

This changes the onnx export structure for continuous actions. I tested the export/import on 3dball and it works.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
