### PR TITLE
[bug-fix] Change entropy computation and loss reporting in Torch to match TF

### DIFF
--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -153,8 +153,14 @@ class TorchPolicy(Policy):
             actions = actions[:, :, 0]
         else:
             actions = actions[:, 0, :]
-
-        return (actions, all_logs if all_log_probs else log_probs, entropies, memories)
+        # Use the sum of entropy across actions, not the mean
+        entropy_sum = torch.sum(entropies, dim=1)
+        return (
+            actions,
+            all_logs if all_log_probs else log_probs,
+            entropy_sum,
+            memories,
+        )
 
     def evaluate_actions(
         self,

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -176,8 +176,9 @@ class TorchPolicy(Policy):
         )
         action_list = [actions[..., i] for i in range(actions.shape[-1])]
         log_probs, entropies, _ = ModelUtils.get_probs_and_entropy(action_list, dists)
-
-        return log_probs, entropies, value_heads
+        # Use the sum of entropy across actions, not the mean
+        entropy_sum = torch.sum(entropies, dim=1)
+        return log_probs, entropy_sum, value_heads
 
     @timed
     def evaluate(

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -187,6 +187,8 @@ class TorchPPOOptimizer(TorchOptimizer):
 
         self.optimizer.step()
         update_stats = {
+            # NOTE: abs() is not technically correct, but matches the behavior in TensorFlow.
+            # TODO: After PyTorch is default, change to something more correct.
             "Losses/Policy Loss": torch.abs(policy_loss).item(),
             "Losses/Value Loss": value_loss.item(),
             "Policy/Learning Rate": decay_lr,

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -174,10 +174,12 @@ class TorchPPOOptimizer(TorchOptimizer):
             ModelUtils.list_to_tensor(batch["action_probs"]),
             loss_masks,
         )
+        # Use the sum of entropy across actions, not the mean
+        entropy_sum = torch.sum(entropy, dim=1)
         loss = (
             policy_loss
             + 0.5 * value_loss
-            - decay_bet * ModelUtils.masked_mean(entropy, loss_masks)
+            - decay_bet * ModelUtils.masked_mean(entropy_sum, loss_masks)
         )
 
         # Set optimizer learning rate

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -174,7 +174,6 @@ class TorchPPOOptimizer(TorchOptimizer):
             ModelUtils.list_to_tensor(batch["action_probs"]),
             loss_masks,
         )
-
         loss = (
             policy_loss
             + 0.5 * value_loss

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -174,12 +174,11 @@ class TorchPPOOptimizer(TorchOptimizer):
             ModelUtils.list_to_tensor(batch["action_probs"]),
             loss_masks,
         )
-        # Use the sum of entropy across actions, not the mean
-        entropy_sum = torch.sum(entropy, dim=1)
+
         loss = (
             policy_loss
             + 0.5 * value_loss
-            - decay_bet * ModelUtils.masked_mean(entropy_sum, loss_masks)
+            - decay_bet * ModelUtils.masked_mean(entropy, loss_masks)
         )
 
         # Set optimizer learning rate
@@ -189,7 +188,7 @@ class TorchPPOOptimizer(TorchOptimizer):
 
         self.optimizer.step()
         update_stats = {
-            "Losses/Policy Loss": policy_loss.item(),
+            "Losses/Policy Loss": torch.abs(policy_loss).item(),
             "Losses/Value Loss": value_loss.item(),
             "Policy/Learning Rate": decay_lr,
             "Policy/Epsilon": decay_eps,

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -251,7 +251,7 @@ class PPOTrainer(RLTrainer):
             behavior_spec,
             self.trainer_settings,
             condition_sigma_on_obs=False,  # Faster training for PPO
-            separate_critic=True,
+            separate_critic=behavior_spec.is_action_continuous(),
         )
         return policy
 

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -251,7 +251,7 @@ class PPOTrainer(RLTrainer):
             behavior_spec,
             self.trainer_settings,
             condition_sigma_on_obs=False,  # Faster training for PPO
-            separate_critic=behavior_spec.is_action_continuous(),
+            separate_critic=True,
         )
         return policy
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -136,7 +136,7 @@ def test_sample_actions(rnn, visual, discrete):
         )
     else:
         assert log_probs.shape == (64, policy.behavior_spec.action_shape)
-    assert entropies.shape == (64, policy.behavior_spec.action_size)
+    assert entropies.shape == (64,)
 
     if rnn:
         assert memories.shape == (1, 1, policy.m_size)

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -93,7 +93,7 @@ def test_evaluate_actions(rnn, visual, discrete):
         seq_len=policy.sequence_length,
     )
     assert log_probs.shape == (64, policy.behavior_spec.action_size)
-    assert entropy.shape == (64, policy.behavior_spec.action_size)
+    assert entropy.shape == (64,)
     for val in values.values():
         assert val.shape == (64,)
 

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -153,7 +153,8 @@ class GaussianDistribution(nn.Module):
         if self.conditional_sigma:
             log_sigma = torch.clamp(self.log_sigma(inputs), min=-20, max=2)
         else:
-            log_sigma = self.log_sigma
+            # Expand so that entropy matches batch size
+            log_sigma = self.log_sigma.expand(inputs.shape[0], -1)
         if self.tanh_squash:
             return [TanhGaussianDistInstance(mu, torch.exp(log_sigma))]
         else:


### PR DESCRIPTION
### Proposed change(s)

Entropy was being treated differently in Torch than in TF (TF took the sum of all the entropy across the actions, and Torch did the mean). Furthermore, TF took the absolute value of policy loss in PPO. This PR makes both of these match TF for easier debugging, consistent entropy bonus magnitude, and more consistent user behavior. 

For continuous actions in PPO, entropy was also a single value - and not reported for every action in the batch. This PR also fixes that bug. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
