### PR TITLE
Allow 2d obs to be communicated

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
@@ -40,7 +40,7 @@ namespace Unity.MLAgents.Sensors
             }
             else if (shape.Length == 2)
             {
-                m_TensorShape = new TensorShape(new int[]{m_Batch, 1, shape[0], shape[1]});
+                m_TensorShape = new TensorShape(new int[] { m_Batch, 1, shape[0], shape[1] });
             }
             else
             {

--- a/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
@@ -38,6 +38,10 @@ namespace Unity.MLAgents.Sensors
             {
                 m_TensorShape = new TensorShape(m_Batch, shape[0]);
             }
+            else if (shape.Length == 2)
+            {
+                m_TensorShape = new TensorShape(new int[]{m_Batch, 1, shape[0], shape[1]});
+            }
             else
             {
                 m_TensorShape = new TensorShape(m_Batch, shape[0], shape[1], shape[2]);

--- a/ml-agents-envs/mlagents_envs/rpc_utils.py
+++ b/ml-agents-envs/mlagents_envs/rpc_utils.py
@@ -238,14 +238,14 @@ def _process_vector_observation(
     ],  # pylint: disable=unsubscriptable-object
 ) -> np.ndarray:
     if len(agent_info_list) == 0:
-        return np.zeros((0, shape[0]), dtype=np.float32)
+        return np.zeros((0,) + shape, dtype=np.float32)
     np_obs = np.array(
         [
             agent_obs.observations[obs_index].float_data.data
             for agent_obs in agent_info_list
         ],
         dtype=np.float32,
-    )
+    ).reshape((len(agent_info_list), ) + shape)
     _raise_on_nan_and_inf(np_obs, "observations")
     return np_obs
 

--- a/ml-agents-envs/mlagents_envs/rpc_utils.py
+++ b/ml-agents-envs/mlagents_envs/rpc_utils.py
@@ -245,7 +245,7 @@ def _process_vector_observation(
             for agent_obs in agent_info_list
         ],
         dtype=np.float32,
-    ).reshape((len(agent_info_list), ) + shape)
+    ).reshape((len(agent_info_list),) + shape)
     _raise_on_nan_and_inf(np_obs, "observations")
     return np_obs
 


### PR DESCRIPTION
### Proposed change(s)

This change allows for 2d sensors to send data to python and for python to receive it.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
