### PR TITLE
Run yamato training tests on Windows

### DIFF
--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -2,7 +2,7 @@
 ---
 {% for config in test_configs %}
 test_standalone_{{ config.name }}:
-  name: Test Mac Standalone {{ config.version }}
+  name: Test {{ config.name }} Standalone
   agent:
     type: {{ config.type }}
     image: {{ config.image }}

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -12,8 +12,8 @@ test_standalone_{{ config.name }}:
   commands:
     - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
-    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade --user
-    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
+    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+    - unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
     - python -u -m ml-agents.tests.yamato.standalone_build_tests
     - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
     - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -4,9 +4,9 @@
 test_standalone_{{ config.name }}:
   name: Test Mac Standalone {{ config.version }}
   agent:
-    type: Unity::VM::osx
-    image: ml-agents/ml-agents-bokken-mac:0.1.4-492264
-    flavor: i1.small
+    type: {{ config.type }}
+    image: {{ config.image }}
+    flavor: {{ config.flavor}}
   variables:
     UNITY_VERSION: {{ config.version }}
   commands:

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -10,16 +10,16 @@ test_standalone_{{ config.name }}:
   variables:
     UNITY_VERSION: {{ config.version }}
   commands:
-    - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - python3 -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
-    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+    - python3 -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
     - unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/WallJump/Scenes/WallJump.unity
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/TestScenes/TestCompressedGrid/TestGridCompressed.unity
-    - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/TestScenes/TestCompressedTexture/TestTextureCompressed.unity
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/WallJump/Scenes/WallJump.unity
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/TestScenes/TestCompressedGrid/TestGridCompressed.unity
+    - python3 -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/TestScenes/TestCompressedTexture/TestTextureCompressed.unity
   triggers:
     cancel_old_ci: true
     expression: |

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -1,19 +1,19 @@
 {% metadata_file .yamato/test_versions.metafile %}
 ---
-{% for editor in test_editors %}
-test_mac_standalone_{{ editor.version }}:
-  name: Test Mac Standalone {{ editor.version }}
+{% for config in test_configs %}
+test_standalone_{{ config.name }}:
+  name: Test Mac Standalone {{ config.version }}
   agent:
     type: Unity::VM::osx
     image: ml-agents/ml-agents-bokken-mac:0.1.4-492264
     flavor: i1.small
   variables:
-    UNITY_VERSION: {{ editor.version }}
+    UNITY_VERSION: {{ config.version }}
   commands:
     - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
     - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade --user
-    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
+    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
     - python -u -m ml-agents.tests.yamato.standalone_build_tests
     - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Basic/Scenes/Basic.unity
     - python -u -m ml-agents.tests.yamato.standalone_build_tests --scene=Assets/ML-Agents/Examples/Bouncer/Scenes/Bouncer.unity

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -1,6 +1,7 @@
 # List of configurations for standalone-build-test and its dependencies.
 # csharp_backcompat_version is used in training-int-tests to determine the
 # older package version to run the backwards compat tests against.
+# TODO either separate dictionary for platforms (type, image, flavor), or list the versions to test by platform.
 test_configs:
   - name: Mac_2018.4
     version: 2018.4
@@ -29,6 +30,7 @@ test_configs:
  #   # but we didn't handle this until 1.2.0
  #   csharp_backcompat_version: 1.2.0
 
+ # TODO skip some tests on Windows based on their triggers.
   - name: Win_2019.4
     version: 2019.4
     type: Unity::VM

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -1,14 +1,37 @@
-# List of editor versions for standalone-build-test and its dependencies.
+# List of configurations for standalone-build-test and its dependencies.
 # csharp_backcompat_version is used in training-int-tests to determine the
 # older package version to run the backwards compat tests against.
-test_editors:
-  - version: 2018.4
+test_configs:
+  - name: Mac_2018.4
+    version: 2018.4
+    type: Unity::VM::osx
+    image: package-ci/mac:stable
+    flavor: b1.small
     csharp_backcompat_version: 1.0.0
-  - version: 2019.4
+ # - name: Mac_2019.4
+ #   version: 2019.4
+ #   type: Unity::VM::osx
+ #   image: package-ci/mac:stable
+ #   flavor: b1.small
+ #   csharp_backcompat_version: 1.0.0
+ # - name: Mac_2020.1
+ #   version: 2020.1
+ #   type: Unity::VM::osx
+ #   image: package-ci/mac:stable
+ #   flavor: b1.small
+ #   csharp_backcompat_version: 1.0.0
+ # - name: Mac_2020.2
+ #   version: 2020.2
+ #   type: Unity::VM::osx
+ #   image: package-ci/mac:stable
+ #   flavor: b1.small
+ #   # 2020.2 moved the AssetImporters namespace
+ #   # but we didn't handle this until 1.2.0
+ #   csharp_backcompat_version: 1.2.0
+
+  - name: Win_2019.4
+    version: 2019.4
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
     csharp_backcompat_version: 1.0.0
-  - version: 2020.1
-    csharp_backcompat_version: 1.0.0
-  - version: 2020.2
-    # 2020.2 moved the AssetImporters namespace
-    # but we didn't handle this until 1.2.0
-    csharp_backcompat_version: 1.2.0

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -10,16 +10,16 @@ test_training_int_{{ config.name }}:
   variables:
     UNITY_VERSION: {{ config.version }}
   commands:
-    - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - python3 -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
-    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+    - python3 -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
     - unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
-    - python -u -m ml-agents.tests.yamato.training_int_tests
+    - python3 -u -m ml-agents.tests.yamato.training_int_tests
     # Backwards-compatibility tests.
     # If we make a breaking change to the communication protocol, these will need
     # to be disabled until the next release.
-    - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.16.0
-    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp={{ config.csharp_backcompat_version }}
+    - python3 -u -m ml-agents.tests.yamato.training_int_tests --python=0.16.0
+    - python3 -u -m ml-agents.tests.yamato.training_int_tests --csharp={{ config.csharp_backcompat_version }}
   dependencies:
     - .yamato/standalone-build-test.yml#test_standalone_{{ config.name }}
   triggers:

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -4,9 +4,9 @@
 test_training_int_{{ config.name }}:
   name: Test {{ config.name }} Fast Training
   agent:
-    type: Unity::VM::osx
-    image: ml-agents/ml-agents-bokken-mac:0.1.4-492264
-    flavor: b1.small
+    type: {{ config.type }}
+    image: {{ config.image }}
+    flavor: {{ config.flavor}}
   variables:
     UNITY_VERSION: {{ config.version }}
   commands:

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -12,8 +12,8 @@ test_training_int_{{ config.name }}:
   commands:
     - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
-    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade --user
-    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
+    - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+    - unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
     - python -u -m ml-agents.tests.yamato.training_int_tests
     # Backwards-compatibility tests.
     # If we make a breaking change to the communication protocol, these will need

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -1,27 +1,27 @@
 {% metadata_file .yamato/test_versions.metafile %}
 ---
-{% for editor in test_editors %}
-test_mac_training_int_{{ editor.version }}:
-  name: Test Mac Fast Training {{ editor.version }}
+{% for config in test_configs %}
+test_training_int_{{ config.name }}:
+  name: Test {{ config.name }} Fast Training
   agent:
     type: Unity::VM::osx
     image: ml-agents/ml-agents-bokken-mac:0.1.4-492264
     flavor: b1.small
   variables:
-    UNITY_VERSION: {{ editor.version }}
+    UNITY_VERSION: {{ config.version }}
   commands:
     - pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     # TODO remove the "--user" command and the path prefix when we can migrate away from the custom bokken image
     - python -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade --user
-    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ editor.version }} -c editor --wait --fast
+    - /Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ config.version }} -c editor --wait --fast
     - python -u -m ml-agents.tests.yamato.training_int_tests
     # Backwards-compatibility tests.
     # If we make a breaking change to the communication protocol, these will need
     # to be disabled until the next release.
     - python -u -m ml-agents.tests.yamato.training_int_tests --python=0.16.0
-    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp={{ editor.csharp_backcompat_version }}
+    - python -u -m ml-agents.tests.yamato.training_int_tests --csharp={{ config.csharp_backcompat_version }}
   dependencies:
-    - .yamato/standalone-build-test.yml#test_mac_standalone_{{ editor.version }}
+    - .yamato/standalone-build-test.yml#test_standalone_{{ config.name }}
   triggers:
     cancel_old_ci: true
     expression: |

--- a/Project/ProjectSettings/ProjectVersion.txt
+++ b/Project/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.4.24f1
+m_EditorVersion: 2018.4.22f1

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -132,8 +132,9 @@ def init_venv(
         pip_commands += extra_packages
     for cmd in pip_commands:
         pip_index_url = "--index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple"
+        # TODO fix venv activate command for windows (or just don't run it)
         subprocess.check_call(
-            f"source {venv_path}/bin/activate; python -m pip install -q {cmd} {pip_index_url}",
+            f"source {venv_path}/bin/activate; python3 -m pip install -q {cmd} {pip_index_url}",
             shell=True,
         )
     return venv_path


### PR DESCRIPTION
### Proposed change(s)
Try running the standalone build and training tests on Windows. This temporarily breaks the other tests (gym, ll, etc) - will fix before merging.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
