### PR TITLE
[bug-fix] Fix ONNX export/Barracuda import for continuous actions

### DIFF
--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -273,10 +273,13 @@ namespace Unity.MLAgentsExamples
             var nnModel = GetModelForBehaviorName(behaviorName);
             if (nnModel == null)
             {
-                overrideError =
-                    $"Didn't find a model for behaviorName {behaviorName}. Make " +
-                    $"sure the behaviorName is set correctly in the commandline " +
-                    $"and that the model file exists";
+                if (string.IsNullOrEmpty(overrideError))
+                {
+                    overrideError =
+                        $"Didn't find a model for behaviorName {behaviorName}. Make " +
+                        "sure the behaviorName is set correctly in the commandline " +
+                        "and that the model file exists";
+                }
             }
             else
             {

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/ModelOverrider.cs
@@ -270,7 +270,16 @@ namespace Unity.MLAgentsExamples
             var bp = m_Agent.GetComponent<BehaviorParameters>();
             var behaviorName = bp.BehaviorName;
 
-            var nnModel = GetModelForBehaviorName(behaviorName);
+            NNModel nnModel = null;
+            try
+            {
+                nnModel = GetModelForBehaviorName(behaviorName);
+            }
+            catch (Exception e)
+            {
+                overrideError = $"Exception calling GetModelForBehaviorName: {e}";
+            }
+
             if (nnModel == null)
             {
                 if (string.IsNullOrEmpty(overrideError))

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -154,7 +154,9 @@ class GaussianDistribution(nn.Module):
             log_sigma = torch.clamp(self.log_sigma(inputs), min=-20, max=2)
         else:
             # Expand so that entropy matches batch size
-            log_sigma = self.log_sigma.expand(inputs.shape[0], -1)
+            log_sigma = self.log_sigma * torch.ones(
+                inputs.shape[0], self.log_sigma.shape[0]
+            )
         if self.tanh_squash:
             return [TanhGaussianDistInstance(mu, torch.exp(log_sigma))]
         else:

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -153,10 +153,10 @@ class GaussianDistribution(nn.Module):
         if self.conditional_sigma:
             log_sigma = torch.clamp(self.log_sigma(inputs), min=-20, max=2)
         else:
-            # Expand so that entropy matches batch size
-            log_sigma = self.log_sigma * torch.ones(
-                inputs.shape[0], self.log_sigma.shape[0]
-            )
+            # Expand so that entropy matches batch size. Note that we're using
+            # torch.cat here instead of torch.expand() becuase it is not supported in the
+            # verified version of Barracuda (1.0.2).
+            log_sigma = torch.cat([self.log_sigma] * inputs.shape[0], axis=0)
         if self.tanh_squash:
             return [TanhGaussianDistInstance(mu, torch.exp(log_sigma))]
         else:


### PR DESCRIPTION
### Proposed change(s)

Bug was introduced in #4538, since Barracuda does not support `torch.expand`. Instead we create a list of duplicate tensors and use `torch.cat`.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
JIRA to revert when support is added for `torch.expand`: https://jira.unity3d.com/browse/MLA-1504