### PR TITLE
[refactor] Don't compute grad for q2_p in SAC Optimizer

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -220,8 +220,8 @@ class AgentBuffer(dict):
         )  # Sample random sequence starts
         for key in self:
             mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
-            # # See various ways to make a list from a list of lists here:
-            # # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
+            # See comparison of ways to make a list from a list of lists here:
+            # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
             mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))
         return mini_batch
 

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -1,7 +1,6 @@
 import numpy as np
 import h5py
 from typing import List, BinaryIO
-import itertools
 
 from mlagents_envs.exception import UnityException
 
@@ -218,11 +217,9 @@ class AgentBuffer(dict):
             np.random.randint(num_sequences_in_buffer, size=num_seq_to_sample)
             * sequence_length
         )  # Sample random sequence starts
-        for key in self:
-            mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
-            # See comparison of ways to make a list from a list of lists here:
-            # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
-            mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))
+        for i in start_idxes:
+            for key in self:
+                mini_batch[key].extend(self[key][i : i + sequence_length])
         return mini_batch
 
     def save_to_file(self, file_object: BinaryIO) -> None:

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -210,7 +210,6 @@ class AgentBuffer(dict):
         :param sequence_length: Length of sequences to sample.
             Number of sequences to sample will be batch_size/sequence_length.
         """
-
         num_seq_to_sample = batch_size // sequence_length
         mini_batch = AgentBuffer()
         buff_len = self.num_experiences

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -1,6 +1,7 @@
 import numpy as np
 import h5py
 from typing import List, BinaryIO
+import itertools
 
 from mlagents_envs.exception import UnityException
 
@@ -209,6 +210,7 @@ class AgentBuffer(dict):
         :param sequence_length: Length of sequences to sample.
             Number of sequences to sample will be batch_size/sequence_length.
         """
+
         num_seq_to_sample = batch_size // sequence_length
         mini_batch = AgentBuffer()
         buff_len = self.num_experiences
@@ -217,9 +219,11 @@ class AgentBuffer(dict):
             np.random.randint(num_sequences_in_buffer, size=num_seq_to_sample)
             * sequence_length
         )  # Sample random sequence starts
-        for i in start_idxes:
-            for key in self:
-                mini_batch[key].extend(self[key][i : i + sequence_length])
+        for key in self:
+            mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
+            # # See various ways to make a list from a list of lists here:
+            # # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
+            mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))
         return mini_batch
 
     def save_to_file(self, file_object: BinaryIO) -> None:

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -13,6 +13,7 @@ from mlagents.trainers.buffer import AgentBuffer
 from mlagents_envs.timers import timed
 from mlagents.trainers.exception import UnityTrainerException
 from mlagents.trainers.settings import TrainerSettings, SACSettings
+from contextlib import ExitStack
 
 EPSILON = 1e-6  # Small value to avoid divide by zero
 
@@ -58,21 +59,29 @@ class TorchSACOptimizer(TorchOptimizer):
             actions: Optional[torch.Tensor] = None,
             memories: Optional[torch.Tensor] = None,
             sequence_length: int = 1,
+            q1_grad: bool = True,
+            q2_grad: bool = True,
         ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
-            q1_out, _ = self.q1_network(
-                vec_inputs,
-                vis_inputs,
-                actions=actions,
-                memories=memories,
-                sequence_length=sequence_length,
-            )
-            q2_out, _ = self.q2_network(
-                vec_inputs,
-                vis_inputs,
-                actions=actions,
-                memories=memories,
-                sequence_length=sequence_length,
-            )
+            with ExitStack() as stack:
+                if not q1_grad:
+                    stack.enter_context(torch.no_grad())
+                q1_out, _ = self.q1_network(
+                    vec_inputs,
+                    vis_inputs,
+                    actions=actions,
+                    memories=memories,
+                    sequence_length=sequence_length,
+                )
+            with ExitStack() as stack:
+                if not q2_grad:
+                    stack.enter_context(torch.no_grad())
+                q2_out, _ = self.q2_network(
+                    vec_inputs,
+                    vis_inputs,
+                    actions=actions,
+                    memories=memories,
+                    sequence_length=sequence_length,
+                )
             return q1_out, q2_out
 
     def __init__(self, policy: TorchPolicy, trainer_params: TrainerSettings):
@@ -450,12 +459,14 @@ class TorchSACOptimizer(TorchOptimizer):
         )
         if self.policy.use_continuous_act:
             squeezed_actions = actions.squeeze(-1)
+            # Only need grad for q1, as that is used for policy.
             q1p_out, q2p_out = self.value_network(
                 vec_obs,
                 vis_obs,
                 sampled_actions,
                 memories=q_memories,
                 sequence_length=self.policy.sequence_length,
+                q2_grad=False,
             )
             q1_out, q2_out = self.value_network(
                 vec_obs,
@@ -466,13 +477,14 @@ class TorchSACOptimizer(TorchOptimizer):
             )
             q1_stream, q2_stream = q1_out, q2_out
         else:
-            with torch.no_grad():
-                q1p_out, q2p_out = self.value_network(
-                    vec_obs,
-                    vis_obs,
-                    memories=q_memories,
-                    sequence_length=self.policy.sequence_length,
-                )
+            q1p_out, q2p_out = self.value_network(
+                vec_obs,
+                vis_obs,
+                memories=q_memories,
+                sequence_length=self.policy.sequence_length,
+                q1_grad=False,
+                q2_grad=False,
+            )
             q1_out, q2_out = self.value_network(
                 vec_obs,
                 vis_obs,

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -62,6 +62,21 @@ class TorchSACOptimizer(TorchOptimizer):
             q1_grad: bool = True,
             q2_grad: bool = True,
         ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+            """
+            Performs a forward pass on the value network, which consists of a Q1 and Q2
+            network. Optionally does not evaluate gradients for either the Q1, Q2, or both.
+            :param vec_inputs: List of vector observation tensors.
+            :param vis_input: List of visual observation tensors.
+            :param actions: For a continuous Q function (has actions), tensor of actions.
+                Otherwise, None.
+            :param memories: Initial memories if using memory. Otherwise, None.
+            :param sequence_length: Sequence length if using memory.
+            :param q1_grad: Whether or not to compute gradients for the Q1 network.
+            :param q2_grad: Whether or not to compute gradients for the Q2 network.
+            :return: Tuple of two dictionaries, which both map {reward_signal: Q} for Q1 and Q2,
+                respectively.
+            """
+            # ExitStack allows us to enter the torch.no_grad() context conditionally
             with ExitStack() as stack:
                 if not q1_grad:
                     stack.enter_context(torch.no_grad())

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -477,6 +477,7 @@ class TorchSACOptimizer(TorchOptimizer):
             )
             q1_stream, q2_stream = q1_out, q2_out
         else:
+            # For discrete, you don't need to backprop through the Q for the policy
             q1p_out, q2p_out = self.value_network(
                 vec_obs,
                 vis_obs,


### PR DESCRIPTION
### Proposed change(s)

The forward pass for the second Q network is used for updating the Value head, but no gradient is needed (Q1 is needed for the Policy network). This PR makes computing gradients optional for the SAC Q networks, and turns it off when necessary. For continuous (3DBall), we see around ~4% improvement in training time. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
