### PR TITLE
[Bug Fix] cattrs 1.1.0 is not compatible with Python 3.6, adding upper limit

### DIFF
--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -67,7 +67,7 @@ setup(
         # https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Installation.md#windows-installing-pytorch
         'torch>=1.6.0,<1.8.0;platform_system!="Windows"',
         "tensorboard>=1.15",
-        "cattrs>=1.0.0",
+        "cattrs>=1.0.0,<1.1.0",
         "attrs>=19.3.0",
         'pypiwin32==223;platform_system=="Windows"',
     ],


### PR DESCRIPTION
### Proposed change

Fixing cattrs version to 1.0.0 since 1.1.0 does not seem to work fine with Python 3.6

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
