### PR TITLE
[refactor] Reduce dimension of continuous entropy coefficient

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -159,10 +159,7 @@ class TorchSACOptimizer(TorchOptimizer):
             requires_grad=True,
         )
         _cont_log_ent_coef = torch.nn.Parameter(
-            torch.log(
-                torch.as_tensor([self.init_entcoef] * self._action_spec.continuous_size)
-            ),
-            requires_grad=True,
+            torch.log(torch.as_tensor([self.init_entcoef])), requires_grad=True
         )
         self._log_ent_coef = TorchSACOptimizer.LogEntCoef(
             discrete=_disc_log_ent_coef, continuous=_cont_log_ent_coef
@@ -426,7 +423,7 @@ class TorchSACOptimizer(TorchOptimizer):
                 )
             # We update all the _cont_ent_coef as one block
             entropy_loss += -1 * ModelUtils.masked_mean(
-                torch.mean(_cont_ent_coef) * target_current_diff, loss_masks
+                _cont_ent_coef * target_current_diff, loss_masks
             )
 
         return entropy_loss


### PR DESCRIPTION
### Proposed change(s)

For hybrid-SAC, we were storing an entropy coefficient per continuous action. We just need to store one for all continuous actions. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
