### PR TITLE
[bug-fix] Fix BC module + action clipping

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -464,7 +464,7 @@ class TorchSACOptimizer(TorchOptimizer):
         self.target_network.network_body.copy_normalization(
             self.policy.actor_critic.network_body
         )
-        (sampled_actions, log_probs, _, _) = self.policy.sample_actions(
+        (sampled_actions, _, log_probs, _, _) = self.policy.sample_actions(
             vec_obs,
             vis_obs,
             masks=act_masks,

--- a/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
+++ b/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
@@ -79,10 +79,10 @@ def _compare_two_policies(policy1: TorchPolicy, policy2: TorchPolicy) -> None:
     ).unsqueeze(0)
 
     with torch.no_grad():
-        _, log_probs1, _, _ = policy1.sample_actions(
+        _, _, log_probs1, _, _ = policy1.sample_actions(
             vec_obs, vis_obs, masks=masks, memories=memories, all_log_probs=True
         )
-        _, log_probs2, _, _ = policy2.sample_actions(
+        _, _, log_probs2, _, _ = policy2.sample_actions(
             vec_obs, vis_obs, masks=masks, memories=memories, all_log_probs=True
         )
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -147,7 +147,10 @@ def test_sample_actions(rnn, visual, discrete):
         )
     else:
         assert log_probs.shape == (64, policy.behavior_spec.action_spec.continuous_size)
-        assert clipped_actions == (64, policy.behavior_spec.action_spec.continuous_size)
+        assert clipped_actions.shape == (
+            64,
+            policy.behavior_spec.action_spec.continuous_size,
+        )
     assert entropies.shape == (64,)
 
     if rnn:

--- a/ml-agents/mlagents/trainers/tests/torch/test_policy.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_policy.py
@@ -126,7 +126,13 @@ def test_sample_actions(rnn, visual, discrete):
     if len(memories) > 0:
         memories = torch.stack(memories).unsqueeze(0)
 
-    (sampled_actions, log_probs, entropies, memories) = policy.sample_actions(
+    (
+        sampled_actions,
+        clipped_actions,
+        log_probs,
+        entropies,
+        memories,
+    ) = policy.sample_actions(
         vec_obs,
         vis_obs,
         masks=act_masks,
@@ -141,6 +147,7 @@ def test_sample_actions(rnn, visual, discrete):
         )
     else:
         assert log_probs.shape == (64, policy.behavior_spec.action_spec.continuous_size)
+        assert clipped_actions == (64, policy.behavior_spec.action_spec.continuous_size)
     assert entropies.shape == (64,)
 
     if rnn:

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -62,7 +62,7 @@ class BCModule:
         # Don't continue training if the learning rate has reached 0, to reduce training time.
 
         decay_lr = self.decay_learning_rate.get_value(self.policy.get_current_step())
-        if self.current_lr <= 0:
+        if self.current_lr <= 1e-10:  # Unlike in TF, this never actually reaches 0.
             return {"Losses/Pretraining Loss": 0}
 
         batch_losses = []

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -164,7 +164,13 @@ class BCModule:
         else:
             vis_obs = []
 
-        selected_actions, all_log_probs, _, _ = self.policy.sample_actions(
+        (
+            selected_actions,
+            clipped_actions,
+            all_log_probs,
+            _,
+            _,
+        ) = self.policy.sample_actions(
             vec_obs,
             vis_obs,
             masks=act_masks,
@@ -173,7 +179,7 @@ class BCModule:
             all_log_probs=True,
         )
         bc_loss = self._behavioral_cloning_loss(
-            selected_actions, all_log_probs, expert_actions
+            clipped_actions, all_log_probs, expert_actions
         )
         self.optimizer.zero_grad()
         bc_loss.backward()


### PR DESCRIPTION
### Proposed change(s)

In the previous action clipping PR, actions were being clipped too late (in `evaluate`) and the BC module didn't receive the clipped actions from the Policy. This PR moves action clipping to `sample_actions`, which also fixes BC module + continuous actions. 

We also compare learning rate to a small epsilon that will allow the BC module to stop training (taking time) when learning rate reaches a low value. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
