### PR TITLE
[bug-fix] Separate critic only for PPO

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -254,7 +254,7 @@ class PPOTrainer(RLTrainer):
             behavior_spec,
             self.trainer_settings,
             condition_sigma_on_obs=False,  # Faster training for PPO
-            separate_critic=behavior_spec.action_spec.is_continuous(),
+            separate_critic=True,  # Match network architecture with TF
         )
         return policy
 


### PR DESCRIPTION
### Proposed change(s)

This might be a controversial change, but probably less so with hybrid-actions on the horizon. 

In PPO-Torch, we use a separate actor and critic network for continuous actions, and a shared one for discrete. In TF, we always used a separate network. This causes some differences in performance between TF and Torch (particularly with the FoodCollector environment, where the combined network does not have enough capacity for both action and value). 

In the principle of least surprise, I think we should change Torch to use a separate network always, at least until TF is deprecated. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
