### PR TITLE
[refactor] Add --tensorflow, enable Torch as default setting

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 ### Major Changes
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+ - PyTorch trainers are now the default. See the
+ [installation docs](https://github.com/Unity-Technologies/ml-agents/blob/mastere/docs/Installation.md) for
+ more information on installing PyTorch. For the time being, TensorFlow is still available;
+ you can use the TensorFlow backend by adding `--tensorflow` to the CLI, or
+ adding `framework: tensorflow` in the configuration YAML. (#4517)
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -169,11 +169,18 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Forces training using CPU only",
     )
     argparser.add_argument(
+        "--torch",
+        default=False,
+        action=DetectDefaultStoreTrue,
+        help="Use the PyTorch framework. Note that this option is not required anymore as PyTorch is the"
+        "default framework, and will be removed in the next release.",
+    )
+    argparser.add_argument(
         "--tensorflow",
         default=False,
         action=DetectDefaultStoreTrue,
         help="(Deprecated) Use the TensorFlow framework instead of PyTorch. Install TensorFlow "
-        "before using this option",
+        "before using this option.",
     )
 
     eng_conf = argparser.add_argument_group(title="Engine Configuration")

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -169,10 +169,10 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Forces training using CPU only",
     )
     argparser.add_argument(
-        "--torch",
+        "--tensorflow",
         default=False,
         action=DetectDefaultStoreTrue,
-        help="(Experimental) Use the PyTorch framework instead of TensorFlow. Install PyTorch "
+        help="(Deprecated) Use the TensorFlow framework instead of PyTorch. Install TensorFlow "
         "before using this option",
     )
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -135,6 +135,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
             param_manager=env_parameter_manager,
             init_path=maybe_init_path,
             multi_gpu=False,
+            force_torch="torch" in DetectDefault.non_default_args,
             force_tensorflow="tensorflow" in DetectDefault.non_default_args,
         )
         # Create controller and begin training.

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -135,7 +135,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
             param_manager=env_parameter_manager,
             init_path=maybe_init_path,
             multi_gpu=False,
-            force_torch="torch" in DetectDefault.non_default_args,
+            force_tensorflow="tensorflow" in DetectDefault.non_default_args,
         )
         # Create controller and begin training.
         tc = TrainerController(

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -620,7 +620,7 @@ class TrainerSettings(ExportableSettings):
     threaded: bool = True
     self_play: Optional[SelfPlaySettings] = None
     behavioral_cloning: Optional[BehavioralCloningSettings] = None
-    framework: FrameworkType = FrameworkType.TENSORFLOW
+    framework: FrameworkType = FrameworkType.PYTORCH
 
     cattr.register_structure_hook(
         Dict[RewardSignalType, RewardSignalSettings], RewardSignalSettings.structure

--- a/ml-agents/mlagents/trainers/trainer/trainer_factory.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer_factory.py
@@ -81,7 +81,7 @@ class TrainerFactory:
             )
             if self._force_torch:
                 logger.warning(
-                    "Both Torch and TensorFlow CLI options were specified. Using TensorFlow."
+                    "Both --torch and --tensorflow CLI options were specified. Using TensorFlow."
                 )
         return TrainerFactory._initialize_trainer(
             trainer_settings,

--- a/ml-agents/mlagents/trainers/trainer/trainer_factory.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer_factory.py
@@ -26,6 +26,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
+        force_torch: bool = False,
         force_tensorflow: bool = False,
     ):
         """
@@ -45,7 +46,9 @@ class TrainerFactory:
         :param init_path: Path from which to load model.
         :param multi_gpu: If True, multi-gpu will be used. (currently not available)
         :param force_torch: If True, the Trainers will all use the PyTorch framework
-        instead of the TensorFlow framework.
+        instead of what is specified in the config YAML.
+        :param force_tensorflow: If True, thee Trainers will all use the TensorFlow
+        framework.
         """
         self.trainer_config = trainer_config
         self.output_path = output_path
@@ -56,6 +59,7 @@ class TrainerFactory:
         self.param_manager = param_manager
         self.multi_gpu = multi_gpu
         self.ghost_controller = GhostController()
+        self._force_torch = force_torch
         self._force_tf = force_tensorflow
 
     def generate(self, behavior_name: str) -> Trainer:
@@ -65,8 +69,20 @@ class TrainerFactory:
                 f"in the trainer configuration file: {sorted(self.trainer_config.keys())}"
             )
         trainer_settings = self.trainer_config[behavior_name]
+        if self._force_torch:
+            trainer_settings.framework = FrameworkType.PYTORCH
+            logger.warning(
+                "Note that specifying --torch is not required anymore as PyTorch is the default framework."
+            )
         if self._force_tf:
             trainer_settings.framework = FrameworkType.TENSORFLOW
+            logger.warning(
+                "Setting the framework to TensorFlow. TensorFlow trainers will be deprecated in the future."
+            )
+            if self._force_torch:
+                logger.warning(
+                    "Both Torch and TensorFlow CLI options were specified. Using TensorFlow."
+                )
         return TrainerFactory._initialize_trainer(
             trainer_settings,
             behavior_name,

--- a/ml-agents/mlagents/trainers/trainer/trainer_factory.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer_factory.py
@@ -26,7 +26,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
-        force_torch: bool = False,
+        force_tensorflow: bool = False,
     ):
         """
         The TrainerFactory generates the Trainers based on the configuration passed as
@@ -56,7 +56,7 @@ class TrainerFactory:
         self.param_manager = param_manager
         self.multi_gpu = multi_gpu
         self.ghost_controller = GhostController()
-        self._force_torch = force_torch
+        self._force_tf = force_tensorflow
 
     def generate(self, behavior_name: str) -> Trainer:
         if behavior_name not in self.trainer_config.keys():
@@ -65,8 +65,8 @@ class TrainerFactory:
                 f"in the trainer configuration file: {sorted(self.trainer_config.keys())}"
             )
         trainer_settings = self.trainer_config[behavior_name]
-        if self._force_torch:
-            trainer_settings.framework = FrameworkType.PYTORCH
+        if self._force_tf:
+            trainer_settings.framework = FrameworkType.TENSORFLOW
         return TrainerFactory._initialize_trainer(
             trainer_settings,
             behavior_name,


### PR DESCRIPTION
### Proposed change(s)

Add a `--tensorflow` option to revert back to TensorFlow. 

Also actually changes the default framework in settings to PyTorch, and adds a changelog entry. 

Note: `pip install mlagents[tensorflow]` was already added in the branch. 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
