### PR TITLE
Add useVectorFrozenFlag option in FoodCollector

### DIFF
--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Prefabs/VisualFoodCollectorArea.prefab
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Prefabs/VisualFoodCollectorArea.prefab
@@ -663,7 +663,7 @@ MonoBehaviour:
   myLaser: {fileID: 1900094563283840}
   contribute: 0
   useVectorObs: 0
-  useFrozenFlag: 1
+  useVectorFrozenFlag: 1
 --- !u!114 &114326390494230518
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -681,6 +681,7 @@ MonoBehaviour:
   m_Width: 84
   m_Height: 84
   m_Grayscale: 0
+  m_ObservationStacks: 1
   m_Compression: 1
 --- !u!114 &4034342608499629224
 MonoBehaviour:
@@ -1246,7 +1247,7 @@ MonoBehaviour:
   myLaser: {fileID: 1307818939507544}
   contribute: 0
   useVectorObs: 0
-  useFrozenFlag: 1
+  useVectorFrozenFlag: 1
 --- !u!114 &114429222608880102
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1264,6 +1265,7 @@ MonoBehaviour:
   m_Width: 84
   m_Height: 84
   m_Grayscale: 0
+  m_ObservationStacks: 1
   m_Compression: 1
 --- !u!114 &7234640249101665162
 MonoBehaviour:
@@ -1643,7 +1645,7 @@ MonoBehaviour:
   myLaser: {fileID: 1898252046043334}
   contribute: 0
   useVectorObs: 0
-  useFrozenFlag: 1
+  useVectorFrozenFlag: 1
 --- !u!114 &114036270357198286
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1661,6 +1663,7 @@ MonoBehaviour:
   m_Width: 84
   m_Height: 84
   m_Grayscale: 0
+  m_ObservationStacks: 1
   m_Compression: 1
 --- !u!114 &3164735207755090463
 MonoBehaviour:
@@ -3460,7 +3463,7 @@ MonoBehaviour:
   myLaser: {fileID: 1779831409734062}
   contribute: 0
   useVectorObs: 0
-  useFrozenFlag: 1
+  useVectorFrozenFlag: 1
 --- !u!114 &114322691115031348
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3478,6 +3481,7 @@ MonoBehaviour:
   m_Width: 84
   m_Height: 84
   m_Grayscale: 0
+  m_ObservationStacks: 1
   m_Compression: 1
 --- !u!114 &5903164052970896384
 MonoBehaviour:

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -30,6 +30,10 @@ public class FoodCollectorAgent : Agent
     public GameObject myLaser;
     public bool contribute;
     public bool useVectorObs;
+    [Tooltip("Use only the frozen flag in vector observations. If \"Use Vector Obs\" " +
+             "is checked, this option has no effect. This option is necessary for the " +
+             "VisualFoodCollector scene.")]
+    public bool useVectorFrozenFlag;
 
     EnvironmentParameters m_ResetParams;
 
@@ -49,9 +53,13 @@ public class FoodCollectorAgent : Agent
             var localVelocity = transform.InverseTransformDirection(m_AgentRb.velocity);
             sensor.AddObservation(localVelocity.x);
             sensor.AddObservation(localVelocity.z);
+            sensor.AddObservation(m_Frozen);
             sensor.AddObservation(m_Shoot);
         }
-        sensor.AddObservation(m_Frozen);
+        else if (useVectorFrozenFlag)
+        {
+            sensor.AddObservation(m_Frozen);
+        }
     }
 
     public Color32 ToColor(int hexVal)


### PR DESCRIPTION
### Proposed change(s)

Bring back useVectorFrozenFlag option that was originally proposed in #4511 , since adding it as default will cause GridFoodCollector to crash.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
