### PR TITLE
[bug-fix] Skip critic when given empty memory array

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 ### Bug Fixes
 #### com.unity.ml-agents (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-
+- A minor bug was causing unneeded critic evaluations during inference (#4695)
 
 ## [1.6.0-preview] - 2020-11-18
 ### Major Changes

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -135,7 +135,7 @@ class TorchPolicy(Policy):
         :return: Tuple of actions, actions clipped to -1, 1, log probabilities (dependent on all_log_probs),
             entropies, and output memories, all as Torch Tensors.
         """
-        if memories is None or memories.numel() == 0:
+        if memories is None:
             dists, memories = self.actor_critic.get_dists(
                 vec_obs, vis_obs, masks, memories, seq_len
             )
@@ -201,8 +201,10 @@ class TorchPolicy(Policy):
         vis_obs = [
             torch.as_tensor(vis_ob) for vis_ob in vec_vis_obs.visual_observations
         ]
-        memories = torch.as_tensor(self.retrieve_memories(global_agent_ids)).unsqueeze(
-            0
+        memories = (
+            torch.as_tensor(self.retrieve_memories(global_agent_ids)).unsqueeze(0)
+            if self.use_recurrent
+            else None
         )
 
         run_out = {}

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -135,7 +135,7 @@ class TorchPolicy(Policy):
         :return: Tuple of actions, actions clipped to -1, 1, log probabilities (dependent on all_log_probs),
             entropies, and output memories, all as Torch Tensors.
         """
-        if memories is None:
+        if memories is None or memories.numel() == 0:
             dists, memories = self.actor_critic.get_dists(
                 vec_obs, vis_obs, masks, memories, seq_len
             )

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -148,7 +148,7 @@ class BCModule:
                 )
             )
 
-        memories = []
+        memories = None
         if self.policy.use_recurrent:
             memories = torch.zeros(1, self.n_sequences, self.policy.m_size)
 


### PR DESCRIPTION
### Proposed change(s)

At some point we added a performance enhancement to not evaluate the critic during inference when a `None` memory is given to the policy `evaluate()`. However, empty memory arrays also caused the critic to be evaluated. This PR makes sure to feed `None` memories if memories aren't used (rather than either empty array or empty tensor), and should provide a ~5% speedup on 3DBall. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
