### PR TITLE
Fix bug in model export with new action output nodes

### DIFF
--- a/ml-agents/mlagents/trainers/torch/action_model.py
+++ b/ml-agents/mlagents/trainers/torch/action_model.py
@@ -159,14 +159,14 @@ class ActionModel(nn.Module):
         continuous_out, discrete_out, action_out_deprecated = None, None, None
         if self.action_spec.continuous_size > 0 and dists.continuous is not None:
             continuous_out = dists.continuous.exported_model_output()
-            action_out_deprecated = continuous_out
+            action_out_deprecated = dists.continuous.exported_model_output()
         if self.action_spec.discrete_size > 0 and dists.discrete is not None:
-            discrete_out = [
+            discrete_out_list = [
                 discrete_dist.exported_model_output()
                 for discrete_dist in dists.discrete
             ]
-            discrete_out = torch.cat(discrete_out, dim=1)
-            action_out_deprecated = discrete_out
+            discrete_out = torch.cat(discrete_out_list, dim=1)
+            action_out_deprecated = torch.cat(discrete_out_list, dim=1)
         # deprecated action field does not support hybrid action
         if self.action_spec.continuous_size > 0 and self.action_spec.discrete_size > 0:
             action_out_deprecated = None

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -66,6 +66,7 @@ class ModelSerializer:
             + [f"visual_observation_{i}" for i in range(self.policy.vis_obs_size)]
             + ["action_masks", "memories"]
         )
+        self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
 
         self.output_names = ["version_number", "memory_size"]
         if self.policy.behavior_spec.action_spec.continuous_size > 0:
@@ -73,8 +74,10 @@ class ModelSerializer:
                 "continuous_actions",
                 "continuous_action_output_shape",
             ]
+            self.dynamic_axes.update({"continuous_actions": {0: "batch"}})
         if self.policy.behavior_spec.action_spec.discrete_size > 0:
             self.output_names += ["discrete_actions", "discrete_action_output_shape"]
+            self.dynamic_axes.update({"discrete_actions": {0: "batch"}})
         if (
             self.policy.behavior_spec.action_spec.continuous_size == 0
             or self.policy.behavior_spec.action_spec.discrete_size == 0
@@ -84,9 +87,7 @@ class ModelSerializer:
                 "is_continuous_control",
                 "action_output_shape",
             ]
-
-        self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
-        self.dynamic_axes.update({"action": {0: "batch"}})
+            self.dynamic_axes.update({"action": {0: "batch"}})
 
     def export_policy_model(self, output_filepath: str) -> None:
         """


### PR DESCRIPTION
### Proposed change(s)

Force the new action output and deprecated action output to be different nodes in the graph

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

The deprecated `action_out_deprecated` is assigned to be the same as continuous or discrete action output according to action spec.

However the new action output and deprecated action output will point to the same tensor and same node in the graph, causing one of them being missing is the graph since one node can only have one name.

Solving this issue by forcing them to be different nodes in the graph.


Also fixing missing nodes in dynamic_axes.


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
