### PR TITLE
Fix set_action_for_agent

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- `ActionSpec.validate_action()` now enforces that `UnityEnvironment.set_action_for_agent()` receives a 1D `np.array`.
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -323,7 +323,7 @@ class ActionSpec(NamedTuple):
         return action
 
     def _validate_action(
-        self, actions: np.ndarray, n_agents: int, name: str
+        self, actions: np.ndarray, n_agents: Optional[int], name: str
     ) -> np.ndarray:
         """
         Validates that action has the correct action dim
@@ -333,7 +333,7 @@ class ActionSpec(NamedTuple):
             _size = self.continuous_size
         else:
             _size = self.discrete_size
-        _expected_shape = (n_agents, _size)
+        _expected_shape = (n_agents, _size) if n_agents else (_size,)
         if actions.shape != _expected_shape:
             raise UnityActionException(
                 f"The behavior {name} needs an input of dimension "

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -353,7 +353,7 @@ class UnityEnvironment(BaseEnv):
             return
         action_spec = self._env_specs[behavior_name].action_spec
         num_agents = len(self._env_state[behavior_name][0])
-        action = action_spec._validate_action(action, num_agents, behavior_name)
+        action = action_spec._validate_action(action, None, behavior_name)
         if behavior_name not in self._env_actions:
             self._env_actions[behavior_name] = action_spec.empty_action(num_agents)
         try:


### PR DESCRIPTION
### Proposed change(s)

Since #4586 `UnityEnvironment.set_action_for_agent` expects a 2D action array instead of the 1D array as before and as documented. This breaks existing scripts. (Even if using a 2D array, the new code still breaks in case there are multiple agents within the same behavior name.)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

#4586 
#4612

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments

Note the fixes in this PR might impact #4612.
