### PR TITLE
[refactor] Allow objects of any type to be added to AgentBufferField

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -33,7 +33,7 @@ class AgentBuffer(dict):
         def __str__(self):
             return str(np.array(self).shape)
 
-        def append(self, element: Any, padding_value: float = 0.0) -> None:
+        def append(self, element: Any, padding_value: Any = 0.0) -> None:
             """
             Adds an element to this AgentBuffer. Also lets you change the padding
             type, so that it can be set on append (e.g. action_masks should

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -22,8 +22,8 @@ class AgentBuffer(dict):
 
     class AgentBufferField(list):
         """
-        AgentBufferField is a list of numpy arrays. When an agent collects a field, you can add it to his
-        AgentBufferField with the append method.
+        AgentBufferField is a list of data, usually numpy arrays. When an agent collects a field,
+        you can add it to its AgentBufferField with the append method.
         """
 
         def __init__(self):

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -190,10 +190,10 @@ class PPOTrainer(RLTrainer):
         n_sequences = max(
             int(self.hyperparameters.batch_size / self.policy.sequence_length), 1
         )
-
-        advantages = self.update_buffer["advantages"].get_batch()
+        # Normalize advantages
+        advantages = np.array(self.update_buffer["advantages"].get_batch())
         self.update_buffer["advantages"].set(
-            (advantages - advantages.mean()) / (advantages.std() + 1e-10)
+            list((advantages - advantages.mean()) / (advantages.std() + 1e-10))
         )
         num_epoch = self.hyperparameters.num_epoch
         batch_update_stats = defaultdict(list)

--- a/ml-agents/mlagents/trainers/tests/test_buffer.py
+++ b/ml-agents/mlagents/trainers/tests/test_buffer.py
@@ -14,14 +14,23 @@ def construct_fake_buffer(fake_agent_id):
     b = AgentBuffer()
     for step in range(9):
         b["vector_observation"].append(
-            [
-                100 * fake_agent_id + 10 * step + 1,
-                100 * fake_agent_id + 10 * step + 2,
-                100 * fake_agent_id + 10 * step + 3,
-            ]
+            np.array(
+                [
+                    100 * fake_agent_id + 10 * step + 1,
+                    100 * fake_agent_id + 10 * step + 2,
+                    100 * fake_agent_id + 10 * step + 3,
+                ],
+                dtype=np.float32,
+            )
         )
         b["action"].append(
-            [100 * fake_agent_id + 10 * step + 4, 100 * fake_agent_id + 10 * step + 5]
+            np.array(
+                [
+                    100 * fake_agent_id + 10 * step + 4,
+                    100 * fake_agent_id + 10 * step + 5,
+                ],
+                dtype=np.float32,
+            )
         )
     return b
 
@@ -33,7 +42,10 @@ def test_buffer():
     a = agent_1_buffer["vector_observation"].get_batch(
         batch_size=2, training_length=1, sequential=True
     )
-    assert_array(np.array(a), np.array([[171, 172, 173], [181, 182, 183]]))
+    assert len(a) == 2
+    assert_array(
+        np.array(a), np.array([[171, 172, 173], [181, 182, 183]], dtype=np.float32)
+    )
     a = agent_2_buffer["vector_observation"].get_batch(
         batch_size=2, training_length=3, sequential=True
     )
@@ -47,7 +59,8 @@ def test_buffer():
                 [261, 262, 263],
                 [271, 272, 273],
                 [281, 282, 283],
-            ]
+            ],
+            dtype=np.float32,
         ),
     )
     a = agent_2_buffer["vector_observation"].get_batch(


### PR DESCRIPTION
### Proposed change(s)

We previously forced all elements that are in an AgentBufferField to be an `np.ndarray` with `dtype=np.float32`, even though the underlying AgentBuffer was a List. However, this prevents us from adding different types of data, for instance `AgentTuple`s (needed for Hybrid Actions) or lists of observations (needed for Centralized Critic). 

This PR is a small step in that direction, and allows anything to be appended to the AgentBufferField. 

NOTE: probably should merge this after the release branch split. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
