### PR TITLE
Export separate nodes for continuous/discrete actions

### DIFF
--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -424,6 +424,7 @@ class UnityEnvironment(BaseEnv):
             if n_agents == 0:
                 continue
             for i in range(n_agents):
+                # TODO add separate fields for continuous and discrete actions in AgentActionProto
                 _act = []
                 if vector_action[b].continuous is not None:
                     _act.append(vector_action[b].continuous[i])

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -424,11 +424,13 @@ class UnityEnvironment(BaseEnv):
             if n_agents == 0:
                 continue
             for i in range(n_agents):
-                # TODO: extend to AgentBuffers
+                # TODO: separate action into different field in AgentActionProto
+                _act = []
                 if vector_action[b].continuous is not None:
-                    _act = vector_action[b].continuous[i]
-                else:
-                    _act = vector_action[b].discrete[i]
+                    _act.append(vector_action[b].continuous[i])
+                if vector_action[b].discrete is not None:
+                    _act.append(vector_action[b].discrete[i])
+                _act = np.concatenate(_act, axis=0)
                 action = AgentActionProto(vector_actions=_act)
                 rl_in.agent_actions[b].value.extend([action])
                 rl_in.command = STEP

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -424,7 +424,6 @@ class UnityEnvironment(BaseEnv):
             if n_agents == 0:
                 continue
             for i in range(n_agents):
-                # TODO: separate action into different field in AgentActionProto
                 _act = []
                 if vector_action[b].continuous is not None:
                     _act.append(vector_action[b].continuous[i])

--- a/ml-agents/mlagents/trainers/torch/action_model.py
+++ b/ml-agents/mlagents/trainers/torch/action_model.py
@@ -117,6 +117,9 @@ class ActionModel(nn.Module):
             ]
             discrete_out = torch.cat(discrete_out, dim=1)
             action_out_deprecated = discrete_out
+        # deprecated action field does not support hybrid action
+        if self.action_spec.continuous_size > 0 and self.action_spec.discrete_size > 0:
+            action_out_deprecated = None
         return continuous_out, discrete_out, action_out_deprecated
 
     def forward(

--- a/ml-agents/mlagents/trainers/torch/action_model.py
+++ b/ml-agents/mlagents/trainers/torch/action_model.py
@@ -106,13 +106,20 @@ class ActionModel(nn.Module):
 
     def get_action_out(self, inputs: torch.Tensor, masks: torch.Tensor) -> torch.Tensor:
         dists = self._get_dists(inputs, masks)
-        out_list: List[torch.Tensor] = []
+        continuous_out, discrete_out = None, None
+        out_list_deprecated = []
         if self.action_spec.continuous_size > 0:
-            out_list.append(dists.continuous.exported_model_output())
+            continuous_out = dists.continuous.exported_model_output()
+            out_list_deprecated.append(continuous_out)
         if self.action_spec.discrete_size > 0:
-            for discrete_dist in dists.discrete:
-                out_list.append(discrete_dist.exported_model_output())
-        return torch.cat(out_list, dim=1)
+            discrete_out = [
+                discrete_dist.exported_model_output()
+                for discrete_dist in dists.discrete
+            ]
+            discrete_out = torch.cat(discrete_out, dim=1)
+            out_list_deprecated.append(discrete_out)
+        out_list_deprecated = torch.cat(out_list_deprecated, dim=1)
+        return continuous_out, discrete_out, out_list_deprecated
 
     def forward(
         self, inputs: torch.Tensor, masks: torch.Tensor

--- a/ml-agents/mlagents/trainers/torch/action_model.py
+++ b/ml-agents/mlagents/trainers/torch/action_model.py
@@ -107,19 +107,17 @@ class ActionModel(nn.Module):
     def get_action_out(self, inputs: torch.Tensor, masks: torch.Tensor) -> torch.Tensor:
         dists = self._get_dists(inputs, masks)
         continuous_out, discrete_out = None, None
-        out_list_deprecated = []
         if self.action_spec.continuous_size > 0:
             continuous_out = dists.continuous.exported_model_output()
-            out_list_deprecated.append(continuous_out)
+            action_out_deprecated = continuous_out
         if self.action_spec.discrete_size > 0:
             discrete_out = [
                 discrete_dist.exported_model_output()
                 for discrete_dist in dists.discrete
             ]
             discrete_out = torch.cat(discrete_out, dim=1)
-            out_list_deprecated.append(discrete_out)
-        out_list_deprecated = torch.cat(out_list_deprecated, dim=1)
-        return continuous_out, discrete_out, out_list_deprecated
+            action_out_deprecated = discrete_out
+        return continuous_out, discrete_out, action_out_deprecated
 
     def forward(
         self, inputs: torch.Tensor, masks: torch.Tensor

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -74,6 +74,13 @@ class ModelSerializer:
             "is_continuous_control",
             "action_output_shape",
         ]
+        if self.policy.action_spec.continuous_size > 0:
+            self.output_names += [
+                "continuous_actions",
+                "continuous_action_output_shape",
+            ]
+        if self.policy.action_spec.discrete_size > 0:
+            self.output_names += ["discrete_actions", "discrete_action_output_shape"]
 
         self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
         self.dynamic_axes.update({"action": {0: "batch"}})

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -67,13 +67,7 @@ class ModelSerializer:
             + ["action_masks", "memories"]
         )
 
-        self.output_names = [
-            "action",
-            "version_number",
-            "memory_size",
-            "is_continuous_control",
-            "action_output_shape",
-        ]
+        self.output_names = ["version_number", "memory_size"]
         if self.policy.action_spec.continuous_size > 0:
             self.output_names += [
                 "continuous_actions",
@@ -81,6 +75,15 @@ class ModelSerializer:
             ]
         if self.policy.action_spec.discrete_size > 0:
             self.output_names += ["discrete_actions", "discrete_action_output_shape"]
+        if (
+            self.policy.action_spec.continuous_size == 0
+            or self.policy.action_spec.discrete_size == 0
+        ):
+            self.output_names += [
+                "action",
+                "is_continuous_control",
+                "action_output_shape",
+            ]
 
         self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
         self.dynamic_axes.update({"action": {0: "batch"}})

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -240,6 +240,7 @@ class SimpleActor(nn.Module, Actor):
         self.continuous_act_size_vector = torch.nn.Parameter(
             torch.Tensor([int(self.action_spec.continuous_size)]), requires_grad=False
         )
+        # TODO: export list of branch sizes instead of sum
         self.discrete_act_size_vector = torch.nn.Parameter(
             torch.Tensor([sum(self.action_spec.discrete_branches)]), requires_grad=False
         )

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -241,13 +241,12 @@ class SimpleActor(nn.Module, Actor):
             torch.Tensor([int(self.action_spec.continuous_size)]), requires_grad=False
         )
         self.discrete_act_size_vector = torch.nn.Parameter(
-            torch.Tensor([int(sum(self.action_spec.discrete_branches))]),
-            requires_grad=False,
+            torch.Tensor([sum(self.action_spec.discrete_branches)]), requires_grad=False
         )
         self.act_size_vector_deprecated = torch.nn.Parameter(
             torch.Tensor(
                 [
-                    int(self.action_spec.continuous_size)
+                    self.action_spec.continuous_size
                     + sum(self.action_spec.discrete_branches)
                 ]
             ),


### PR DESCRIPTION
### Proposed change(s)

Output three action output nodes: one continuous, one discrete, and one legacy action output 


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
