### PR TITLE
Fix SubprocessEnvManager hanging on unexpected exceptions.

### DIFF
--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -335,13 +335,13 @@ class SubprocessEnvManager(EnvManager):
         # Sanity check to kill zombie workers and report an issue if they occur.
         if self.workers_alive > 0:
             logger.error(
-                f"SubprocessEnvManager's had workers that didn't signal shutdown"
+                "SubprocessEnvManager's had workers that didn't signal shutdown"
             )
             for w in self.env_workers:
                 if not w.closed and w.process.exitcode is None:
                     w.process.terminate()
                     raise AssertionError(
-                        f"A SubprocessEnvManager worker did not shut down correctly"
+                        "A SubprocessEnvManager worker did not shut down correctly"
                     )
         self.step_queue.join_thread()
 

--- a/ml-agents/mlagents/trainers/tests/simple_test_envs.py
+++ b/ml-agents/mlagents/trainers/tests/simple_test_envs.py
@@ -297,3 +297,12 @@ class RecordEnvironment(SimpleEnvironment):
                 else:
                     self.action[name] = [[float(self.goal[name])]]
             self.step()
+
+
+class UnexpectedExceptionEnvironment(SimpleEnvironment):
+    def __init__(self, brain_names, use_discrete, to_raise):
+        super().__init__(brain_names, use_discrete)
+        self.to_raise = to_raise
+
+    def step(self) -> None:
+        raise self.to_raise()

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -217,7 +217,7 @@ class CustomTestOnlyException(Exception):
 
 @pytest.mark.parametrize("num_envs", [1, 4])
 def test_subprocess_failing_step(num_envs):
-    def failing_step_env_factory(worker_id, config):
+    def failing_step_env_factory(_worker_id, _config):
         env = UnexpectedExceptionEnvironment(
             ["1D"], use_discrete=True, to_raise=CustomTestOnlyException
         )

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -15,7 +15,10 @@ from mlagents_envs.base_env import BaseEnv
 from mlagents_envs.side_channel.engine_configuration_channel import EngineConfig
 from mlagents_envs.side_channel.stats_side_channel import StatsAggregationMethod
 from mlagents_envs.exception import UnityEnvironmentException
-from mlagents.trainers.tests.simple_test_envs import SimpleEnvironment
+from mlagents.trainers.tests.simple_test_envs import (
+    SimpleEnvironment,
+    UnexpectedExceptionEnvironment,
+)
 from mlagents.trainers.stats import StatsReporter
 from mlagents.trainers.agent_processor import AgentManagerQueue
 from mlagents.trainers.tests.check_env_trains import (
@@ -205,6 +208,32 @@ def test_subprocess_env_endtoend(num_envs):
     assert all(
         val > 0.7 for val in StatsReporter.writers[0].get_last_rewards().values()
     )
+    env_manager.close()
+
+
+class CustomTestOnlyException(Exception):
+    pass
+
+
+@pytest.mark.parametrize("num_envs", [1, 4])
+def test_subprocess_failing_step(num_envs):
+    def failing_step_env_factory(worker_id, config):
+        env = UnexpectedExceptionEnvironment(
+            ["1D"], use_discrete=True, to_raise=CustomTestOnlyException
+        )
+        return env
+
+    env_manager = SubprocessEnvManager(
+        failing_step_env_factory, EngineConfig.default_config()
+    )
+    # Expect the exception raised to be routed back up to the top level.
+    with pytest.raises(CustomTestOnlyException):
+        check_environment_trains(
+            failing_step_env_factory(0, []),
+            {"1D": ppo_dummy_config()},
+            env_manager=env_manager,
+            success_threshold=None,
+        )
     env_manager.close()
 
 


### PR DESCRIPTION
### Proposed change(s)

Fixes 2 issues:

1. **Issue:** SubprocessEnvManager could hang if a subprocess sent an unexpected exception (e.g. NAN error). **fix:** This is fixed by forwarding unknown exceptions (in addition to the previous whitelist of specific exceptions) to the manager from the workers.
1. **Issue:** SubprocessEnvManager could miss handling exception messages from workers if the workers shut down before flushing their messages to the queue. **fix:** This is fixed by removing the cancel_join_thread() call, and instead sending a sentinel value to indicate worker shutdown. The manager will now wait for workers to shutdown for 10 seconds before killing them rather than possibly shutting down before them.


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-1199

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
N/A
