### PR TITLE
[MLA-1474] detect recursion on Agent methods and throw

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
+- `Agent.CollectObservations()` and `Agent.EndEpisode()` will now throw an exception
+if they are called recursively (for example, if they call `Agent.EndEpisode()`).
+Previously, this would result in an infinite loop and cause the editor to hang. (#4573)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -25,26 +25,6 @@ using Unity.Barracuda;
 
 namespace Unity.MLAgents
 {
-    internal class RecursionChecker : IDisposable
-    {
-        private bool m_IsRunning;
-
-        public IDisposable Start()
-        {
-            if (m_IsRunning)
-            {
-                throw new UnityAgentsException("Don't do this.");
-            }
-            m_IsRunning = true;
-            return this;
-        }
-
-        public void Dispose()
-        {
-            m_IsRunning = false;
-        }
-    }
-
     /// <summary>
     /// Helper class to step the Academy during FixedUpdate phase.
     /// </summary>

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -155,9 +155,9 @@ namespace Unity.MLAgents
         // Flag used to keep track of the first time the Academy is reset.
         bool m_HadFirstReset;
 
-        // Whether the Academy is in the middle of a step. This is used to detect and Academy
+        // Whether the Academy is in the middle of a step. This is used to detect an Academy
         // step called by user code that is also called by the Academy.
-        private RecursionChecker m_StepRecursionChecker = new RecursionChecker();
+        private RecursionChecker m_StepRecursionChecker = new RecursionChecker("EnvironmentStep");
 
         // Random seed used for inference.
         int m_InferenceSeed;

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -155,8 +155,7 @@ namespace Unity.MLAgents
         // Flag used to keep track of the first time the Academy is reset.
         bool m_HadFirstReset;
 
-        // Whether the Academy is in the middle of a step. This is used to detect an Academy
-        // step called by user code that is also called by the Academy.
+        // Detect an Academy step called by user code that is also called by the Academy.
         private RecursionChecker m_StepRecursionChecker = new RecursionChecker("EnvironmentStep");
 
         // Random seed used for inference.

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -283,8 +283,8 @@ namespace Unity.MLAgents
         /// </summary>
         internal VectorSensor collectObservationsSensor;
 
-        private RecursionChecker m_CollectObservationsChecker = new RecursionChecker();
-        private RecursionChecker m_OnEpisodeBeginChecker = new RecursionChecker();
+        private RecursionChecker m_CollectObservationsChecker = new RecursionChecker("CollectObservations");
+        private RecursionChecker m_OnEpisodeBeginChecker = new RecursionChecker("OnEpisodeBegin");
 
         /// <summary>
         /// List of IActuators that this Agent will delegate actions to if any exist.

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -283,6 +283,9 @@ namespace Unity.MLAgents
         /// </summary>
         internal VectorSensor collectObservationsSensor;
 
+        private RecursionChecker m_CollectObservationsChecker = new RecursionChecker();
+        private RecursionChecker m_OnEpisodeBeginChecker = new RecursionChecker();
+
         /// <summary>
         /// List of IActuators that this Agent will delegate actions to if any exist.
         /// </summary>
@@ -435,7 +438,10 @@ namespace Unity.MLAgents
             // episode when initializing until after the Academy had its first reset.
             if (Academy.Instance.TotalStepCount != 0)
             {
-                OnEpisodeBegin();
+                using (m_OnEpisodeBeginChecker.Start())
+                {
+                    OnEpisodeBegin();
+                }
             }
         }
 
@@ -512,7 +518,10 @@ namespace Unity.MLAgents
             {
                 // Make sure the latest observations are being passed to training.
                 collectObservationsSensor.Reset();
-                CollectObservations(collectObservationsSensor);
+                using (m_CollectObservationsChecker.Start())
+                {
+                    CollectObservations(collectObservationsSensor);
+                }
             }
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately
@@ -1006,7 +1015,10 @@ namespace Unity.MLAgents
             UpdateSensors();
             using (TimerStack.Instance.Scoped("CollectObservations"))
             {
-                CollectObservations(collectObservationsSensor);
+                using (m_CollectObservationsChecker.Start())
+                {
+                    CollectObservations(collectObservationsSensor);
+                }
             }
             using (TimerStack.Instance.Scoped("CollectDiscreteActionMasks"))
             {
@@ -1229,7 +1241,11 @@ namespace Unity.MLAgents
         {
             ResetData();
             m_StepCount = 0;
-            OnEpisodeBegin();
+            using (m_OnEpisodeBeginChecker.Start())
+            {
+                OnEpisodeBegin();
+            }
+
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/RecursionChecker.cs
+++ b/com.unity.ml-agents/Runtime/RecursionChecker.cs
@@ -5,12 +5,22 @@ namespace Unity.MLAgents
     internal class RecursionChecker : IDisposable
     {
         private bool m_IsRunning;
+        private string m_MethodName;
+
+        public RecursionChecker(string methodName)
+        {
+            m_MethodName = methodName;
+        }
 
         public IDisposable Start()
         {
             if (m_IsRunning)
             {
-                throw new UnityAgentsException("Don't do this.");
+                throw new UnityAgentsException(
+                    $"{m_MethodName} called recursively. " +
+                    "This might happen if you call EnvironmentStep() or EndEpisode() from custom " +
+                    "code such as CollectObservations() or OnActionReceived()."
+                );
             }
             m_IsRunning = true;
             return this;

--- a/com.unity.ml-agents/Runtime/RecursionChecker.cs
+++ b/com.unity.ml-agents/Runtime/RecursionChecker.cs
@@ -28,6 +28,7 @@ namespace Unity.MLAgents
 
         public void Dispose()
         {
+            // Reset the flag when we're done (or if an exception occurred).
             m_IsRunning = false;
         }
     }

--- a/com.unity.ml-agents/Runtime/RecursionChecker.cs
+++ b/com.unity.ml-agents/Runtime/RecursionChecker.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Unity.MLAgents
+{
+    internal class RecursionChecker : IDisposable
+    {
+        private bool m_IsRunning;
+
+        public IDisposable Start()
+        {
+            if (m_IsRunning)
+            {
+                throw new UnityAgentsException("Don't do this.");
+            }
+            m_IsRunning = true;
+            return this;
+        }
+
+        public void Dispose()
+        {
+            m_IsRunning = false;
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/RecursionChecker.cs.meta
+++ b/com.unity.ml-agents/Runtime/RecursionChecker.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 49ebd06532b24078a6edda823aeff5d2
+timeCreated: 1602731302

--- a/com.unity.ml-agents/Tests/Editor/RecursionCheckerTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/RecursionCheckerTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+
+namespace Unity.MLAgents.Tests
+{
+    [TestFixture]
+    public class RecursionCheckerTests
+    {
+        class InfiniteRecurser
+        {
+            RecursionChecker m_checker = new RecursionChecker("InfiniteRecurser");
+            public int NumCalls = 0;
+
+            public void Implode()
+            {
+                NumCalls++;
+                using (m_checker.Start())
+                {
+                    Implode();
+                }
+            }
+        }
+
+        [Test]
+        public void TestRecursionCheck()
+        {
+            var rc = new InfiniteRecurser();
+            Assert.Throws<UnityAgentsException>(() =>
+            {
+                rc.Implode();
+            });
+
+            // Should increment twice before bailing out.
+            Assert.AreEqual(2, rc.NumCalls);
+        }
+    }
+}

--- a/com.unity.ml-agents/Tests/Editor/RecursionCheckerTests.cs.meta
+++ b/com.unity.ml-agents/Tests/Editor/RecursionCheckerTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a7183e11dd5434684a4225c80169173
+timeCreated: 1602781778


### PR DESCRIPTION
### Proposed change(s)
It was possible for user implementations of Agent.CollectObservations() and Agent.OnEpisodeBegin() to get stuck in infinite recursion if EndEpisode was called from them. We now detect the recursive calls and throw an exception.

This generalizes the approach from a similar issue on Academy.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Fixes some (but not all) of the concerns in https://github.com/Unity-Technologies/ml-agents/issues/4558
https://jira.unity3d.com/browse/MLA-1474
https://github.com/Unity-Technologies/ml-agents/pull/4227


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
