### PR TITLE
[R10] Workaround code coverage tests in trunk

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -16,7 +16,8 @@ test_editors:
 
 trunk_editor:
   - version: trunk
-    enableCodeCoverage: !!bool true
+    # Workaround for MLA-1596 - need to make sure we load the right results.
+    enableCodeCoverage: !!bool false
     testProject: DevProject
 
 test_platforms:


### PR DESCRIPTION
### Proposed change(s)
Recently code coverage checks started failing for Windows editor in trunk. The actual coverage for the package is 77%, but the checker is looking at the DevProject results which is ~50% for some reason. So I think it's a false alarm.

Disable the check on trunk builds until we can investigate.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1596 (contains yamato build result links)

### Types of change(s)

- [ ] Hack

### Checklist
- [ ] Ran tests that prove my fix is effective or that my feature works
