### PR TITLE
Fixing CPU resource allocation for new CI

### DIFF
--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -2,9 +2,6 @@ from typing import Optional
 
 import os
 
-from mlagents_envs.logging_util import get_logger
-logger = get_logger(__name__)
-
 
 def get_num_threads_to_use() -> Optional[int]:
     """
@@ -25,14 +22,6 @@ def _get_num_available_cpus() -> Optional[int]:
     quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
     share = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.shares")
     is_kubernetes = os.getenv("KUBERNETES_SERVICE_HOST") is not None
-
-    logger.error("period " + str(period))
-    logger.error("quota " + str(quota))
-    logger.error("share " + str(share))
-    logger.error("is_kubernetes " + str(is_kubernetes))
-
-    print("AAAAAAAAAAAAAAAAAAAAAAAAAA")
-
 
     if period > 0 and quota > 0:
         return int(quota // period)

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -20,7 +20,7 @@ def _get_num_available_cpus() -> Optional[int]:
     """
     period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
     quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
-    share = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.share")
+    share = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.shares")
     if period > 0 and quota > 0:
         return int(quota // period)
     elif period > 0 and share > 0:

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import os
 
+from mlagents_envs.logging_util import get_logger
+logger = get_logger(__name__)
+
 
 def get_num_threads_to_use() -> Optional[int]:
     """
@@ -21,10 +24,20 @@ def _get_num_available_cpus() -> Optional[int]:
     period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
     quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
     share = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.shares")
+    is_kubernetes = os.getenv("KUBERNETES_SERVICE_HOST") is not None
+
+    logger.error("period " + str(period))
+    logger.error("quota " + str(quota))
+    logger.error("share " + str(share))
+    logger.error("is_kubernetes " + str(is_kubernetes))
+
+    print("AAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+
     if period > 0 and quota > 0:
         return int(quota // period)
-    elif period > 0 and share > 0:
-        # In docker, each requested CPU is 1024 CPU shares
+    elif period > 0 and share > 0 and is_kubernetes:
+        # In kubernetes, each requested CPU is 1024 CPU shares
         # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run
         return int(share // 1024)
     else:

--- a/ml-agents/mlagents/torch_utils/cpu_utils.py
+++ b/ml-agents/mlagents/torch_utils/cpu_utils.py
@@ -20,8 +20,13 @@ def _get_num_available_cpus() -> Optional[int]:
     """
     period = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
     quota = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    share = _read_in_integer_file("/sys/fs/cgroup/cpu/cpu.share")
     if period > 0 and quota > 0:
         return int(quota // period)
+    elif period > 0 and share > 0:
+        # In docker, each requested CPU is 1024 CPU shares
+        # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run
+        return int(share // 1024)
     else:
         return os.cpu_count()
 


### PR DESCRIPTION
### Proposed change(s)

If running on kubernetes, if no CPU limits are specified, our current code will assume all CPUs are available.
This causes issues with the new cloud CI as no limits are specified on the container. 
As a solution, we use the number of CPU shares for which 1 CPU = 1024 CPU_SHARES (Note that this equality is only valid in Docker)
Kubernetes will set the CPU shares to 1024 * resources.request.cpu

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
