### PR TITLE
Adding correst setup commands for verifying torch is installed

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest>4.0.0,<6.0.0
 pytest-cov==2.6.1
 pytest-xdist==1.34.0
 
-# PyTorch tests are here for the time being, before they are used in the codebase.
-torch>=1.5.0
+# Tensorflow tests are here for the time being, before they are used in the codebase.
+tensorflow>=1.14,<3.0
 
 tf2onnx>=1.5.5


### PR DESCRIPTION
### Proposed change(s)

This should fix the test. 
On Windows, the user will see an error message when installing if they do not have torch installed.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
