### PR TITLE
Disable threading for self-play environments

### DIFF
--- a/config/ppo/SoccerTwos.yaml
+++ b/config/ppo/SoccerTwos.yaml
@@ -23,7 +23,7 @@ behaviors:
     max_steps: 50000000
     time_horizon: 1000
     summary_freq: 10000
-    threaded: true
+    threaded: false
     self_play:
       save_steps: 50000
       team_change: 200000

--- a/config/ppo/StrikersVsGoalie.yaml
+++ b/config/ppo/StrikersVsGoalie.yaml
@@ -23,7 +23,7 @@ behaviors:
     max_steps: 30000000
     time_horizon: 1000
     summary_freq: 10000
-    threaded: true
+    threaded: false
     self_play:
       save_steps: 50000
       team_change: 200000
@@ -55,7 +55,7 @@ behaviors:
     max_steps: 30000000
     time_horizon: 1000
     summary_freq: 10000
-    threaded: true
+    threaded: false
     self_play:
       save_steps: 50000
       team_change: 200000

--- a/config/ppo/Tennis.yaml
+++ b/config/ppo/Tennis.yaml
@@ -23,7 +23,7 @@ behaviors:
     max_steps: 50000000
     time_horizon: 1000
     summary_freq: 10000
-    threaded: true
+    threaded: false
     self_play:
       save_steps: 50000
       team_change: 100000


### PR DESCRIPTION
### Proposed change(s)

We were seeing slowdowns for Soccer and Tennis when using PyTorch. There might be a couple contributing factors:

- Generally inference is slower in Torch than in TF.
- Self-play environments have more inference calls than normal environments per step (2x)
- Multiple environments, when combined with threading, cause thrashing of the GIL, especially with Torch. 

Disabling threading for self-play should bring performance back close to TF. Ultimately. we'll need to move to a true multithreaded solution for Torch, given how Torch interleaves C++ library calls with Python calls. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
