### PR TITLE
[refactor] Optimize buffer sample_minibatch

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -220,8 +220,8 @@ class AgentBuffer(dict):
         )  # Sample random sequence starts
         for key in self:
             mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
-            # # See various ways to make a list from a list of lists here:
-            # # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
+            # See comparison of ways to make a list from a list of lists here:
+            # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
             mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))
         return mini_batch
 

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -210,7 +210,6 @@ class AgentBuffer(dict):
         :param sequence_length: Length of sequences to sample.
             Number of sequences to sample will be batch_size/sequence_length.
         """
-
         num_seq_to_sample = batch_size // sequence_length
         mini_batch = AgentBuffer()
         buff_len = self.num_experiences

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -1,6 +1,7 @@
 import numpy as np
 import h5py
 from typing import List, BinaryIO
+import itertools
 
 from mlagents_envs.exception import UnityException
 
@@ -209,6 +210,7 @@ class AgentBuffer(dict):
         :param sequence_length: Length of sequences to sample.
             Number of sequences to sample will be batch_size/sequence_length.
         """
+
         num_seq_to_sample = batch_size // sequence_length
         mini_batch = AgentBuffer()
         buff_len = self.num_experiences
@@ -217,9 +219,11 @@ class AgentBuffer(dict):
             np.random.randint(num_sequences_in_buffer, size=num_seq_to_sample)
             * sequence_length
         )  # Sample random sequence starts
-        for i in start_idxes:
-            for key in self:
-                mini_batch[key].extend(self[key][i : i + sequence_length])
+        for key in self:
+            mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
+            # # See various ways to make a list from a list of lists here:
+            # # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
+            mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))
         return mini_batch
 
     def save_to_file(self, file_object: BinaryIO) -> None:


### PR DESCRIPTION
### Proposed change(s)

Optimize experience replay buffer sampling. The old method used a loop across all elements, which was slow. Using an iterator and list comprehension, we get around 2.5x speedup for this method (0.0025s per batch of 64 to 0.001s). This results in a decent overall speedup (~10% for 3dball) for SAC. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
