### PR TITLE
Add 8D tensor test if newer barracuda is installed

### DIFF
--- a/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
@@ -19,7 +19,7 @@ namespace Unity.MLAgents.Tests
                 // Unfortunately, the PackageInfo methods don't exist in earlier versions of the editor,
                 // so just skip that variant of the test then.
                 // It's unlikely, but possible that we'll upgrade to a newer dependency of Barracuda,
-                // in which case we should make sure this test kicks in the.
+                // in which case we should make sure this test is run then.
 #if UNITY_2019_3_OR_NEWER
                 var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(Tensor).Assembly);
                 Assert.AreEqual("com.unity.barracuda", packageInfo.name);

--- a/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/TensorUtilsTest.cs
@@ -9,8 +9,31 @@ namespace Unity.MLAgents.Tests
     public class TensorUtilsTest
     {
         [TestCase(4, TestName = "TestResizeTensor_4D")]
+        [TestCase(8, TestName = "TestResizeTensor_8D")]
         public void TestResizeTensor(int dimension)
         {
+            if (dimension == 8)
+            {
+                // Barracuda 1.0.x doesn't support 8D tensors
+                // Barracuda 1.1.x does but it initially broke ML-Agents support
+                // Unfortunately, the PackageInfo methods don't exist in earlier versions of the editor,
+                // so just skip that variant of the test then.
+                // It's unlikely, but possible that we'll upgrade to a newer dependency of Barracuda,
+                // in which case we should make sure this test kicks in the.
+#if UNITY_2019_3_OR_NEWER
+                var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(Tensor).Assembly);
+                Assert.AreEqual("com.unity.barracuda", packageInfo.name);
+                var barracuda8DSupport = new Version(1, 1, 0);
+                var strippedBarracudaVersion = packageInfo.version.Replace("-preview", "");
+                var version = new Version(strippedBarracudaVersion);
+                if (version <= barracuda8DSupport)
+                {
+                    return;
+                }
+#else
+                return;
+#endif
+            }
             var alloc = new TensorCachingAllocator();
             var height = 64;
             var width = 84;


### PR DESCRIPTION
### Proposed change(s)
I wasn't sure if this was going to work so I didn't mention it on the other PR.

It's unlikely, but if we ever upgrade this branch to barracuda 1.1.x, we'll want the 8D tensor test back. This checks the package version, and if it's newer run the test, otherwise just exit early.

On 2018.4 there's no API to get the package version, so just skip (other versions will still run the test, so it's better than nothing).

Manually tested with breakpoints and updating the package.
