### PR TITLE
handle no valid moves more gracefully

### DIFF
--- a/com.unity.ml-agents.extensions/Runtime/Match3/AbstractBoard.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/AbstractBoard.cs
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Extensions.Match3
         /// An optional callback for when the all moves are invalid. Ideally, the game state should
         /// be changed before this happens, but this is a way to get notified if not.
         /// </summary>
-        public Action NoValidMoves;
+        public Action OnNoValidMovesAction;
 
         /// <summary>
         /// Iterate through all Moves on the board.

--- a/com.unity.ml-agents.extensions/Runtime/Match3/AbstractBoard.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/AbstractBoard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -64,22 +65,43 @@ namespace Unity.MLAgents.Extensions.Match3
         /// <returns></returns>
         public abstract bool MakeMove(Move m);
 
+        /// <summary>
+        /// Return the total number of moves possible for the board.
+        /// </summary>
+        /// <returns></returns>
+        public int NumMoves()
+        {
+            return Move.NumPotentialMoves(Rows, Columns);
+        }
+
+        /// <summary>
+        /// An optional callback for when the all moves are invalid. Ideally, the game state should
+        /// be changed before this happens, but this is a way to get notified if not.
+        /// </summary>
+        public Action NoValidMoves;
+
+        /// <summary>
+        /// Iterate through all Moves on the board.
+        /// </summary>
+        /// <returns></returns>
         public IEnumerable<Move> AllMoves()
         {
             var currentMove = Move.FromMoveIndex(0, Rows, Columns);
-            var numMoves = Move.NumPotentialMoves(Rows, Columns);
-            for (var i = 0; i < numMoves; i++)
+            for (var i = 0; i < NumMoves(); i++)
             {
                 yield return currentMove;
                 currentMove.Advance(Rows, Columns);
             }
         }
 
+        /// <summary>
+        /// Iterate through all valid Moves on the board.
+        /// </summary>
+        /// <returns></returns>
         public IEnumerable<Move> ValidMoves()
         {
             var currentMove = Move.FromMoveIndex(0, Rows, Columns);
-            var numMoves = Move.NumPotentialMoves(Rows, Columns);
-            for (var i = 0; i < numMoves; i++)
+            for (var i = 0; i < NumMoves(); i++)
             {
                 if (IsMoveValid(currentMove))
                 {
@@ -89,11 +111,14 @@ namespace Unity.MLAgents.Extensions.Match3
             }
         }
 
+        /// <summary>
+        /// Iterate through all invalid Moves on the board.
+        /// </summary>
+        /// <returns></returns>
         public IEnumerable<Move> InvalidMoves()
         {
             var currentMove = Move.FromMoveIndex(0, Rows, Columns);
-            var numMoves = Move.NumPotentialMoves(Rows, Columns);
-            for (var i = 0; i < numMoves; i++)
+            for (var i = 0; i < NumMoves(); i++)
             {
                 if (!IsMoveValid(currentMove))
                 {

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3Actuator.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3Actuator.cs
@@ -86,9 +86,9 @@ namespace Unity.MLAgents.Extensions.Match3
                     // later on in IDiscreteActionMask. Instead, fire a callback to the user if they provided one,
                     // (or log a warning if not) and leave the last action unmasked. This isn't great, but
                     // an invalid move should be easier to handle than an exception..
-                    if (m_Board.NoValidMoves != null)
+                    if (m_Board.OnNoValidMovesAction != null)
                     {
-                        m_Board.NoValidMoves();
+                        m_Board.OnNoValidMovesAction();
                     }
                     else
                     {

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3Actuator.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3Actuator.cs
@@ -75,8 +75,31 @@ namespace Unity.MLAgents.Extensions.Match3
 
         IEnumerable<int> InvalidMoveIndices()
         {
+            var numValidMoves = m_Board.NumMoves();
+
             foreach (var move in m_Board.InvalidMoves())
             {
+                numValidMoves--;
+                if (numValidMoves == 0)
+                {
+                    // If all the moves are invalid and we mask all the actions out, this will cause an assert
+                    // later on in IDiscreteActionMask. Instead, fire a callback to the user if they provided one,
+                    // (or log a warning if not) and leave the last action unmasked. This isn't great, but
+                    // an invalid move should be easier to handle than an exception..
+                    if (m_Board.NoValidMoves != null)
+                    {
+                        m_Board.NoValidMoves();
+                    }
+                    else
+                    {
+                        Debug.LogWarning(
+                            "No valid moves are available. The last action will be left unmasked, so " +
+                            "an invalid move will be passed to AbstractBoard.MakeMove()."
+                        );
+                    }
+                    // This means the last move won't be returned as an invalid index.
+                    yield break;
+                }
                 yield return move.MoveIndex;
             }
         }

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/AbstractBoardTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/AbstractBoardTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NUnit.Framework;
-using Unity.MLAgents.Sensors;
 using Unity.MLAgents.Extensions.Match3;
 
 namespace Unity.MLAgents.Extensions.Tests.Match3

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs
@@ -1,0 +1,88 @@
+using NUnit.Framework;
+using Unity.MLAgents.Actuators;
+using Unity.MLAgents.Extensions.Match3;
+using UnityEngine;
+
+namespace Unity.MLAgents.Extensions.Tests.Match3
+{
+    internal class SimpleBoard : AbstractBoard
+    {
+        public int LastMoveIndex;
+        public bool MovesAreValid = true;
+
+        public bool CallbackCalled;
+
+        public override int GetCellType(int row, int col)
+        {
+            return 0;
+        }
+
+        public override int GetSpecialType(int row, int col)
+        {
+            return 0;
+        }
+
+        public override bool IsMoveValid(Move m)
+        {
+            return MovesAreValid;
+        }
+
+        public override bool MakeMove(Move m)
+        {
+            LastMoveIndex = m.MoveIndex;
+            return MovesAreValid;
+        }
+
+        public void Callback()
+        {
+            CallbackCalled = true;
+        }
+    }
+
+    public class Match3ActuatorTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            if (Academy.IsInitialized)
+            {
+                Academy.Instance.Dispose();
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestValidMoves(bool movesAreValid)
+        {
+            // Check that a board with no valid moves doesn't raise an exception.
+            var gameObj = new GameObject();
+            var board = gameObj.AddComponent<SimpleBoard>();
+            var agent = gameObj.AddComponent<Agent>();
+            gameObj.AddComponent<Match3ActuatorComponent>();
+
+            board.Rows = 5;
+            board.Columns = 5;
+            board.NumCellTypes = 5;
+            board.NumSpecialTypes = 0;
+
+            board.MovesAreValid = movesAreValid;
+            board.NoValidMoves = board.Callback;
+            board.LastMoveIndex = -1;
+
+            agent.LazyInitialize();
+            agent.RequestDecision();
+            Academy.Instance.EnvironmentStep();
+
+            if (movesAreValid)
+            {
+                Assert.IsFalse(board.CallbackCalled);
+            }
+            else
+            {
+                Assert.IsTrue(board.CallbackCalled);
+            }
+            Assert.AreNotEqual(-1, board.LastMoveIndex);
+        }
+
+    }
+}

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs
@@ -66,7 +66,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             board.NumSpecialTypes = 0;
 
             board.MovesAreValid = movesAreValid;
-            board.NoValidMoves = board.Callback;
+            board.OnNoValidMovesAction = board.Callback;
             board.LastMoveIndex = -1;
 
             agent.LazyInitialize();

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs.meta
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3ActuatorTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2edf24df24ac426085cb31a94d063683
+timeCreated: 1603392289

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/MoveTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/MoveTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using UnityEngine;
 using NUnit.Framework;
-using Unity.MLAgents.Sensors;
 using Unity.MLAgents.Extensions.Match3;
 
 namespace Unity.MLAgents.Extensions.Tests.Match3


### PR DESCRIPTION
### Proposed change(s)
Handle no valid moves more gracefully. Currently this will result in an exception being thrown from ActuatorDiscreteActionMask because all the actions for the branch will be masked off.

Ideally, the users should check for this state and change the board state before it happens. But we still need to more gracefully handle this since it's not a situation they're _actively_ causing.

The changes in the PR are to:
1) Don't mask the last action if it's invalid. This will result in an invalid action being passed to AbstractBoard.MakeMove, but that's easier to handle later.
2) Fire an optional action callback, AbstractBoard.NoValidMoves. If that's not set, log a warning explaining what we're doing.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1455


### Types of change(s)
- [x] New feature

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
