### PR TITLE
Use GoalSensor in GridWorld

### DIFF
--- a/Project/Assets/ML-Agents/Examples/GridWorld/Prefabs/Area.prefab
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Prefabs/Area.prefab
@@ -305,6 +305,7 @@ GameObject:
   - component: {fileID: 114650561397225712}
   - component: {fileID: 114889700908650620}
   - component: {fileID: 7980686505185502968}
+  - component: {fileID: 8359584214300847863}
   m_Layer: 8
   m_Name: Agent
   m_TagString: agent
@@ -364,7 +365,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_BrainParameters:
-    VectorObservationSize: 2
+    VectorObservationSize: 0
     NumStackedVectorObservations: 1
     VectorActionSize: 05000000
     VectorActionDescriptions: []
@@ -430,6 +431,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   debugCommandLineOverride: 
+--- !u!114 &8359584214300847863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488387672112076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 163dac4bcbb2f4d8499db2cdcb22a89e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  observationSize: 1
 --- !u!1 &1625008366184734
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scenes/GridWorld.unity
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scenes/GridWorld.unity
@@ -254,6 +254,7 @@ GameObject:
   - component: {fileID: 125487790}
   - component: {fileID: 125487787}
   - component: {fileID: 125487791}
+  - component: {fileID: 125487792}
   m_Layer: 8
   m_Name: RenderTextureAgent
   m_TagString: agent
@@ -338,7 +339,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_BrainParameters:
-    VectorObservationSize: 2
+    VectorObservationSize: 0
     NumStackedVectorObservations: 1
     VectorActionSize: 05000000
     VectorActionDescriptions: []
@@ -368,6 +369,19 @@ MonoBehaviour:
   m_Grayscale: 0
   m_ObservationStacks: 1
   m_Compression: 1
+--- !u!114 &125487792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 125487785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 163dac4bcbb2f4d8499db2cdcb22a89e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  observationSize: 1
 --- !u!1 &260425459
 GameObject:
   m_ObjectHideFlags: 0
@@ -812,7 +826,7 @@ PrefabInstance:
     - target: {fileID: 114935253044749092, guid: 5c2bd19e4bbda4991b74387ca5d28156,
         type: 3}
       propertyPath: m_BrainParameters.VectorObservationSize
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114935253044749092, guid: 5c2bd19e4bbda4991b74387ca5d28156,
         type: 3}

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -23,6 +23,7 @@ public class GridAgent : Agent
         "masking turned on may not behave optimally when action masking is turned off.")]
     public bool maskActions = true;
 
+    GoalSensorComponent goalSensor;
 
     public GridGoal gridGoal;
 
@@ -49,7 +50,8 @@ public class GridAgent : Agent
     {
         Array values = Enum.GetValues(typeof(GridGoal));
         int goalNum = (int)gridGoal;
-        sensor.AddOneHotObservation(goalNum, values.Length);
+        goalSensor = this.GetComponent<GoalSensorComponent>();
+        goalSensor.AddGoal(goalNum);
     }
 
     public override void WriteDiscreteActionMask(IDiscreteActionMask actionMask)

--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -247,8 +247,9 @@ class TerminalSteps(Mapping):
 
 class SensorType(Enum):
     OBSERVATION = 0
-    PARAMETERIZATION = 1
+    GOAL = 1
     REWARD = 2
+
 
 class _ActionTupleBase(ABC):
     """

--- a/ml-agents/mlagents/trainers/tests/simple_test_envs.py
+++ b/ml-agents/mlagents/trainers/tests/simple_test_envs.py
@@ -61,7 +61,9 @@ class SimpleEnvironment(BaseEnv):
             continuous_action_size + discrete_action_size
         )  # to set the goals/positions
         self.action_spec = action_spec
-        self.behavior_spec = BehaviorSpec(self._make_obs_spec(), sensor_types, action_spec)
+        self.behavior_spec = BehaviorSpec(
+            self._make_obs_spec(), sensor_types, action_spec
+        )
         self.action_spec = action_spec
         self.names = brain_names
         self.positions: Dict[str, List[float]] = {}


### PR DESCRIPTION
### Proposed change(s)

Adds GoalSensor to GridWorld agents, and use it to collect goal.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
