### PR TITLE
[WIP] Integrate BrainParameters with ActionSpec, update BrainParametersDrawer

### DIFF
--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -167,7 +167,7 @@ namespace Unity.MLAgents.Editor
         void UpdateBrainParameters()
         {
             var behaviorParameters = (BehaviorParameters)target;
-            behaviorParameters.BrainParameters.UpdateBrainParameters();
+            behaviorParameters.BrainParameters.UpdateDiscreteParameters();
         }
     }
 }

--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -27,6 +27,7 @@ namespace Unity.MLAgents.Editor
             var so = serializedObject;
             so.Update();
             bool needPolicyUpdate; // Whether the name, model, inference device, or BehaviorType changed.
+            bool needBrainParametersUpdate;
 
             // Drawing the Behavior Parameters
             EditorGUI.indentLevel++;
@@ -38,11 +39,13 @@ namespace Unity.MLAgents.Editor
             }
             needPolicyUpdate = EditorGUI.EndChangeCheck();
 
+            EditorGUI.BeginChangeCheck();
             EditorGUI.BeginDisabledGroup(!EditorUtilities.CanUpdateModelProperties());
             {
                 EditorGUILayout.PropertyField(so.FindProperty("m_BrainParameters"), true);
             }
             EditorGUI.EndDisabledGroup();
+            needBrainParametersUpdate = EditorGUI.EndChangeCheck();
 
             EditorGUI.BeginChangeCheck();
             {
@@ -75,6 +78,10 @@ namespace Unity.MLAgents.Editor
             if (needPolicyUpdate)
             {
                 UpdateAgentPolicy();
+            }
+            if (needBrainParametersUpdate)
+            {
+                UpdateBrainParameters();
             }
         }
 
@@ -155,6 +162,13 @@ namespace Unity.MLAgents.Editor
         {
             var behaviorParameters = (BehaviorParameters)target;
             behaviorParameters.UpdateAgentPolicy();
+        }
+
+        void UpdateBrainParameters()
+        {
+            var behaviorParameters = (BehaviorParameters)target;
+            var brainParameters = behaviorParameters.BrainParameters;
+            brainParameters.UpdateBrainParameters();
         }
     }
 }

--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -27,7 +27,7 @@ namespace Unity.MLAgents.Editor
             var so = serializedObject;
             so.Update();
             bool needPolicyUpdate; // Whether the name, model, inference device, or BehaviorType changed.
-            bool needBrainParametersUpdate;
+            bool needBrainParametersUpdate; // Whether the brain parameters changed
 
             // Drawing the Behavior Parameters
             EditorGUI.indentLevel++;
@@ -167,8 +167,7 @@ namespace Unity.MLAgents.Editor
         void UpdateBrainParameters()
         {
             var behaviorParameters = (BehaviorParameters)target;
-            var brainParameters = behaviorParameters.BrainParameters;
-            brainParameters.UpdateBrainParameters();
+            behaviorParameters.BrainParameters.UpdateBrainParameters();
         }
     }
 }

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -14,6 +14,10 @@ namespace Unity.MLAgents.Editor
         // The height of a line in the Unity Inspectors
         const float k_LineHeight = 17f;
         const int k_VecObsNumLine = 3;
+        const string k_ActionSpecName = "VectorActionSpec";
+        const string k_ContinuousActionSizeName = "m_NumContinuousActions";
+        const string k_DiscreteActionSizeName = "m_NumDiscreteActions";
+        const string k_DiscreteBranchSizeName = "m_BranchSizes";
         const string k_ActionSizePropName = "VectorActionSize";
         const string k_ActionTypePropName = "VectorActionSpaceType";
         const string k_ActionDescriptionPropName = "VectorActionDescriptions";
@@ -97,22 +101,10 @@ namespace Unity.MLAgents.Editor
             EditorGUI.LabelField(position, "Vector Action");
             position.y += k_LineHeight;
             EditorGUI.indentLevel++;
-            var bpVectorActionType = property.FindPropertyRelative(k_ActionTypePropName);
-            EditorGUI.PropertyField(
-                position,
-                bpVectorActionType,
-                new GUIContent("Space Type",
-                    "Corresponds to whether state vector contains  a single integer (Discrete) " +
-                    "or a series of real-valued floats (Continuous)."));
+            var actionSpecProperty = property.FindPropertyRelative(k_ActionSpecName);
+            DrawContinuousVectorAction(position, actionSpecProperty);
             position.y += k_LineHeight;
-            if (bpVectorActionType.enumValueIndex == 1)
-            {
-                DrawContinuousVectorAction(position, property);
-            }
-            else
-            {
-                DrawDiscreteVectorAction(position, property);
-            }
+            DrawDiscreteVectorAction(position, actionSpecProperty);
         }
 
         /// <summary>
@@ -123,21 +115,11 @@ namespace Unity.MLAgents.Editor
         /// to make the custom GUI for.</param>
         static void DrawContinuousVectorAction(Rect position, SerializedProperty property)
         {
-            var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
-
-            // This check is here due to:
-            // https://fogbugz.unity3d.com/f/cases/1246524/
-            // If this case has been resolved, please remove this if condition.
-            if (vecActionSize.arraySize != 1)
-            {
-                vecActionSize.arraySize = 1;
-            }
-            var continuousActionSize =
-                vecActionSize.GetArrayElementAtIndex(0);
+            var continuousActionSize = property.FindPropertyRelative(k_ContinuousActionSizeName);
             EditorGUI.PropertyField(
                 position,
                 continuousActionSize,
-                new GUIContent("Space Size", "Length of continuous action vector."));
+                new GUIContent("Continuous Action Size", "Length of continuous action vector."));
         }
 
         /// <summary>
@@ -148,27 +130,27 @@ namespace Unity.MLAgents.Editor
         /// to make the custom GUI for.</param>
         static void DrawDiscreteVectorAction(Rect position, SerializedProperty property)
         {
-            var vecActionSize = property.FindPropertyRelative(k_ActionSizePropName);
+            var branchSizes = property.FindPropertyRelative(k_DiscreteBranchSizeName);
             var newSize = EditorGUI.IntField(
-                position, "Branches Size", vecActionSize.arraySize);
+                position, "Discrete Branch Sizes", branchSizes.arraySize);
 
             // This check is here due to:
             // https://fogbugz.unity3d.com/f/cases/1246524/
             // If this case has been resolved, please remove this if condition.
-            if (newSize != vecActionSize.arraySize)
+            if (newSize != branchSizes.arraySize)
             {
-                vecActionSize.arraySize = newSize;
+                branchSizes.arraySize = newSize;
             }
 
             position.y += k_LineHeight;
             position.x += 20;
             position.width -= 20;
             for (var branchIndex = 0;
-                 branchIndex < vecActionSize.arraySize;
+                 branchIndex < branchSizes.arraySize;
                  branchIndex++)
             {
                 var branchActionSize =
-                    vecActionSize.GetArrayElementAtIndex(branchIndex);
+                    branchSizes.GetArrayElementAtIndex(branchIndex);
 
                 EditorGUI.PropertyField(
                     position,
@@ -185,11 +167,8 @@ namespace Unity.MLAgents.Editor
         /// <returns>The height of the drawer of the Vector Action.</returns>
         static float GetHeightDrawVectorAction(SerializedProperty property)
         {
-            var actionSize = 2 + property.FindPropertyRelative(k_ActionSizePropName).arraySize;
-            if (property.FindPropertyRelative(k_ActionTypePropName).enumValueIndex == 0)
-            {
-                actionSize += 1;
-            }
+            var actionSpecProperty = property.FindPropertyRelative(k_ActionSpecName);
+            var actionSize = 3 + actionSpecProperty.FindPropertyRelative("m_BranchSizes").arraySize;
             return actionSize * k_LineHeight;
         }
     }

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -132,7 +132,7 @@ namespace Unity.MLAgents.Editor
         {
             var branchSizes = property.FindPropertyRelative(k_DiscreteBranchSizeName);
             var newSize = EditorGUI.IntField(
-                position, "Discrete Branch Sizes", branchSizes.arraySize);
+                position, "Discrete Branch Size", branchSizes.arraySize);
 
             // This check is here due to:
             // https://fogbugz.unity3d.com/f/cases/1246524/

--- a/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
+++ b/com.unity.ml-agents/Editor/BrainParametersDrawer.cs
@@ -16,10 +16,7 @@ namespace Unity.MLAgents.Editor
         const int k_VecObsNumLine = 3;
         const string k_ActionSpecName = "VectorActionSpec";
         const string k_ContinuousActionSizeName = "m_NumContinuousActions";
-        const string k_DiscreteActionSizeName = "m_NumDiscreteActions";
         const string k_DiscreteBranchSizeName = "m_BranchSizes";
-        const string k_ActionSizePropName = "VectorActionSize";
-        const string k_ActionTypePropName = "VectorActionSpaceType";
         const string k_ActionDescriptionPropName = "VectorActionDescriptions";
         const string k_VecObsPropName = "VectorObservationSize";
         const string k_NumVecObsPropName = "NumStackedVectorObservations";

--- a/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
@@ -72,17 +72,17 @@ namespace Unity.MLAgents.Editor
         /// </summary>
         void MakeActionsProperty(SerializedProperty property)
         {
-            // TODO: update deprecated fields to ActionSpec
-            var actSizeProperty = property.FindPropertyRelative("VectorActionSize");
-            var actSpaceTypeProp = property.FindPropertyRelative("VectorActionSpaceType");
+            var actSpecProperty = property.FindPropertyRelative("VectorActionSpec");
+            var continuousSizeProperty = actSpecProperty.FindPropertyRelative("m_NumContinuousActions");
+            var discreteSizeProperty = actSpecProperty.FindPropertyRelative("m_NumDiscreteActions");
 
-            var vecActSizeLabel =
-                actSizeProperty.displayName + ": " + BuildIntArrayLabel(actSizeProperty);
-            var actSpaceTypeLabel = actSpaceTypeProp.displayName + ": " +
-                (SpaceType)actSpaceTypeProp.enumValueIndex;
+            var continuousSizeLabel =
+                continuousSizeProperty.displayName + ": " + continuousSizeProperty.intValue;
+            var discreteSizeLabel = discreteSizeProperty.displayName + ": " +
+                discreteSizeProperty.intValue;
 
-            EditorGUILayout.LabelField(vecActSizeLabel);
-            EditorGUILayout.LabelField(actSpaceTypeLabel);
+            EditorGUILayout.LabelField(continuousSizeLabel);
+            EditorGUILayout.LabelField(discreteSizeLabel);
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
+++ b/com.unity.ml-agents/Editor/DemonstrationDrawer.cs
@@ -72,6 +72,7 @@ namespace Unity.MLAgents.Editor
         /// </summary>
         void MakeActionsProperty(SerializedProperty property)
         {
+            // TODO: update deprecated fields to ActionSpec
             var actSizeProperty = property.FindPropertyRelative("VectorActionSize");
             var actSpaceTypeProp = property.FindPropertyRelative("VectorActionSpaceType");
 

--- a/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
@@ -73,6 +73,18 @@ namespace Unity.MLAgents.Actuators
             return actuatorSpace;
         }
 
+        public void SetContinuous(int numContinuousActions)
+        {
+            m_NumContinuousActions = numContinuousActions;
+        }
+
+        public void SetDiscrete(int numDiscreteActions, int[] branchSizes)
+        {
+            m_NumDiscreteActions = numDiscreteActions;
+            m_BranchSizes = branchSizes;
+            m_SumOfDiscreteBranchSizes = branchSizes.Sum();
+        }
+
         internal ActionSpec(int numContinuousActions, int numDiscreteActions, int[] branchSizes = null)
         {
             m_NumContinuousActions = numContinuousActions;

--- a/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
@@ -73,11 +73,21 @@ namespace Unity.MLAgents.Actuators
             return actuatorSpace;
         }
 
+        /// <summary>
+        /// Set action size fields related to continuous actions.
+        /// </summary>
+        /// <param name="numContinuousActions">Number of Continuous Actions</param>
         public void SetContinuous(int numContinuousActions)
         {
             m_NumContinuousActions = numContinuousActions;
         }
 
+        /// <summary>
+        /// Set action size fields related to discrete actions.
+        /// </summary>
+        /// <param name="numDiscreteActions">Number of Discrete Actions</param>
+        /// <param name="branchSizes">The array of branch sizes for the discrete action space.  Each index
+        /// contains the number of actions available for that branch.</param>
         public void SetDiscrete(int numDiscreteActions, int[] branchSizes)
         {
             m_NumDiscreteActions = numDiscreteActions;

--- a/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
@@ -1,15 +1,24 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Unity.MLAgents.Policies;
+using UnityEngine;
 
 namespace Unity.MLAgents.Actuators
 {
     /// <summary>
     /// Defines the structure of an Action Space to be used by the Actuator system.
     /// </summary>
-    public readonly struct ActionSpec
+    [Serializable]
+    public struct ActionSpec
     {
+        [SerializeField]
+        int[] m_BranchSizes;
+        [SerializeField]
+        int m_NumContinuousActions;
+        [SerializeField]
+        int m_NumDiscreteActions;
+        [SerializeField]
+        int m_SumOfDiscreteBranchSizes;
 
         /// <summary>
         /// An array of branch sizes for our action space.
@@ -21,23 +30,23 @@ namespace Unity.MLAgents.Actuators
         ///
         /// For an IActuator with a Continuous it will be null.
         /// </summary>
-        public readonly int[] BranchSizes;
+        public int[] BranchSizes { get { return m_BranchSizes; } set { m_BranchSizes = value; } }
 
         /// <summary>
         /// The number of actions for a Continuous <see cref="SpaceType"/>.
         /// </summary>
-        public int NumContinuousActions { get; }
+        public int NumContinuousActions { get { return m_NumContinuousActions; } set { m_NumContinuousActions = value; } }
 
         /// <summary>
         /// The number of branches for a Discrete <see cref="SpaceType"/>.
         /// </summary>
-        public int NumDiscreteActions { get; }
+        public int NumDiscreteActions { get { return m_NumDiscreteActions; } set { m_NumDiscreteActions = value; } }
 
         /// <summary>
         /// Get the total number of Discrete Actions that can be taken by calculating the Sum
         /// of all of the Discrete Action branch sizes.
         /// </summary>
-        public int SumOfDiscreteBranchSizes { get; }
+        public int SumOfDiscreteBranchSizes { get { return m_SumOfDiscreteBranchSizes; } set { m_SumOfDiscreteBranchSizes = value; } }
 
         /// <summary>
         /// Creates a Continuous <see cref="ActionSpec"/> with the number of actions available.
@@ -66,10 +75,10 @@ namespace Unity.MLAgents.Actuators
 
         internal ActionSpec(int numContinuousActions, int numDiscreteActions, int[] branchSizes = null)
         {
-            NumContinuousActions = numContinuousActions;
-            NumDiscreteActions = numDiscreteActions;
-            BranchSizes = branchSizes;
-            SumOfDiscreteBranchSizes = branchSizes?.Sum() ?? 0;
+            m_NumContinuousActions = numContinuousActions;
+            m_NumDiscreteActions = numDiscreteActions;
+            m_BranchSizes = branchSizes;
+            m_SumOfDiscreteBranchSizes = branchSizes?.Sum() ?? 0;
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Actuators/VectorActuator.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/VectorActuator.cs
@@ -22,33 +22,15 @@ namespace Unity.MLAgents.Actuators
         /// Create a VectorActuator that forwards to the provided IActionReceiver.
         /// </summary>
         /// <param name="actionReceiver">The <see cref="IActionReceiver"/> used for OnActionReceived and WriteDiscreteActionMask.</param>
-        /// <param name="vectorActionSize">For discrete action spaces, the branch sizes for each action.
-        /// For continuous action spaces, the number of actions is the 0th element.</param>
-        /// <param name="spaceType"></param>
+        /// <param name="actionSpec"></param>
         /// <param name="name"></param>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown for invalid <see cref="SpaceType"/></exception>
         public VectorActuator(IActionReceiver actionReceiver,
-                              int[] vectorActionSize,
-                              SpaceType spaceType,
+                              ActionSpec actionSpec,
                               string name = "VectorActuator")
         {
             m_ActionReceiver = actionReceiver;
-            string suffix;
-            switch (spaceType)
-            {
-                case SpaceType.Continuous:
-                    ActionSpec = ActionSpec.MakeContinuous(vectorActionSize[0]);
-                    suffix = "-Continuous";
-                    break;
-                case SpaceType.Discrete:
-                    ActionSpec = ActionSpec.MakeDiscrete(vectorActionSize);
-                    suffix = "-Discrete";
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(spaceType),
-                        spaceType,
-                        "Unknown enum value.");
-            }
+            ActionSpec = actionSpec;
+            string suffix = $"-Continuous-{actionSpec.NumContinuousActions}-Discrete-{actionSpec.NumDiscreteActions}";
             Name = name + suffix;
         }
 

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -875,7 +875,7 @@ namespace Unity.MLAgents
         public virtual void Heuristic(in ActionBuffers actionsOut)
         {
             // For backward compatibility
-            switch (m_PolicyFactory.BrainParameters.VectorActionSpaceType)
+            switch (m_PolicyFactory.BrainParameters.VectorActionSpaceTypeDeprecated)
             {
                 case SpaceType.Continuous:
                     Heuristic(actionsOut.ContinuousActions.Array);
@@ -975,7 +975,7 @@ namespace Unity.MLAgents
             // Support legacy OnActionReceived
             // TODO don't set this up if the sizes are 0?
             var param = m_PolicyFactory.BrainParameters;
-            m_VectorActuator = new VectorActuator(this, param.VectorActionSize, param.VectorActionSpaceType);
+            m_VectorActuator = new VectorActuator(this, param.VectorActionSpec);
             m_ActuatorManager = new ActuatorManager(attachedActuators.Length + 1);
             m_LegacyActionCache = new float[m_VectorActuator.TotalNumberOfActions()];
 

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -96,10 +96,11 @@ namespace Unity.MLAgents
         {
             var brainParametersProto = new BrainParametersProto
             {
-                VectorActionSizeDeprecated = { bp.VectorActionSize },
-                VectorActionSpaceTypeDeprecated = (SpaceTypeProto)bp.VectorActionSpaceType,
+                VectorActionSizeDeprecated = { bp.VectorActionSizeDeprecated },
+                VectorActionSpaceTypeDeprecated = (SpaceTypeProto)bp.VectorActionSpaceTypeDeprecated,
                 BrainName = name,
-                IsTraining = isTraining
+                IsTraining = isTraining,
+                ActionSpec = ToActionSpecProto(bp.VectorActionSpec),
             };
             if (bp.VectorActionDescriptions != null)
             {
@@ -120,18 +121,9 @@ namespace Unity.MLAgents
             var brainParametersProto = new BrainParametersProto
             {
                 BrainName = name,
-                IsTraining = isTraining
+                IsTraining = isTraining,
+                ActionSpec = ToActionSpecProto(actionSpec),
             };
-            var actionSpecProto = new ActionSpecProto
-            {
-                NumContinuousActions = actionSpec.NumContinuousActions,
-                NumDiscreteActions = actionSpec.NumDiscreteActions,
-            };
-            if (actionSpec.BranchSizes != null)
-            {
-                actionSpecProto.DiscreteBranchSizes.AddRange(actionSpec.BranchSizes);
-            }
-            brainParametersProto.ActionSpec = actionSpecProto;
 
             var supportHybrid = Academy.Instance.TrainerCapabilities == null || Academy.Instance.TrainerCapabilities.HybridActions;
             if (!supportHybrid)
@@ -162,13 +154,48 @@ namespace Unity.MLAgents
         {
             var bp = new BrainParameters
             {
-                VectorActionSize = bpp.VectorActionSizeDeprecated.ToArray(),
+                VectorActionSizeDeprecated = bpp.VectorActionSizeDeprecated.ToArray(),
                 VectorActionDescriptions = bpp.VectorActionDescriptionsDeprecated.ToArray(),
-                VectorActionSpaceType = (SpaceType)bpp.VectorActionSpaceTypeDeprecated
+                VectorActionSpaceTypeDeprecated = (SpaceType)bpp.VectorActionSpaceTypeDeprecated,
+                VectorActionSpec = ToActionSpec(bpp.ActionSpec),
             };
             return bp;
         }
 
+        /// <summary>
+        /// Convert a ActionSpecProto to a ActionSpec struct.
+        /// </summary>
+        /// <param name="actionSpecProto">An instance of an action spec protobuf object.</param>
+        /// <returns>An ActionSpec struct.</returns>
+        public static ActionSpec ToActionSpec(this ActionSpecProto actionSpecProto)
+        {
+            var actionSpec = new ActionSpec
+            (
+                actionSpecProto.NumContinuousActions,
+                actionSpecProto.NumDiscreteActions,
+                actionSpecProto.DiscreteBranchSizes.ToArray()
+            );
+            return actionSpec;
+        }
+
+        /// <summary>
+        /// Convert a ActionSpec struct to a ActionSpecProto.
+        /// </summary>
+        /// <param name="actionSpecProto">An instance of an action spec struct.</param>
+        /// <returns>An ActionSpecProto.</returns>
+        public static ActionSpecProto ToActionSpecProto(this ActionSpec actionSpec)
+        {
+            var actionSpecProto = new ActionSpecProto
+            {
+                NumContinuousActions = actionSpec.NumContinuousActions,
+                NumDiscreteActions = actionSpec.NumDiscreteActions,
+            };
+            if (actionSpec.BranchSizes != null)
+            {
+                actionSpecProto.DiscreteBranchSizes.AddRange(actionSpec.BranchSizes);
+            }
+            return actionSpecProto;
+        }
         #endregion
 
         #region DemonstrationMetaData

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -397,8 +397,8 @@ namespace Unity.MLAgents.Inference
             BrainParameters brainParameters, TensorProxy tensorProxy,
             SensorComponent[] sensorComponents, int observableAttributeTotalSize)
         {
-            // TODO: Update this check after intergrating ActionSpec into BrainParameters
-            var numberActionsBp = brainParameters.VectorActionSize.Length;
+            var numberActionsBp = brainParameters.VectorActionSpec.NumContinuousActions +
+                brainParameters.VectorActionSpec.NumDiscreteActions;
             var numberActionsT = tensorProxy.shape[tensorProxy.shape.Length - 1];
             if (numberActionsBp != numberActionsT)
             {
@@ -489,11 +489,7 @@ namespace Unity.MLAgents.Inference
         static string CheckDiscreteActionOutputShape(
             BrainParameters brainParameters, ActuatorComponent[] actuatorComponents, TensorShape? shape, int modelContinuousActionSize, int modelSumDiscreteBranchSizes)
         {
-            var sumOfDiscreteBranchSizes = 0;
-            if (brainParameters.VectorActionSpaceType == SpaceType.Discrete)
-            {
-                sumOfDiscreteBranchSizes += brainParameters.VectorActionSize.Sum();
-            }
+            var sumOfDiscreteBranchSizes = brainParameters.VectorActionSpec.SumOfDiscreteBranchSizes;
 
             foreach (var actuatorComponent in actuatorComponents)
             {
@@ -529,11 +525,7 @@ namespace Unity.MLAgents.Inference
         static string CheckContinuousActionOutputShape(
             BrainParameters brainParameters, ActuatorComponent[] actuatorComponents, TensorShape? shape, int modelContinuousActionSize, int modelSumDiscreteBranchSizes)
         {
-            var numContinuousActions = 0;
-            if (brainParameters.VectorActionSpaceType == SpaceType.Continuous)
-            {
-                numContinuousActions += brainParameters.NumActions;
-            }
+            var numContinuousActions = brainParameters.VectorActionSpec.NumContinuousActions;
 
             foreach (var actuatorComponent in actuatorComponents)
             {

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -33,7 +33,7 @@ namespace Unity.MLAgents.Policies
     /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
     /// </remarks>
     [Serializable]
-    public class BrainParameters
+    public class BrainParameters : ISerializationCallbackReceiver
     {
         /// <summary>
         /// The number of the observations that are added in
@@ -119,6 +119,42 @@ namespace Unity.MLAgents.Policies
                 VectorActionSpaceTypeDeprecated = VectorActionSpaceTypeDeprecated,
                 VectorActionSpec = new ActionSpec(VectorActionSpec.NumContinuousActions, VectorActionSpec.NumDiscreteActions, VectorActionSpec.BranchSizes)
             };
+        }
+
+        public void OnBeforeSerialize()
+        {
+            if (!hasUpgradedBrainParametersWithActionSpec)
+            {
+                if (VectorActionSpec.NumContinuousActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Continuous)
+                {
+                    VectorActionSpec.NumContinuousActions = VectorActionSizeDeprecated[0];
+                }
+                if (VectorActionSpec.NumDiscreteActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Discrete)
+                {
+                    VectorActionSpec.NumDiscreteActions = VectorActionSizeDeprecated.Length;
+                    VectorActionSpec.BranchSizes = VectorActionSizeDeprecated;
+                    VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSizeDeprecated.Sum();
+                }
+                hasUpgradedBrainParametersWithActionSpec = true;
+            }
+        }
+
+        public void OnAfterDeserialize()
+        {
+            if (!hasUpgradedBrainParametersWithActionSpec)
+            {
+                if (VectorActionSpec.NumContinuousActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Continuous)
+                {
+                    VectorActionSpec.NumContinuousActions = VectorActionSizeDeprecated[0];
+                }
+                if (VectorActionSpec.NumDiscreteActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Discrete)
+                {
+                    VectorActionSpec.NumDiscreteActions = VectorActionSizeDeprecated.Length;
+                    VectorActionSpec.BranchSizes = VectorActionSizeDeprecated;
+                    VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSizeDeprecated.Sum();
+                }
+                hasUpgradedBrainParametersWithActionSpec = true;
+            }
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Serialization;
 using Unity.MLAgents.Actuators;
@@ -64,7 +65,8 @@ namespace Unity.MLAgents.Policies
         /// For the discrete action space: the number of branches in the action space.
         /// </value>
         [FormerlySerializedAs("vectorActionSize")]
-        public int[] VectorActionSize = new[] { 1 };
+        [FormerlySerializedAs("VectorActionSize")]
+        public int[] VectorActionSizeDeprecated = new[] { 1 };
 
         /// <summary>
         /// The list of strings describing what the actions correspond to.
@@ -76,21 +78,26 @@ namespace Unity.MLAgents.Policies
         /// Defines if the action is discrete or continuous.
         /// </summary>
         [FormerlySerializedAs("vectorActionSpaceType")]
-        public SpaceType VectorActionSpaceType = SpaceType.Discrete;
+        [FormerlySerializedAs("VectorActionSpaceType")]
+        public SpaceType VectorActionSpaceTypeDeprecated = SpaceType.Discrete;
+
+        [SerializeField]
+        [HideInInspector]
+        internal bool hasUpgradedBrainParametersWithActionSpec;
 
         /// <summary>
         /// The number of actions specified by this Brain.
         /// </summary>
-        public int NumActions
+        public int NumActionsDeprecated
         {
             get
             {
-                switch (VectorActionSpaceType)
+                switch (VectorActionSpaceTypeDeprecated)
                 {
                     case SpaceType.Discrete:
-                        return VectorActionSize.Length;
+                        return VectorActionSizeDeprecated.Length;
                     case SpaceType.Continuous:
-                        return VectorActionSize[0];
+                        return VectorActionSizeDeprecated[0];
                     default:
                         return 0;
                 }
@@ -107,9 +114,9 @@ namespace Unity.MLAgents.Policies
             {
                 VectorObservationSize = VectorObservationSize,
                 NumStackedVectorObservations = NumStackedVectorObservations,
-                VectorActionSize = (int[])VectorActionSize.Clone(),
+                VectorActionSizeDeprecated = (int[])VectorActionSizeDeprecated.Clone(),
                 VectorActionDescriptions = (string[])VectorActionDescriptions.Clone(),
-                VectorActionSpaceType = VectorActionSpaceType,
+                VectorActionSpaceTypeDeprecated = VectorActionSpaceTypeDeprecated,
                 VectorActionSpec = new ActionSpec(VectorActionSpec.NumContinuousActions, VectorActionSpec.NumDiscreteActions, VectorActionSpec.BranchSizes)
             };
         }

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -196,7 +196,7 @@ namespace Unity.MLAgents.Policies
             }
         }
 
-        internal void UpdateBrainParameters()
+        internal void UpdateDiscreteParameters()
         {
             VectorActionSpec.NumDiscreteActions = VectorActionSpec.BranchSizes.Length;
             VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSpec.BranchSizes.Sum();

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.Serialization;
+using Unity.MLAgents.Actuators;
 
 namespace Unity.MLAgents.Policies
 {
@@ -49,6 +50,8 @@ namespace Unity.MLAgents.Policies
         /// </summary>
         [FormerlySerializedAs("numStackedVectorObservations")]
         [Range(1, 50)] public int NumStackedVectorObservations = 1;
+
+        public ActionSpec VectorActionSpec = new ActionSpec(0, 0, new int[] { });
 
         /// <summary>
         /// The size of the action space.
@@ -106,7 +109,8 @@ namespace Unity.MLAgents.Policies
                 NumStackedVectorObservations = NumStackedVectorObservations,
                 VectorActionSize = (int[])VectorActionSize.Clone(),
                 VectorActionDescriptions = (string[])VectorActionDescriptions.Clone(),
-                VectorActionSpaceType = VectorActionSpaceType
+                VectorActionSpaceType = VectorActionSpaceType,
+                VectorActionSpec = new ActionSpec(VectorActionSpec.NumContinuousActions, VectorActionSpec.NumDiscreteActions, VectorActionSpec.BranchSizes)
             };
         }
     }

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -52,10 +52,13 @@ namespace Unity.MLAgents.Policies
         [FormerlySerializedAs("numStackedVectorObservations")]
         [Range(1, 50)] public int NumStackedVectorObservations = 1;
 
+        /// <summary>
+        /// The specification of the Action space for the BrainParameters.
+        /// </summary>
         public ActionSpec VectorActionSpec = new ActionSpec(0, 0, new int[] { });
 
         /// <summary>
-        /// The size of the action space.
+        /// (Deprecated) The size of the action space.
         /// </summary>
         /// <remarks>The size specified is interpreted differently depending on whether
         /// the agent uses the continuous or the discrete action space.</remarks>
@@ -75,7 +78,7 @@ namespace Unity.MLAgents.Policies
         public string[] VectorActionDescriptions;
 
         /// <summary>
-        /// Defines if the action is discrete or continuous.
+        /// (Deprecated) Defines if the action is discrete or continuous.
         /// </summary>
         [FormerlySerializedAs("vectorActionSpaceType")]
         [FormerlySerializedAs("VectorActionSpaceType")]
@@ -86,7 +89,7 @@ namespace Unity.MLAgents.Policies
         internal bool hasUpgradedBrainParametersWithActionSpec;
 
         /// <summary>
-        /// The number of actions specified by this Brain.
+        /// (Deprecated) The number of actions specified by this Brain.
         /// </summary>
         public int NumActionsDeprecated
         {
@@ -121,6 +124,26 @@ namespace Unity.MLAgents.Policies
             };
         }
 
+        /// <summary>
+        /// Called by Unity immediately before serializing this object.
+        /// </summary>
+        /// <remarks>
+        /// The BrainParameter class uses OnBeforeSerialize() for internal housekeeping. Call the
+        /// base class implementation if you need your own custom serialization logic.
+        ///
+        /// See [OnBeforeSerialize] for more information.
+        ///
+        /// [OnBeforeSerialize]: https://docs.unity3d.com/ScriptReference/ISerializationCallbackReceiver.OnAfterDeserialize.html
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// public new void OnBeforeSerialize()
+        /// {
+        ///     base.OnBeforeSerialize();
+        ///     // additional serialization logic...
+        /// }
+        /// </code>
+        /// </example>
         public void OnBeforeSerialize()
         {
             if (!hasUpgradedBrainParametersWithActionSpec)
@@ -137,6 +160,26 @@ namespace Unity.MLAgents.Policies
             }
         }
 
+        /// <summary>
+        /// Called by Unity immediately after deserializing this object.
+        /// </summary>
+        /// <remarks>
+        /// The BrainParameter class uses OnAfterDeserialize() for internal housekeeping. Call the
+        /// base class implementation if you need your own custom deserialization logic.
+        ///
+        /// See [OnAfterDeserialize] for more information.
+        ///
+        /// [OnAfterDeserialize]: https://docs.unity3d.com/ScriptReference/ISerializationCallbackReceiver.OnAfterDeserialize.html
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// public new void OnAfterDeserialize()
+        /// {
+        ///     base.OnAfterDeserialize();
+        ///     // additional deserialization logic...
+        /// }
+        /// </code>
+        /// </example>
         public void OnAfterDeserialize()
         {
             if (!hasUpgradedBrainParametersWithActionSpec)

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -127,13 +127,11 @@ namespace Unity.MLAgents.Policies
             {
                 if (VectorActionSpec.NumContinuousActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Continuous)
                 {
-                    VectorActionSpec.NumContinuousActions = VectorActionSizeDeprecated[0];
+                    VectorActionSpec.SetContinuous(VectorActionSizeDeprecated[0]);
                 }
                 if (VectorActionSpec.NumDiscreteActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Discrete)
                 {
-                    VectorActionSpec.NumDiscreteActions = VectorActionSizeDeprecated.Length;
-                    VectorActionSpec.BranchSizes = VectorActionSizeDeprecated;
-                    VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSizeDeprecated.Sum();
+                    VectorActionSpec.SetDiscrete(VectorActionSizeDeprecated.Length, VectorActionSizeDeprecated);
                 }
                 hasUpgradedBrainParametersWithActionSpec = true;
             }
@@ -145,13 +143,11 @@ namespace Unity.MLAgents.Policies
             {
                 if (VectorActionSpec.NumContinuousActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Continuous)
                 {
-                    VectorActionSpec.NumContinuousActions = VectorActionSizeDeprecated[0];
+                    VectorActionSpec.SetContinuous(VectorActionSizeDeprecated[0]);
                 }
                 if (VectorActionSpec.NumDiscreteActions == 0 && VectorActionSpaceTypeDeprecated == SpaceType.Discrete)
                 {
-                    VectorActionSpec.NumDiscreteActions = VectorActionSizeDeprecated.Length;
-                    VectorActionSpec.BranchSizes = VectorActionSizeDeprecated;
-                    VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSizeDeprecated.Sum();
+                    VectorActionSpec.SetDiscrete(VectorActionSizeDeprecated.Length, VectorActionSizeDeprecated);
                 }
                 hasUpgradedBrainParametersWithActionSpec = true;
             }

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -152,5 +152,11 @@ namespace Unity.MLAgents.Policies
                 hasUpgradedBrainParametersWithActionSpec = true;
             }
         }
+
+        internal void UpdateBrainParameters()
+        {
+            VectorActionSpec.NumDiscreteActions = VectorActionSpec.BranchSizes.Length;
+            VectorActionSpec.SumOfDiscreteBranchSizes = VectorActionSpec.BranchSizes.Sum();
+        }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/Actuators/VectorActuatorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Actuators/VectorActuatorTests.cs
@@ -32,13 +32,13 @@ namespace Unity.MLAgents.Tests.Actuators
         public void TestConstruct()
         {
             var ar = new TestActionReceiver();
-            var va = new VectorActuator(ar, new[] { 1, 2, 3 }, SpaceType.Discrete, "name");
+            var va = new VectorActuator(ar, ActionSpec.MakeDiscrete(new int[] { 1, 2, 3 }), "name");
 
             Assert.IsTrue(va.ActionSpec.NumDiscreteActions == 3);
             Assert.IsTrue(va.ActionSpec.SumOfDiscreteBranchSizes == 6);
             Assert.IsTrue(va.ActionSpec.NumContinuousActions == 0);
 
-            var va1 = new VectorActuator(ar, new[] { 4 }, SpaceType.Continuous, "name");
+            var va1 = new VectorActuator(ar, ActionSpec.MakeContinuous(4), "name");
 
             Assert.IsTrue(va1.ActionSpec.NumContinuousActions == 4);
             Assert.IsTrue(va1.ActionSpec.SumOfDiscreteBranchSizes == 0);
@@ -49,7 +49,7 @@ namespace Unity.MLAgents.Tests.Actuators
         public void TestOnActionReceived()
         {
             var ar = new TestActionReceiver();
-            var va = new VectorActuator(ar, new[] { 1, 2, 3 }, SpaceType.Discrete, "name");
+            var va = new VectorActuator(ar, ActionSpec.MakeDiscrete(new int[] { 1, 2, 3 }), "name");
 
             var discreteActions = new[] { 0, 1, 1 };
             var ab = new ActionBuffers(ActionSegment<float>.Empty,
@@ -67,7 +67,7 @@ namespace Unity.MLAgents.Tests.Actuators
         public void TestResetData()
         {
             var ar = new TestActionReceiver();
-            var va = new VectorActuator(ar, new[] { 1, 2, 3 }, SpaceType.Discrete, "name");
+            var va = new VectorActuator(ar, ActionSpec.MakeDiscrete(new int[] { 1, 2, 3 }), "name");
 
             var discreteActions = new[] { 0, 1, 1 };
             var ab = new ActionBuffers(ActionSegment<float>.Empty,
@@ -80,7 +80,7 @@ namespace Unity.MLAgents.Tests.Actuators
         public void TestWriteDiscreteActionMask()
         {
             var ar = new TestActionReceiver();
-            var va = new VectorActuator(ar, new[] { 1, 2, 3 }, SpaceType.Discrete, "name");
+            var va = new VectorActuator(ar, ActionSpec.MakeDiscrete(new int[] { 1, 2, 3 }), "name");
             var bdam = new ActuatorDiscreteActionMask(new[] { va }, 6, 3);
 
             var groundTruthMask = new[] { false, true, false, false, true, true };

--- a/com.unity.ml-agents/Tests/Editor/Actuators/VectorActuatorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Actuators/VectorActuatorTests.cs
@@ -42,7 +42,7 @@ namespace Unity.MLAgents.Tests.Actuators
 
             Assert.IsTrue(va1.ActionSpec.NumContinuousActions == 4);
             Assert.IsTrue(va1.ActionSpec.SumOfDiscreteBranchSizes == 0);
-            Assert.AreEqual(va1.Name, "name-Continuous");
+            Assert.AreEqual(va1.Name, "name-Continuous-4-Discrete-0");
         }
 
         [Test]

--- a/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/DemonstrationTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using UnityEngine;
 using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
+using Unity.MLAgents.Actuators;
 using Unity.MLAgents.CommunicatorObjects;
 using Unity.MLAgents.Sensors;
 using Unity.MLAgents.Demonstrations;
@@ -46,8 +47,7 @@ namespace Unity.MLAgents.Tests
             bp.BrainParameters.VectorObservationSize = 3;
             bp.BrainParameters.NumStackedVectorObservations = 2;
             bp.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bp.BrainParameters.VectorActionSize = new[] { 2, 2 };
-            bp.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
+            bp.BrainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new[] { 2, 2 });
 
             gameobj.AddComponent<TestAgent>();
 
@@ -103,8 +103,7 @@ namespace Unity.MLAgents.Tests
             bpA.BrainParameters.VectorObservationSize = 3;
             bpA.BrainParameters.NumStackedVectorObservations = 1;
             bpA.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            bpA.BrainParameters.VectorActionSize = new[] { 2, 2 };
-            bpA.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
+            bpA.BrainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new[] { 2, 2 });
 
             agentGo1.AddComponent<ObservationAgent>();
             var agent1 = agentGo1.GetComponent<ObservationAgent>();

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -340,14 +340,12 @@ namespace Unity.MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo1.AddComponent<TestAgent>();
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var agentGo2 = new GameObject("TestAgent");
             var bp2 = agentGo2.AddComponent<BehaviorParameters>();
-            bp2.BrainParameters.VectorActionSize = new[] { 1 };
-            bp2.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp2.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo2.AddComponent<TestAgent>();
             var agent2 = agentGo2.GetComponent<TestAgent>();
 
@@ -452,14 +450,12 @@ namespace Unity.MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo1.AddComponent<TestAgent>();
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var agentGo2 = new GameObject("TestAgent");
             var bp2 = agentGo2.AddComponent<BehaviorParameters>();
-            bp2.BrainParameters.VectorActionSize = new[] { 1 };
-            bp2.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp2.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo2.AddComponent<TestAgent>();
             var agent2 = agentGo2.GetComponent<TestAgent>();
 
@@ -538,8 +534,7 @@ namespace Unity.MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             var agent1 = agentGo1.AddComponent<TestAgent>();
             var behaviorParameters = agentGo1.GetComponent<BehaviorParameters>();
             behaviorParameters.BrainParameters.NumStackedVectorObservations = 3;
@@ -588,13 +583,11 @@ namespace Unity.MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             var agent1 = agentGo1.AddComponent<TestAgent>();
             var agentGo2 = new GameObject("TestAgent");
             var bp2 = agentGo2.AddComponent<BehaviorParameters>();
-            bp2.BrainParameters.VectorActionSize = new[] { 1 };
-            bp2.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp2.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             var agent2 = agentGo2.AddComponent<TestAgent>();
             var aca = Academy.Instance;
 
@@ -632,8 +625,7 @@ namespace Unity.MLAgents.Tests
         {
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo1.AddComponent<TestAgent>();
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var aca = Academy.Instance;
@@ -698,8 +690,7 @@ namespace Unity.MLAgents.Tests
             // Make sure that Agents with HeuristicPolicies step their sensors each Academy step.
             var agentGo1 = new GameObject("TestAgent");
             var bp1 = agentGo1.AddComponent<BehaviorParameters>();
-            bp1.BrainParameters.VectorActionSize = new[] { 1 };
-            bp1.BrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            bp1.BrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(1);
             agentGo1.AddComponent<TestAgent>();
             var agent1 = agentGo1.GetComponent<TestAgent>();
             var aca = Academy.Instance;

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -109,16 +109,14 @@ namespace Unity.MLAgents.Tests
             return validBrainParameters;
         }
 
-        // TODO: update and enable this after integrating action spec into BrainParameters
-        // BrainParameters GetHybridBrainParameters()
-        // {
-        //     var validBrainParameters = new BrainParameters();
-        //     validBrainParameters.VectorObservationSize = 53;
-        //     validBrainParameters.VectorActionSize = new[] { 2 };
-        //     validBrainParameters.NumStackedVectorObservations = 1;
-        //     validBrainParameters.VectorActionSpaceType = SpaceType.Discrete;
-        //     return validBrainParameters;
-        // }
+        BrainParameters GetHybridBrainParameters()
+        {
+            var validBrainParameters = new BrainParameters();
+            validBrainParameters.VectorObservationSize = 53;
+            validBrainParameters.NumStackedVectorObservations = 1;
+            validBrainParameters.VectorActionSpec = new ActionSpec(3, 1, new int[] { 2 });
+            return validBrainParameters;
+        }
 
         [SetUp]
         public void SetUp()
@@ -252,19 +250,18 @@ namespace Unity.MLAgents.Tests
             Assert.AreEqual(0, errors.Count()); // There should not be any errors
         }
 
-        // TODO: update and enable this test after integrating action spec into BrainParameters
-        // [Test]
-        // public void TestCheckModelValidHybrid()
-        // {
-        //     var model = ModelLoader.Load(hybridModel);
-        //     var validBrainParameters = GetHybridBrainParameters();
+        [Test]
+        public void TestCheckModelValidHybrid()
+        {
+            var model = ModelLoader.Load(hybridONNXModel);
+            var validBrainParameters = GetHybridBrainParameters();
 
-        //     var errors = BarracudaModelParamLoader.CheckModel(
-        //         model, validBrainParameters,
-        //         new SensorComponent[] { }, new ActuatorComponent[0]
-        //     );
-        //     Assert.AreEqual(0, errors.Count()); // There should not be any errors
-        // }
+            var errors = BarracudaModelParamLoader.CheckModel(
+                model, validBrainParameters,
+                new SensorComponent[] { }, new ActuatorComponent[0]
+            );
+            Assert.AreEqual(0, errors.Count()); // There should not be any errors
+        }
 
         [TestCase(true)]
         [TestCase(false)]
@@ -301,28 +298,27 @@ namespace Unity.MLAgents.Tests
             Assert.Greater(errors.Count(), 0);
         }
 
-        // TODO: update and enable this test after integrating action spec into BrainParameters
-        // [Test]
-        // public void TestCheckModelThrowsVectorObservationHybrid()
-        // {
-        //     var model = ModelLoader.Load(hybridModel);
+        [Test]
+        public void TestCheckModelThrowsVectorObservationHybrid()
+        {
+            var model = ModelLoader.Load(hybridONNXModel);
 
-        //     var brainParameters = GetHybridBrainParameters();
-        //     brainParameters.VectorObservationSize = 9; // Invalid observation
-        //     var errors = BarracudaModelParamLoader.CheckModel(
-        //         model, brainParameters,
-        //         new SensorComponent[] { }, new ActuatorComponent[0]
-        //     );
-        //     Assert.Greater(errors.Count(), 0);
+            var brainParameters = GetHybridBrainParameters();
+            brainParameters.VectorObservationSize = 9; // Invalid observation
+            var errors = BarracudaModelParamLoader.CheckModel(
+                model, brainParameters,
+                new SensorComponent[] { }, new ActuatorComponent[0]
+            );
+            Assert.Greater(errors.Count(), 0);
 
-        //     brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-        //     brainParameters.NumStackedVectorObservations = 2;// Invalid stacking
-        //     errors = BarracudaModelParamLoader.CheckModel(
-        //         model, brainParameters,
-        //         new SensorComponent[] { }, new ActuatorComponent[0]
-        //     );
-        //     Assert.Greater(errors.Count(), 0);
-        // }
+            brainParameters = GetContinuous2vis8vec2actionBrainParameters();
+            brainParameters.NumStackedVectorObservations = 2;// Invalid stacking
+            errors = BarracudaModelParamLoader.CheckModel(
+                model, brainParameters,
+                new SensorComponent[] { }, new ActuatorComponent[0]
+            );
+            Assert.Greater(errors.Count(), 0);
+        }
 
         [TestCase(true)]
         [TestCase(false)]
@@ -358,22 +354,21 @@ namespace Unity.MLAgents.Tests
             Assert.Greater(errors.Count(), 0);
         }
 
-        // TODO: update and enable this test after integrating action spec into BrainParameters
-        // [Test]
-        // public void TestCheckModelThrowsActionHybrid()
-        // {
-        //     var model = ModelLoader.Load(hybridModel);
+        [Test]
+        public void TestCheckModelThrowsActionHybrid()
+        {
+            var model = ModelLoader.Load(hybridONNXModel);
 
-        //     var brainParameters = GetHybridBrainParameters();
-        //     brainParameters.VectorActionSize = new[] { 3 }; // Invalid action
-        //     var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
-        //     Assert.Greater(errors.Count(), 0);
+            var brainParameters = GetHybridBrainParameters();
+            brainParameters.VectorActionSpec = new ActionSpec(3, 1, new int[] { 3 }); ; // Invalid discrete action size
+            var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
+            Assert.Greater(errors.Count(), 0);
 
-        //     brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-        //     brainParameters.VectorActionSpaceType = SpaceType.Discrete;// Invalid SpaceType
-        //     errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
-        //     Assert.Greater(errors.Count(), 0);
-        // }
+            brainParameters = GetContinuous2vis8vec2actionBrainParameters();
+            brainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new int[] { 2 }); // Missing continuous action
+            errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
+            Assert.Greater(errors.Count(), 0);
+        }
 
         [Test]
         public void TestCheckModelThrowsNoModel()

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -95,9 +95,8 @@ namespace Unity.MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.VectorObservationSize = 8;
-            validBrainParameters.VectorActionSize = new[] { 2 };
             validBrainParameters.NumStackedVectorObservations = 1;
-            validBrainParameters.VectorActionSpaceType = SpaceType.Continuous;
+            validBrainParameters.VectorActionSpec = ActionSpec.MakeContinuous(2);
             return validBrainParameters;
         }
 
@@ -105,9 +104,8 @@ namespace Unity.MLAgents.Tests
         {
             var validBrainParameters = new BrainParameters();
             validBrainParameters.VectorObservationSize = 0;
-            validBrainParameters.VectorActionSize = new[] { 2, 3 };
             validBrainParameters.NumStackedVectorObservations = 1;
-            validBrainParameters.VectorActionSpaceType = SpaceType.Discrete;
+            validBrainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new[] { 2, 3 });
             return validBrainParameters;
         }
 
@@ -333,12 +331,12 @@ namespace Unity.MLAgents.Tests
             var model = useDeprecatedNNModel ? ModelLoader.Load(continuousNNModel) : ModelLoader.Load(continuousONNXModel);
 
             var brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.VectorActionSize = new[] { 3 }; // Invalid action
+            brainParameters.VectorActionSpec.SetContinuous(3); // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
             Assert.Greater(errors.Count(), 0);
 
             brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.VectorActionSpaceType = SpaceType.Discrete;// Invalid SpaceType
+            brainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new int[] { 3 }); // Invalid SpaceType
             errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3, sensor_20_22_3 }, new ActuatorComponent[0]);
             Assert.Greater(errors.Count(), 0);
         }
@@ -350,12 +348,12 @@ namespace Unity.MLAgents.Tests
             var model = useDeprecatedNNModel ? ModelLoader.Load(discreteNNModel) : ModelLoader.Load(discreteONNXModel);
 
             var brainParameters = GetDiscrete1vis0vec_2_3action_recurrModelBrainParameters();
-            brainParameters.VectorActionSize = new[] { 3, 3 }; // Invalid action
+            brainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new[] { 3, 3 }); // Invalid action
             var errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 }, new ActuatorComponent[0]);
             Assert.Greater(errors.Count(), 0);
 
             brainParameters = GetContinuous2vis8vec2actionBrainParameters();
-            brainParameters.VectorActionSpaceType = SpaceType.Continuous;// Invalid SpaceType
+            brainParameters.VectorActionSpec = ActionSpec.MakeContinuous(2); // Invalid SpaceType
             errors = BarracudaModelParamLoader.CheckModel(model, brainParameters, new SensorComponent[] { sensor_21_20_3 }, new ActuatorComponent[0]);
             Assert.Greater(errors.Count(), 0);
         }

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -72,8 +72,7 @@ namespace Tests
             behaviorParams.BrainParameters.VectorObservationSize = 3;
             behaviorParams.BrainParameters.NumStackedVectorObservations = 2;
             behaviorParams.BrainParameters.VectorActionDescriptions = new[] { "TestActionA", "TestActionB" };
-            behaviorParams.BrainParameters.VectorActionSize = new[] { 2, 2 };
-            behaviorParams.BrainParameters.VectorActionSpaceType = SpaceType.Discrete;
+            behaviorParams.BrainParameters.VectorActionSpec = ActionSpec.MakeDiscrete(new[] { 2, 2 });
             behaviorParams.BehaviorName = "TestBehavior";
             behaviorParams.TeamId = 42;
             behaviorParams.UseChildSensors = true;


### PR DESCRIPTION
### Proposed change(s)

* Add an ActionSpec in BrainParameters, replace old fields in BrainParameters with corresponding fields in ActionSpec and deprecate the old fields
* Add serialization callbacks to propagate ActionSpec fields from the old fields
* Update BrainParametersDrawer to allow specifying hybrid actions in editor
* ActionSpec is modified to be _not_ read-only

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
JIRA: [MLA-1320](https://jira.unity3d.com/browse/MLA-1320)


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
