### PR TITLE
pin pip to 20.2 for now

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,7 @@ on:
     - 'gym-unity/**'
     - 'test_constraints*.txt'
     - 'test_requirements.txt'
+    - '.github/workflows/pytest.yml'
   push:
     branches: [master]
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,8 @@ jobs:
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        # pin pip to workaround https://github.com/pypa/pip/issues/9180
+        python -m pip install pip==20.2
         python -m pip install --upgrade setuptools
         python -m pip install --progress-bar=off -e ./ml-agents-envs -c ${{ matrix.pip_constraints }}
         python -m pip install --progress-bar=off -e ./ml-agents -c ${{ matrix.pip_constraints }}


### PR DESCRIPTION
### Proposed change(s)
pip 20.3 throws an exception trying to install our dependencies. pin to 20.2 until they get a fix

We might need this later for tests that run on yamato, but as of the moment, the pypi mirror we use internally hasn't gotten 20.3

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/pypa/pip/issues/9180


### Types of change(s)
- [x] Bug workaround
