### PR TITLE
Add global lock for torch.onnx.export()

### DIFF
--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -78,7 +78,6 @@ class ModelSerializer:
 
         self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
         self.dynamic_axes.update({"action": {0: "batch"}})
-        # self.lock = threading.Lock()
 
     def export_policy_model(self, output_filepath: str) -> None:
         """

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -27,8 +27,8 @@ class exporting_to_onnx:
     _lock = threading.Lock()
 
     def __enter__(self):
-        self._local_data._is_exporting = True
         self._lock.acquire()
+        self._local_data._is_exporting = True
 
     def __exit__(self, *args):
         self._local_data._is_exporting = False

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -7,7 +7,6 @@ from mlagents.trainers.settings import SerializationSettings
 
 
 logger = get_logger(__name__)
-lock = threading.Lock()
 
 
 class exporting_to_onnx:
@@ -20,14 +19,20 @@ class exporting_to_onnx:
     This implementation is thread safe.
     """
 
+    # local is_exporting flag for each thread
     _local_data = threading.local()
     _local_data._is_exporting = False
 
+    # global lock shared among all threads, to make sure only one thread is exporting at a time
+    _lock = threading.Lock()
+
     def __enter__(self):
         self._local_data._is_exporting = True
+        self._lock.acquire()
 
     def __exit__(self, *args):
         self._local_data._is_exporting = False
+        self._lock.release()
 
     @staticmethod
     def is_exporting():
@@ -91,15 +96,14 @@ class ModelSerializer:
         onnx_output_path = f"{output_filepath}.onnx"
         logger.info(f"Converting to {onnx_output_path}")
 
-        with lock:
-            with exporting_to_onnx():
-                torch.onnx.export(
-                    self.policy.actor_critic,
-                    self.dummy_input,
-                    onnx_output_path,
-                    opset_version=SerializationSettings.onnx_opset,
-                    input_names=self.input_names,
-                    output_names=self.output_names,
-                    dynamic_axes=self.dynamic_axes,
-                )
+        with exporting_to_onnx():
+            torch.onnx.export(
+                self.policy.actor_critic,
+                self.dummy_input,
+                onnx_output_path,
+                opset_version=SerializationSettings.onnx_opset,
+                input_names=self.input_names,
+                output_names=self.output_names,
+                dynamic_axes=self.dynamic_axes,
+            )
         logger.info(f"Exported {onnx_output_path}")


### PR DESCRIPTION
### Proposed change(s)

`torch.onnx.export()` can only be used by one thread at a time.
When training multiple behavior with threading=True, multiple thread could be trying to export model at the same time and resulted in exception.
Adding a global lock for model serialization solves the problem.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
