### PR TITLE
[bug-fix] Remove extra period

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+ - Remove extra period after "Training" in console log. (#4674)
 
 
 ## [1.6.0-preview] - 2020-11-18

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -136,7 +136,7 @@ class ConsoleWriter(StatsWriter):
         else:
             log_info.append("No episode was completed since last summary")
             log_info.append(is_training)
-        logger.info(". ".join(log_info))
+        logger.info(". ".join(log_info) + ".")
 
     def add_property(
         self, category: str, property_type: StatsPropertyType, value: Any

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -111,11 +111,11 @@ class ConsoleWriter(StatsWriter):
     def write_stats(
         self, category: str, values: Dict[str, StatsSummary], step: int
     ) -> None:
-        is_training = "Not Training."
+        is_training = "Not Training"
         if "Is Training" in values:
             stats_summary = values["Is Training"]
             if stats_summary.mean > 0.0:
-                is_training = "Training."
+                is_training = "Training"
 
         elapsed_time = time.time() - self.training_start_time
         log_info: List[str] = [category]


### PR DESCRIPTION
### Proposed change(s)

Removes a superfluous period that was printed in after "Training" in the console output. 
![image](https://user-images.githubusercontent.com/5085265/99731999-8ff90780-2a73-11eb-9bed-8ddc65e795d5.png)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
