### PR TITLE
Assign new BrainParametersProto fields based on capabilities

### DIFF
--- a/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
@@ -81,7 +81,8 @@ namespace Unity.MLAgents.Actuators
         {
             if (NumContinuousActions > 0 && NumDiscreteActions > 0)
             {
-                throw new UnityAgentsException("ActionSpecs must be all continuous or all discrete.");
+                throw new UnityAgentsException("Hybrid action spaces not supported by the trainer. " +
+                    "ActionSpecs must be all continuous or all discrete.");
             }
         }
     }


### PR DESCRIPTION
### Proposed change(s)

Assign new ActionSpec fields in BrainParametersProto.
Fill deprecated fields if trainer does not support (based on capabilities).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
JIRA: [MLA-1316](https://jira.unity3d.com/browse/MLA-1316)


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
