### PR TITLE
[MLA-1519] Don't mark action_probs as an output node.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,9 @@ jobs:
         python -m pip install --progress-bar=off -r test_requirements.txt -c ${{ matrix.pip_constraints }}
         python -m pip install --progress-bar=off -e ./gym-unity -c ${{ matrix.pip_constraints }}
     - name: Save python dependencies
-      run: pip freeze > pip_versions-${{ matrix.python-version }}.txt
+      run: |
+        pip freeze > pip_versions-${{ matrix.python-version }}.txt
+        cat pip_versions-${{ matrix.python-version }}.txt
     - name: Run pytest
       run: pytest --cov=ml-agents --cov=ml-agents-envs --cov=gym-unity --cov-report html --junitxml=junit/test-results-${{ matrix.python-version }}.xml -p no:warnings
     - name: Upload pytest test results

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 #### com.unity.ml-agents (C#)
 - The Barracuda dependency was upgraded to 1.1.2 (#4571)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- The `action_probs` node is no longer listed as an output in TensorFlow models (#4613).
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/ml-agents/mlagents/trainers/tf/model_serialization.py
+++ b/ml-agents/mlagents/trainers/tf/model_serialization.py
@@ -40,9 +40,7 @@ POSSIBLE_INPUT_NODES = frozenset(
     ]
 )
 
-POSSIBLE_OUTPUT_NODES = frozenset(
-    ["action", "action_probs", "recurrent_out", "value_estimate"]
-)
+POSSIBLE_OUTPUT_NODES = frozenset(["action", "recurrent_out", "value_estimate"])
 
 MODEL_CONSTANTS = frozenset(
     [

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -67,7 +67,7 @@ setup(
         # https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Installation.md#windows-installing-pytorch
         'torch>=1.6.0,<1.8.0;platform_system!="Windows"',
         "tensorboard>=1.15",
-        "cattrs>=1.0.0",
+        "cattrs>=1.0.0,<1.1.0",
         "attrs>=19.3.0",
         'pypiwin32==223;platform_system=="Windows"',
     ],

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -67,6 +67,7 @@ setup(
         # https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Installation.md#windows-installing-pytorch
         'torch>=1.6.0,<1.8.0;platform_system!="Windows"',
         "tensorboard>=1.15",
+        # cattrs 1.1.0 dropped support for python 3.6.
         "cattrs>=1.0.0,<1.1.0",
         "attrs>=19.3.0",
         'pypiwin32==223;platform_system=="Windows"',


### PR DESCRIPTION
### Proposed change(s)
`action_probs` is not used for inference but was marked as an output in TensorFlow models. Remove it from the list of nodes to flag as output.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/issues/4596
https://jira.unity3d.com/browse/MLA-1519

### Types of change(s)

- [ ] Bug fix

### Checklist
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
