### PR TITLE
Add link for curriculum

### DIFF
--- a/docs/Learning-Environment-Design.md
+++ b/docs/Learning-Environment-Design.md
@@ -116,7 +116,9 @@ methods that control specific parameters in your environment. As such, it is
 important to ensure that your environment parameters are updated at each step to
 the correct values. To enable this, we expose a `EnvironmentParameters` C# class
 that you can use to retrieve the values of the parameters defined in the
-training configurations for both of those features.
+training configurations for both of those features. Please see our
+[documentation](Training-ML-Agents.md#environment-parameters)
+for curriculum learning and environment parameter randomization for details.
 
 We recommend modifying the environment from the Agent's `OnEpisodeBegin()`
 function by leveraging `Academy.Instance.EnvironmentParameters`. See the


### PR DESCRIPTION
### Proposed change(s)

Addressing https://github.com/Unity-Technologies/ml-agents/issues/4684

We could also add a link to the Training-Configuration-File docs since technically env parameters go in that file but I think this is a reasonable compromise.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
