### PR TITLE
Refactor BarracudaModel loader checks

### DIFF
--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelExtensions.cs
@@ -16,7 +16,7 @@ namespace Unity.MLAgents.Inference
         /// The Barracuda engine model for loading static parameters.
         /// </param>
         /// <returns>Array of the input tensor names of the model</returns>
-        public static string[] GetInputTensorNames(this Model model)
+        public static string[] GetInputNames(this Model model)
         {
             var names = new List<string>();
 

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -125,7 +125,7 @@ namespace Unity.MLAgents.Inference
         )
         {
             var failedModelChecks = new List<string>();
-            var tensorsNames = model.GetInputTensorNames();
+            var tensorsNames = model.GetInputNames();
 
             // If there is no Vector Observation Input but the Brain Parameters expect one.
             if ((brainParameters.VectorObservationSize != 0) &&

--- a/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
@@ -78,8 +78,8 @@ namespace Unity.MLAgents.Inference
                 m_Engine = null;
             }
 
-            m_InferenceInputs = BarracudaModelParamLoader.GetInputTensors(barracudaModel);
-            m_OutputNames = BarracudaModelParamLoader.GetOutputNames(barracudaModel);
+            m_InferenceInputs = barracudaModel.GetInputTensors();
+            m_OutputNames = barracudaModel.GetOutputNames();
             m_TensorGenerator = new TensorGenerator(
                 seed, m_TensorAllocator, m_Memories, barracudaModel);
             m_TensorApplier = new TensorApplier(

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -152,7 +152,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsContinuous(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(continuousNNModel) : ModelLoader.Load(continuousONNXModel);
-            var inputNames = model.GetInputTensorNames();
+            var inputNames = model.GetInputNames();
             // Model should contain 3 inputs : vector, visual 1 and visual 2
             Assert.AreEqual(3, inputNames.Count());
             Assert.Contains(TensorNames.VectorObservationPlaceholder, inputNames);
@@ -172,7 +172,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsDiscrete(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(discreteNNModel) : ModelLoader.Load(discreteONNXModel);
-            var inputNames = model.GetInputTensorNames();
+            var inputNames = model.GetInputNames();
             // Model should contain 2 inputs : recurrent and visual 1
 
             Assert.Contains(TensorNames.VisualObservationPlaceholderPrefix + "0", inputNames);
@@ -183,7 +183,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsHybrid()
         {
             var model = ModelLoader.Load(hybridONNXModel);
-            var inputNames = model.GetInputTensorNames();
+            var inputNames = model.GetInputNames();
             Assert.Contains(TensorNames.VectorObservationPlaceholder, inputNames);
         }
 

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -152,19 +152,19 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsContinuous(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(continuousNNModel) : ModelLoader.Load(continuousONNXModel);
-            var inputTensors = BarracudaModelParamLoader.GetInputTensors(model);
-            var inputNames = inputTensors.Select(x => x.name).ToList();
+            var inputNames = model.GetInputTensorNames();
             // Model should contain 3 inputs : vector, visual 1 and visual 2
-            Assert.AreEqual(3, inputNames.Count);
+            Assert.AreEqual(3, inputNames.Count());
             Assert.Contains(TensorNames.VectorObservationPlaceholder, inputNames);
             Assert.Contains(TensorNames.VisualObservationPlaceholderPrefix + "0", inputNames);
             Assert.Contains(TensorNames.VisualObservationPlaceholderPrefix + "1", inputNames);
 
-            Assert.AreEqual(2, BarracudaModelParamLoader.GetNumVisualInputs(model));
+            Assert.AreEqual(2, model.GetNumVisualInputs());
 
             // Test if the model is null
-            Assert.AreEqual(0, BarracudaModelParamLoader.GetInputTensors(null).Count);
-            Assert.AreEqual(0, BarracudaModelParamLoader.GetNumVisualInputs(null));
+            model = null;
+            Assert.AreEqual(0, model.GetInputTensors().Count);
+            Assert.AreEqual(0, model.GetNumVisualInputs());
         }
 
         [TestCase(true)]
@@ -172,8 +172,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsDiscrete(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(discreteNNModel) : ModelLoader.Load(discreteONNXModel);
-            var inputTensors = BarracudaModelParamLoader.GetInputTensors(model);
-            var inputNames = inputTensors.Select(x => x.name).ToList();
+            var inputNames = model.GetInputTensorNames();
             // Model should contain 2 inputs : recurrent and visual 1
 
             Assert.Contains(TensorNames.VisualObservationPlaceholderPrefix + "0", inputNames);
@@ -184,8 +183,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetInputTensorsHybrid()
         {
             var model = ModelLoader.Load(hybridONNXModel);
-            var inputTensors = BarracudaModelParamLoader.GetInputTensors(model);
-            var inputNames = inputTensors.Select(x => x.name).ToList();
+            var inputNames = model.GetInputTensorNames();
             Assert.Contains(TensorNames.VectorObservationPlaceholder, inputNames);
         }
 
@@ -194,12 +192,13 @@ namespace Unity.MLAgents.Tests
         public void TestGetOutputTensorsContinuous(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(continuousNNModel) : ModelLoader.Load(continuousONNXModel);
-            var outputNames = BarracudaModelParamLoader.GetOutputNames(model);
+            var outputNames = model.GetOutputNames();
             var actionOutputName = useDeprecatedNNModel ? TensorNames.ActionOutputDeprecated : TensorNames.ContinuousActionOutput;
             Assert.Contains(actionOutputName, outputNames);
             Assert.AreEqual(1, outputNames.Count());
 
-            Assert.AreEqual(0, BarracudaModelParamLoader.GetOutputNames(null).Count());
+            model = null;
+            Assert.AreEqual(0, model.GetOutputNames().Count());
         }
 
         [TestCase(true)]
@@ -207,7 +206,7 @@ namespace Unity.MLAgents.Tests
         public void TestGetOutputTensorsDiscrete(bool useDeprecatedNNModel)
         {
             var model = useDeprecatedNNModel ? ModelLoader.Load(discreteNNModel) : ModelLoader.Load(discreteONNXModel);
-            var outputNames = BarracudaModelParamLoader.GetOutputNames(model);
+            var outputNames = model.GetOutputNames();
             var actionOutputName = useDeprecatedNNModel ? TensorNames.ActionOutputDeprecated : TensorNames.DiscreteActionOutput;
             Assert.Contains(actionOutputName, outputNames);
             // TODO : There are some memory tensors as well
@@ -217,13 +216,14 @@ namespace Unity.MLAgents.Tests
         public void TestGetOutputTensorsHybrid()
         {
             var model = ModelLoader.Load(hybridONNXModel);
-            var outputNames = BarracudaModelParamLoader.GetOutputNames(model);
+            var outputNames = model.GetOutputNames();
 
             Assert.AreEqual(2, outputNames.Count());
             Assert.Contains(TensorNames.ContinuousActionOutput, outputNames);
             Assert.Contains(TensorNames.DiscreteActionOutput, outputNames);
 
-            Assert.AreEqual(0, BarracudaModelParamLoader.GetOutputNames(null).Count());
+            model = null;
+            Assert.AreEqual(0, model.GetOutputNames().Count());
         }
 
         [TestCase(true)]


### PR DESCRIPTION
### Proposed change(s)

* Move methods for getting model attributes (GetInputNames, GetOutputNames, GetNumVisualInputs) to BarracudaModelExtensions.
* Add `CheckExpectedTensors` to check the existence all expected tensors and call it before all other model checks, to make sure it's safe to call the extension methods and doesn't throw exception.
* Explicitly checks the model has expected action_output_shape/is_continuous for different model format (current/deprecated).
 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
