### PR TITLE
[Release 10 Cherry-pick][Bug-fix] Remove extra directory created at checkpoint (#4675)

### DIFF
--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from mlagents.torch_utils import torch
 
@@ -90,9 +89,6 @@ class ModelSerializer:
 
         :param output_filepath: file path to output the model (without file suffix)
         """
-        if not os.path.exists(output_filepath):
-            os.makedirs(output_filepath)
-
         onnx_output_path = f"{output_filepath}.onnx"
         logger.info(f"Converting to {onnx_output_path}")
 


### PR DESCRIPTION
* [Bug-fix] Remove extra directory created at checkpoint

* removing os import

### Proposed change(s)

No more creating an extra dir at each checkpoint

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
