### PR TITLE
update barracuda version, enable tests for 2020.2

### DIFF
--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -1,6 +1,14 @@
 # List of editor versions for standalone-build-test and its dependencies.
+# csharp_backcompat_version is used in training-int-tests to determine the
+# older package version to run the backwards compat tests against.
 test_editors:
   - version: 2018.4
+    csharp_backcompat_version: 1.0.0
   - version: 2019.4
+    csharp_backcompat_version: 1.0.0
   - version: 2020.1
+    csharp_backcompat_version: 1.0.0
   - version: 2020.2
+    # 2020.2 moved the AssetImporters namespace
+    # but we didn't handle this until 1.2.0
+    csharp_backcompat_version: 1.2.0

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -3,5 +3,4 @@ test_editors:
   - version: 2018.4
   - version: 2019.4
   - version: 2020.1
-# Waiting on a barracuda fix, see https://jira.unity3d.com/browse/MLA-1464
-#  - version: 2020.2
+  - version: 2020.2

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -19,7 +19,7 @@ test_mac_training_int_{{ editor.version }}:
     # If we make a breaking change to the communication protocol, these will need
     # to be disabled until the next release.
     - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.16.0
-    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp=1.0.0
+    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp={{ editor.csharp_backcompat_version }}
   dependencies:
     - .yamato/standalone-build-test.yml#test_mac_standalone_{{ editor.version }}
   triggers:

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)
+- The Barracuda dependency was upgraded to 1.1.2 (#4571)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Bug Fixes

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,7 +5,7 @@
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.barracuda": "1.1.1-preview",
+    "com.unity.barracuda": "1.1.2-preview",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.physics": "1.0.0",

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -150,10 +150,11 @@ def checkout_csharp_version(csharp_version):
         return
 
     csharp_tag = f"com.unity.ml-agents_{csharp_version}"
-    csharp_dirs = ["com.unity.ml-agents", "Project"]
+    csharp_dirs = ["com.unity.ml-agents", "com.unity.ml-agents.extensions", "Project"]
     for csharp_dir in csharp_dirs:
         subprocess.check_call(f"rm -rf {csharp_dir}", shell=True)
-        subprocess.check_call(f"git checkout {csharp_tag} -- {csharp_dir}", shell=True)
+        # Allow the checkout to fail, since the extensions folder isn't availabe in 1.0.0
+        subprocess.call(f"git checkout {csharp_tag} -- {csharp_dir}", shell=True)
 
 
 def undo_git_checkout():


### PR DESCRIPTION
### Proposed change(s)
Upgrade barracuda dependency to 1.1.2-preview. This contains a fix for 2020.2, so we can re-enable that in the test versions.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1464

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
