### PR TITLE
clean up docs on actions, code examples, reference to hybrid

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Reacher/Scripts/ReacherAgent.cs
@@ -63,7 +63,6 @@ public class ReacherAgent : Agent
     /// The agent's four actions correspond to torques on each of the two joints.
     /// </summary>
     public override void OnActionReceived(ActionBuffers actionBuffers)
-
     {
         m_GoalDegree += m_GoalSpeed;
         UpdateGoalPosition();

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,10 +14,8 @@ and this project adheres to
 
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-- Analytics events are now collected when performing inference in the editor. For more details on what is collected and
-how to opt out, see the [package README](Documentation~/com.unity.ml-agents.md). (#4677)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- `ActionSpec.validate_action()` now enforces that `UnityEnvironment.set_action_for_agent()` receives a 1D `np.array`. (#4691)
+- `ActionSpec.validate_action()` now enforces that `UnityEnvironment.set_action_for_agent()` receives a 1D `np.array`.
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to
 
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
+- Analytics events are now collected when performing inference in the editor. For more details on what is collected and
+how to opt out, see the [package README](Documentation~/com.unity.ml-agents.md). (#4677)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- `ActionSpec.validate_action()` now enforces that `UnityEnvironment.set_action_for_agent()` receives a 1D `np.array`.
+- `ActionSpec.validate_action()` now enforces that `UnityEnvironment.set_action_for_agent()` receives a 1D `np.array`. (#4691)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -89,7 +89,7 @@ namespace Unity.MLAgents
         ///     </item>
         ///     <item>
         ///         <term>1.3.0</term>
-        ///         <description>Support hybrid action spaces.</description>
+        ///         <description>Support action spaces with both continuous and discrete actions.</description>
         ///     </item>
         /// </list>
         /// </remarks>
@@ -256,6 +256,7 @@ namespace Unity.MLAgents
                 Dispose();
             }
         }
+
 #endif
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActionSpec.cs
@@ -10,7 +10,6 @@ namespace Unity.MLAgents.Actuators
     /// </summary>
     public readonly struct ActionSpec
     {
-
         /// <summary>
         /// An array of branch sizes for our action space.
         ///
@@ -73,16 +72,18 @@ namespace Unity.MLAgents.Actuators
         }
 
         /// <summary>
-        /// Temporary check that the ActionSpec uses either all continuous or all discrete actions.
-        /// This should be removed once the trainer supports them.
+        /// Check that the ActionSpec uses either all continuous or all discrete actions.
+        /// This is only used when connecting to old versions of the trainer that don't support this.
         /// </summary>
         /// <exception cref="UnityAgentsException"></exception>
-        internal void CheckNotHybrid()
+        internal void CheckAllContinuousOrDiscrete()
         {
             if (NumContinuousActions > 0 && NumDiscreteActions > 0)
             {
-                throw new UnityAgentsException("Hybrid action spaces not supported by the trainer. " +
-                    "ActionSpecs must be all continuous or all discrete.");
+                throw new UnityAgentsException(
+                    "Action spaces with both continuous and discrete actions are not supported by the trainer. " +
+                    "ActionSpecs must be all continuous or all discrete."
+                );
             }
         }
     }

--- a/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
@@ -102,7 +102,6 @@ namespace Unity.MLAgents.Actuators
                 for (var i = 0; i < actionSpec.NumDiscreteActions; i++)
                 {
                     discreteActions[i] = (int)actions[i + offset];
-
                 }
                 discreteActionSegment = new ActionSegment<int>(discreteActions);
             }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1265,7 +1265,6 @@ namespace Unity.MLAgents
             {
                 OnEpisodeBegin();
             }
-
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -89,7 +89,6 @@ namespace Unity.MLAgents
             return summariesOut;
         }
 
-
         #endregion
 
         #region BrainParameters
@@ -144,7 +143,7 @@ namespace Unity.MLAgents
             var supportHybrid = Academy.Instance.TrainerCapabilities == null || Academy.Instance.TrainerCapabilities.HybridActions;
             if (!supportHybrid)
             {
-                actionSpec.CheckNotHybrid();
+                actionSpec.CheckAllContinuousOrDiscrete();
                 if (actionSpec.NumContinuousActions > 0)
                 {
                     brainParametersProto.VectorActionSizeDeprecated.Add(actionSpec.NumContinuousActions);
@@ -215,6 +214,7 @@ namespace Unity.MLAgents
             }
             return dm;
         }
+
         #endregion
 
         public static UnityRLInitParameters ToUnityRLInitParameters(this UnityRLInitializationInputProto inputProto)
@@ -290,8 +290,8 @@ namespace Unity.MLAgents
                     if (!s_HaveWarnedTrainerCapabilitiesMapping)
                     {
                         Debug.LogWarning($"The sensor {sensor.GetName()} is using non-trivial mapping and " +
-                                "the attached trainer doesn't support compression mapping. " +
-                                "Switching to uncompressed observations.");
+                            "the attached trainer doesn't support compression mapping. " +
+                            "Switching to uncompressed observations.");
                         s_HaveWarnedTrainerCapabilitiesMapping = true;
                     }
                     compressionType = SensorCompressionType.None;
@@ -327,7 +327,7 @@ namespace Unity.MLAgents
                         $"GetCompressedObservation() returned null data for sensor named {sensor.GetName()}. " +
                         "You must return a byte[]. If you don't want to use compressed observations, " +
                         "return SensorCompressionType.None from GetCompressionType()."
-                        );
+                    );
                 }
                 observationProto = new ObservationProto
                 {
@@ -343,6 +343,7 @@ namespace Unity.MLAgents
             observationProto.Shape.AddRange(shape);
             return observationProto;
         }
+
         #endregion
 
         public static UnityRLCapabilities ToRLCapabilities(this UnityRLCapabilitiesProto proto)

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -75,7 +75,6 @@ namespace Unity.MLAgents
                 {
                     return false;
                 }
-
             }
             else if (unityVersion.Major != pythonVersion.Major)
             {

--- a/com.unity.ml-agents/Runtime/Communicator/UnityRLCapabilities.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/UnityRLCapabilities.cs
@@ -37,10 +37,9 @@ namespace Unity.MLAgents
                 return false;
             }
             Debug.LogWarning("Unity has connected to a Training process that does not support" +
-                             "Base Reinforcement Learning Capabilities.  Please make sure you have the" +
-                             " latest training codebase installed for this version of the ML-Agents package.");
+                "Base Reinforcement Learning Capabilities.  Please make sure you have the" +
+                " latest training codebase installed for this version of the ML-Agents package.");
             return true;
         }
-
     }
 }

--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelExtensions.cs
@@ -79,7 +79,6 @@ namespace Unity.MLAgents.Inference
             return tensors;
         }
 
-
         /// <summary>
         /// Get number of visual observation inputs to the model.
         /// </summary>
@@ -154,7 +153,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return false;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return (int)model.GetTensorByName(TensorNames.IsContinuousControlDeprecated)[0] > 0;
             }
@@ -176,7 +175,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return 0;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return (int)model.GetTensorByName(TensorNames.IsContinuousControlDeprecated)[0] > 0 ?
                     (int)model.GetTensorByName(TensorNames.ActionOutputShapeDeprecated)[0] : 0;
@@ -199,7 +198,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return null;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return TensorNames.ActionOutputDeprecated;
             }
@@ -220,7 +219,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return false;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return (int)model.GetTensorByName(TensorNames.IsContinuousControlDeprecated)[0] == 0;
             }
@@ -242,7 +241,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return 0;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return (int)model.GetTensorByName(TensorNames.IsContinuousControlDeprecated)[0] > 0 ?
                     0 : (int)model.GetTensorByName(TensorNames.ActionOutputShapeDeprecated)[0];
@@ -265,7 +264,7 @@ namespace Unity.MLAgents.Inference
         {
             if (model == null)
                 return null;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 return TensorNames.ActionOutputDeprecated;
             }
@@ -283,7 +282,7 @@ namespace Unity.MLAgents.Inference
         /// The Barracuda engine model for loading static parameters.
         /// </param>
         /// <returns>True if the model supports hybrid action spaces.</returns>
-        public static bool HasHybridSupport(this Model model)
+        public static bool SupportsContinuousAndDiscrete(this Model model)
         {
             return model == null ||
                 model.outputs.Contains(TensorNames.ContinuousActionOutput) ||
@@ -325,7 +324,7 @@ namespace Unity.MLAgents.Inference
             }
 
             // Check the presence of action output shape tensor
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
                 if (model.GetTensorByName(TensorNames.ActionOutputShapeDeprecated) == null)
                 {

--- a/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs
@@ -59,9 +59,9 @@ namespace Unity.MLAgents.Inference
             }
 
             var model = (Model)barracudaModel;
-            if (!model.HasHybridSupport())
+            if (!model.SupportsContinuousAndDiscrete())
             {
-                actionSpec.CheckNotHybrid();
+                actionSpec.CheckAllContinuousOrDiscrete();
             }
             if (actionSpec.NumContinuousActions > 0)
             {

--- a/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
@@ -62,7 +62,6 @@ namespace Unity.MLAgents.Policies
         /// <inheritdoc />
         public ref readonly ActionBuffers DecideAction()
         {
-
             if (m_ModelRunner == null)
             {
                 m_LastActionBuffer = ActionBuffers.Empty;

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -82,7 +82,7 @@ eight elements: the `x` and `z` components of the agent cube's rotation and the
 
 #### Behavior Parameters : Vector Action Space
 
-An Agent is given instructions in the form `ActionBuffers`.
+An Agent is given instructions in the form of actions.
 ML-Agents Toolkit classifies actions into two types: continuous and discrete.
 The 3D Balance Ball example is programmed to use continuous actions, which
 are a vector of floating-point numbers that can vary continuously. More specifically,

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -82,11 +82,11 @@ eight elements: the `x` and `z` components of the agent cube's rotation and the
 
 #### Behavior Parameters : Vector Action Space
 
-An Agent is given instructions in the form of a float array of _actions_.
+An Agent is given instructions in the form `ActionBuffers`.
 ML-Agents Toolkit classifies actions into two types: continuous and discrete.
-The 3D Balance Ball example is programmed to use continuous action space which
-is a a vector of numbers that can vary continuously. More specifically, it uses
-a `Space Size` of 2 to control the amount of `x` and `z` rotations to apply to
+The 3D Balance Ball example is programmed to use continuous actions, which
+are a vector of floating-point numbers that can vary continuously. More specifically,
+it uses a `Space Size` of 2 to control the amount of `x` and `z` rotations to apply to
 itself to keep the ball balanced on its head.
 
 ## Running a pre-trained model

--- a/docs/Learning-Environment-Create-New.md
+++ b/docs/Learning-Environment-Create-New.md
@@ -148,7 +148,7 @@ extend three methods from the `Agent` base class:
 
 - `OnEpisodeBegin()`
 - `CollectObservations(VectorSensor sensor)`
-- `OnActionReceived(float[] vectorAction)`
+- `OnActionReceived(ActionBuffers actionBuffers)`
 
 We overview each of these in more detail in the dedicated subsections below.
 
@@ -314,12 +314,12 @@ With the action and reward logic outlined above, the final version of the
 
 ```csharp
 public float forceMultiplier = 10;
-public override void OnActionReceived(float[] vectorAction)
+public override void OnActionReceived(ActionBuffers actionBuffers)
 {
     // Actions, size = 2
     Vector3 controlSignal = Vector3.zero;
-    controlSignal.x = vectorAction[0];
-    controlSignal.z = vectorAction[1];
+    controlSignal.x = actionBuffers.ContinuousActions[0];
+    controlSignal.z = actionBuffers.ContinuousActions[1];
     rBody.AddForce(controlSignal * forceMultiplier);
 
     // Rewards
@@ -375,10 +375,11 @@ action corresponding to the values of the "Horizontal" and "Vertical" input axis
 (which correspond to the keyboard arrow keys):
 
 ```csharp
-public override void Heuristic(float[] actionsOut)
+public override void Heuristic(in ActionBuffers actionsOut)
 {
-    actionsOut[0] = Input.GetAxis("Horizontal");
-    actionsOut[1] = Input.GetAxis("Vertical");
+    var continuousActionsOut = actionsOut.ContinuousActions;
+    continuousActionsOut[0] = Input.GetAxis("Horizontal");
+    continuousActionsOut[1] = Input.GetAxis("Vertical");
 }
 ```
 

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -541,7 +541,7 @@ up to use either the continuous or the discrete vector action spaces.
 
 ### Continuous Action Space
 
-When an Agent uses a Policy set to the **Continuous** vector action space, the
+When an Agent's Policy has **Continuous** actions, the
 `ActionBuffers.ContinuousActions` passed to the Agent's `OnActionReceived()` function
 is an array with length equal to the `Vector Action Space Size` property value. The
 individual values in the array have whatever meanings that you ascribe to them.
@@ -576,7 +576,7 @@ As shown above, you can scale the control values as needed after clamping them.
 
 ### Discrete Action Space
 
-When an Agent uses a **Discrete** vector action space, the
+When an Agent's Policy uses **discrete** actions, the
 `ActionBuffers.DiscreteActions` passed to the Agent's `OnActionReceived()` function
 is an array of integers. When defining the discrete vector action space, `Branches`
 is an array of integers, each value corresponds to the number of possibilities for each branch.

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -510,20 +510,9 @@ setting the State Size.
 ## Actions
 
 An action is an instruction from the Policy that the agent carries out. The
-action is passed to the Agent as a parameter when the Academy invokes the
-agent's `OnActionReceived()` function. Actions for an agent can take one of two
-forms, either **Continuous** or **Discrete**.
-
-When you specify that the vector action space is **Continuous**, the action
-parameter passed to the Agent is an array of floating point numbers with length
-equal to the `Vector Action Space Size` property. When you specify a
-**Discrete** vector action space type, the action parameter is an array
-containing integers. Each integer is an index into a list or table of commands.
-In the **Discrete** vector action space type, the action parameter is an array
-of indices. The number of indices in the array is determined by the number of
-branches defined in the `Branches Size` property. Each branch corresponds to an
-action table, you can specify the size of each table by modifying the `Branches`
-property.
+action is passed to the Agent as the `ActionBuffers` parameter when the Academy invokes the
+agent's `OnActionReceived()` function. There are two types of actions supported:
+ **Continuous** and **Discrete**.
 
 Neither the Policy nor the training algorithm know anything about what the
 action values themselves mean. The training algorithm simply tries different
@@ -553,8 +542,8 @@ up to use either the continuous or the discrete vector action spaces.
 ### Continuous Action Space
 
 When an Agent uses a Policy set to the **Continuous** vector action space, the
-action parameter passed to the Agent's `OnActionReceived()` function is an array
-with length equal to the `Vector Action Space Size` property value. The
+`ActionBuffers.ContinuousActions` passed to the Agent's `OnActionReceived()` function
+is an array with length equal to the `Vector Action Space Size` property value. The
 individual values in the array have whatever meanings that you ascribe to them.
 If you assign an element in the array as the speed of an Agent, for example, the
 training process learns to control the speed of the Agent through this
@@ -568,16 +557,16 @@ continuous action space with four control values.
 These control values are applied as torques to the bodies making up the arm:
 
 ```csharp
-public override void OnActionReceived(float[] act)
-{
-    float torque_x = Mathf.Clamp(act[0], -1, 1) * 100f;
-    float torque_z = Mathf.Clamp(act[1], -1, 1) * 100f;
-    rbA.AddTorque(new Vector3(torque_x, 0f, torque_z));
+    public override void OnActionReceived(ActionBuffers actionBuffers)
+    {
+        var torqueX = Mathf.Clamp(actionBuffers.ContinuousActions[0], -1f, 1f) * 150f;
+        var torqueZ = Mathf.Clamp(actionBuffers.ContinuousActions[1], -1f, 1f) * 150f;
+        m_RbA.AddTorque(new Vector3(torqueX, 0f, torqueZ));
 
-    torque_x = Mathf.Clamp(act[2], -1, 1) * 100f;
-    torque_z = Mathf.Clamp(act[3], -1, 1) * 100f;
-    rbB.AddTorque(new Vector3(torque_x, 0f, torque_z));
-}
+        torqueX = Mathf.Clamp(actionBuffers.ContinuousActions[2], -1f, 1f) * 150f;
+        torqueZ = Mathf.Clamp(actionBuffers.ContinuousActions[3], -1f, 1f) * 150f;
+        m_RbB.AddTorque(new Vector3(torqueX, 0f, torqueZ));
+    }
 ```
 
 By default the output from our provided PPO algorithm pre-clamps the values of
@@ -587,10 +576,10 @@ As shown above, you can scale the control values as needed after clamping them.
 
 ### Discrete Action Space
 
-When an Agent uses a **Discrete** vector action space, the action parameter
-passed to the Agent's `OnActionReceived()` function is an array containing
-indices. With the discrete vector action space, `Branches` is an array of
-integers, each value corresponds to the number of possibilities for each branch.
+When an Agent uses a **Discrete** vector action space, the
+`ActionBuffers.DiscreteActions` passed to the Agent's `OnActionReceived()` function
+is an array of integers. When defining the discrete vector action space, `Branches`
+is an array of integers, each value corresponds to the number of possibilities for each branch.
 
 For example, if we wanted an Agent that can move in a plane and jump, we could
 define two branches (one for motion and one for jumping) because we want our
@@ -601,9 +590,9 @@ and the second one to have 2 possible actions (don't jump, jump). The
 
 ```csharp
 // Get the action index for movement
-int movement = Mathf.FloorToInt(act[0]);
+int movement = actionBuffers.DiscreteActions[0];
 // Get the action index for jumping
-int jump = Mathf.FloorToInt(act[1]);
+int jump = actionBuffers.DiscreteActions[1];
 
 // Look up the index in the movement action list:
 if (movement == 1) { directionX = -1; }
@@ -619,10 +608,6 @@ gameObject.GetComponent<Rigidbody>().AddForce(
         directionX * 40f, directionY * 300f, directionZ * 40f));
 ```
 
-Note that the above code example is a simplified extract from the AreaAgent
-class, which provides alternate implementations for both the discrete and the
-continuous action spaces.
-
 #### Masking Discrete Actions
 
 When using Discrete Actions, it is possible to specify that some actions are
@@ -630,12 +615,13 @@ impossible for the next decision. When the Agent is controlled by a neural
 network, the Agent will be unable to perform the specified action. Note that
 when the Agent is controlled by its Heuristic, the Agent will still be able to
 decide to perform the masked action. In order to mask an action, override the
-`Agent.CollectDiscreteActionMasks()` virtual method, and call
-`DiscreteActionMasker.SetMask()` in it:
+`Agent.WriteDiscreteActionMask()` virtual method, and call
+`WriteMask()` on the provided `IDiscreteActionMask`:
 
 ```csharp
-public override void CollectDiscreteActionMasks(DiscreteActionMasker actionMasker){
-    actionMasker.SetMask(branch, actionIndices)
+public override void WriteDiscreteActionMask(IDiscreteActionMask actionMask)
+{
+    actionMasker.WriteMask(branch, actionIndices)
 }
 ```
 
@@ -644,7 +630,7 @@ Where:
 - `branch` is the index (starting at 0) of the branch on which you want to mask
   the action
 - `actionIndices` is a list of `int` corresponding to the indices of the actions
-  that the Agent cannot perform.
+  that the Agent **cannot** perform.
 
 For example, if you have an Agent with 2 branches and on the first branch
 (branch 0) there are 4 possible actions : _"do nothing"_, _"jump"_, _"shoot"_
@@ -653,26 +639,26 @@ nothing"_ or _"change weapon"_ for his next decision (since action index 1 and 2
 are masked)
 
 ```csharp
-SetMask(0, new int[2]{1,2})
+WriteMask(0, new int[2]{1,2})
 ```
 
 Notes:
 
-- You can call `SetMask` multiple times if you want to put masks on multiple
+- You can call `WriteMask` multiple times if you want to put masks on multiple
   branches.
 - You cannot mask all the actions of a branch.
 - You cannot mask actions in continuous control.
 
 ### Actions Summary & Best Practices
 
-- Actions can either use `Discrete` or `Continuous` spaces.
-- When using `Discrete` it is possible to assign multiple action branches, and
-  to mask certain actions.
+- Agents can either use `Discrete` or `Continuous` actions.
+- Discrete actions can have multiple action branches, and it's possible to mask
+  certain actions so that they won't be taken.
 - In general, smaller action spaces will make for easier learning.
 - Be sure to set the Vector Action's Space Size to the number of used Vector
   Actions, and not greater, as doing the latter can interfere with the
   efficiency of the training process.
-- When using continuous control, action values should be clipped to an
+- Continuous action values should be clipped to an
   appropriate range. The provided PPO model automatically clips these values
   between -1 and 1, but third party training systems may not do so.
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -111,8 +111,8 @@ A `BaseEnv` has the following methods:
   terminates the communication.
 - **Behavior Specs : `env.behavior_specs`** Returns a Mapping of
   `BehaviorName` to `BehaviorSpec` objects (read only).
-  A `BehaviorSpec` contains information such as the observation shapes, the
-  action type (multi-discrete or continuous) and the action shape. Note that
+  A `BehaviorSpec` contains information such as the observation shapes and the
+  `ActionSpec` (which defines the action shape). Note that
   the `BehaviorSpec` for a specific group is fixed throughout the simulation.
   The number of entries in the Mapping can change over time in the simulation
   if new Agent behaviors are created in the simulation.
@@ -130,22 +130,18 @@ A `BaseEnv` has the following methods:
   number of agents is not guaranteed to remain constant during the simulation
   and it is not unusual to have either `DecisionSteps` or `TerminalSteps`
   contain no Agents at all.
-- **Set Actions :`env.set_actions(behavior_name: str, action: np.array)`** Sets
-  the actions for a whole agent group. `action` is a 2D `np.array` of
-  `dtype=np.int32` in the discrete action case and `dtype=np.float32` in the
-  continuous action case. The first dimension of `action` is the number of
-  agents that requested a decision since the last call to `env.step()`. The
-  second dimension is the number of discrete actions in multi-discrete action
-  type and the number of actions in continuous action type.
+- **Set Actions :`env.set_actions(behavior_name: str, action: ActionTuple)`** Sets
+  the actions for a whole agent group. `action` is an `ActionTuple`, which
+  is made up of a 2D `np.array` of `dtype=np.int32` for discrete action, and
+  `dtype=np.float32` for continuous action case. The first dimension of `np.array`
+  in the tuple is the number of agents that requested a decision since the
+  last call to `env.step()`. The second dimension is the number of discrete or
+  continuous actions for the corresponding array.
 - **Set Action for Agent :
-  `env.set_action_for_agent(agent_group: str, agent_id: int, action: np.array)`**
+  `env.set_action_for_agent(agent_group: str, agent_id: int, action: ActionTuple)`**
   Sets the action for a specific Agent in an agent group. `agent_group` is the
   name of the group the Agent belongs to and `agent_id` is the integer
-  identifier of the Agent. Action is a 1D array of type `dtype=np.int32` and
-  size equal to the number of discrete actions in multi-discrete action type and
-  of type `dtype=np.float32` and size equal to the number of actions in
-  continuous action type.
-
+  identifier of the Agent. `action` is an `ActionTuple` as described above.
 **Note:** If no action is provided for an agent group between two calls to
 `env.step()` then the default action will be all zeros (in either discrete or
 continuous action space)
@@ -166,7 +162,7 @@ A `DecisionSteps` has the following fields :
   for the corresponding Agent. This is used to track Agents across simulation
   steps.
 - `action_mask` is an optional list of two dimensional array of booleans. Only
-  available in multi-discrete action space type. Each array corresponds to an
+  available when using multi-discrete actions. Each array corresponds to an
   action branch. The first dimension of each array is the batch size and the
   second contains a mask for each action of the branch. If true, the action is
   not available for the agent during this simulation step.
@@ -186,7 +182,7 @@ A `DecisionStep` has the following fields:
   the last simulation step.
 - `agent_id` is an int and an unique identifier for the corresponding Agent.
 - `action_mask` is an optional list of one dimensional array of booleans. Only
-  available in multi-discrete action space type. Each array corresponds to an
+  available when using multi-discrete actions. Each array corresponds to an
   action branch. Each array contains a mask for each action of the branch. If
   true, the action is not available for the agent during this simulation step.
 
@@ -230,32 +226,26 @@ A `TerminalStep` has the following fields:
 
 #### BehaviorSpec
 
-An Agent behavior can either have discrete or continuous actions. To check which
-type it is, use `spec.is_action_discrete()` or `spec.is_action_continuous()` to
-see which one it is. If discrete, the action tensors are expected to be
-`np.int32`. If continuous, the actions are expected to be `np.float32`.
-
 A `BehaviorSpec` has the following fields :
 
 - `observation_shapes` is a List of Tuples of int : Each Tuple corresponds to an
   observation's dimensions (without the number of agents dimension). The shape
   tuples have the same ordering as the ordering of the DecisionSteps,
   DecisionStep, TerminalSteps and TerminalStep.
-- `action_type` is the type of data of the action. it can be discrete or
-  continuous. If discrete, the action tensors are expected to be `np.int32`. If
-  continuous, the actions are expected to be `np.float32`.
-- `action_size` is an `int` corresponding to the expected dimension of the
-  action array.
-  - In continuous action space it is the number of floats that constitute the
-    action.
-  - In discrete action space (same as multi-discrete) it corresponds to the
-    number of branches (the number of independent actions)
-- `discrete_action_branches` is a Tuple of int only for discrete action space.
-  Each int corresponds to the number of different options for each branch of the
-  action. For example : In a game direction input (no movement, left, right) and
+- `action_spec` is an `ActionSpec` namedtuple that defines the number and types
+  of actions for the Agent.
+
+An `ActionSpec` has the following fields and properties:
+- `continuous_size` is the number of floats that constitute the continuous actions.
+- `discrete_size` is the number of branches (the number of independent actions) that
+  constitute the multi-discrete actions.
+- `discrete_branches` is a Tuple of ints. Each int corresponds to the number of
+  different options for each branch of the action. For example:
+  In a game direction input (no movement, left, right) and
   jump input (no jump, jump) there will be two branches (direction and jump),
-  the first one with 3 options and the second with 2 options. (`action_size = 2`
+  the first one with 3 options and the second with 2 options. (`discrete_size = 2`
   and `discrete_action_branches = (3,2,)`)
+
 
 ### Communicating additional information with the Environment
 

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -111,7 +111,7 @@ A `BaseEnv` has the following methods:
   terminates the communication.
 - **Behavior Specs : `env.behavior_specs`** Returns a Mapping of
   `BehaviorName` to `BehaviorSpec` objects (read only).
-  A `BehaviorSpec` contains information such as the observation shapes and the
+  A `BehaviorSpec` contains the observation shapes and the
   `ActionSpec` (which defines the action shape). Note that
   the `BehaviorSpec` for a specific group is fixed throughout the simulation.
   The number of entries in the Mapping can change over time in the simulation

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -181,7 +181,7 @@ A `DecisionStep` has the following fields:
 - `reward` is a float. Corresponds to the rewards collected by the agent since
   the last simulation step.
 - `agent_id` is an int and an unique identifier for the corresponding Agent.
-- `action_mask` is an optional list of one dimensional array of booleans. Only
+- `action_mask` is an optional list of one dimensional arrays of booleans which is only
   available when using multi-discrete actions. Each array corresponds to an
   action branch. Each array contains a mask for each action of the branch. If
   true, the action is not available for the agent during this simulation step.

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -132,8 +132,8 @@ A `BaseEnv` has the following methods:
   contain no Agents at all.
 - **Set Actions :`env.set_actions(behavior_name: str, action: ActionTuple)`** Sets
   the actions for a whole agent group. `action` is an `ActionTuple`, which
-  is made up of a 2D `np.array` of `dtype=np.int32` for discrete action, and
-  `dtype=np.float32` for continuous action case. The first dimension of `np.array`
+  is made up of a 2D `np.array` of `dtype=np.int32` for discrete actions, and
+  `dtype=np.float32` for continuous actions. The first dimension of `np.array`
   in the tuple is the number of agents that requested a decision since the
   last call to `env.step()`. The second dimension is the number of discrete or
   continuous actions for the corresponding array.

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -161,7 +161,7 @@ A `DecisionSteps` has the following fields :
 - `agent_id` is an int vector of length batch size containing unique identifier
   for the corresponding Agent. This is used to track Agents across simulation
   steps.
-- `action_mask` is an optional list of two dimensional array of booleans. Only
+- `action_mask` is an optional list of two dimensional arrays of booleans which is only
   available when using multi-discrete actions. Each array corresponds to an
   action branch. The first dimension of each array is the batch size and the
   second contains a mask for each action of the branch. If true, the action is

--- a/docs/Training-Configuration-File.md
+++ b/docs/Training-Configuration-File.md
@@ -159,8 +159,8 @@ and setting `memory_size` and `sequence_length`:
 
 A few considerations when deciding to use memory:
 
-- LSTM does not work well with continuous vector action space. Please use
-  discrete vector action space for better results.
+- LSTM does not work well with continuous vector actions. Please use
+  discrete actions for better results.
 - Since the memories must be sent back and forth between Python and Unity, using
   too large `memory_size` will slow down training.
 - Adding a recurrent layer increases the complexity of the neural network, it is

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -61,7 +61,7 @@ class UnityEnvironment(BaseEnv):
     #  * 1.0.0 - initial version
     #  * 1.1.0 - support concatenated PNGs for compressed observations.
     #  * 1.2.0 - support compression mapping for stacked compressed observations.
-    #  * 1.3.0 - support hybrid action spaces.
+    #  * 1.3.0 - support action spaces with both continuous and discrete actions.
     API_VERSION = "1.3.0"
 
     # Default port that the editor listens on. If an environment executable


### PR DESCRIPTION
### Proposed change(s)
* Update examples to use the ActionBuffers form of Heuristic and OnActionReceived
* Revise the action documentation. It's still a bit vague - it doesn't actually say "you can use both continuous and discrete", since you can't set that up in the Agent's BrainParameters yet.
* Reworded some of the references to "hybrid".

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
