### PR TITLE
[bug-fix] Use proper masking for entropy and policy losses

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -335,7 +335,8 @@ class TorchSACOptimizer(TorchOptimizer):
                     for i, (_lp, _qt) in enumerate(
                         zip(branched_per_action_ent, branched_q_term)
                     )
-                ]
+                ],
+                dim=1,
             )
             batch_policy_loss = torch.squeeze(branched_policy_loss)
             policy_loss = ModelUtils.masked_mean(batch_policy_loss, loss_masks)

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -338,7 +338,7 @@ class TorchSACOptimizer(TorchOptimizer):
                 ]
             )
             batch_policy_loss = torch.squeeze(branched_policy_loss)
-        policy_loss = torch.mean(loss_masks * batch_policy_loss)
+            policy_loss = ModelUtils.masked_mean(batch_policy_loss, loss_masks)
         return policy_loss
 
     def sac_entropy_loss(
@@ -347,8 +347,8 @@ class TorchSACOptimizer(TorchOptimizer):
         if not discrete:
             with torch.no_grad():
                 target_current_diff = torch.sum(log_probs + self.target_entropy, dim=1)
-            entropy_loss = -torch.mean(
-                self._log_ent_coef * loss_masks * target_current_diff
+            entropy_loss = -1 * ModelUtils.masked_mean(
+                self._log_ent_coef * target_current_diff, loss_masks
             )
         else:
             with torch.no_grad():


### PR DESCRIPTION
### Proposed change(s)

Some entropy and policy losses weren't using the `masked_mean` function - this fixes that. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
