### PR TITLE
[refactor] Remove critic pass during inference

### DIFF
--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -135,7 +135,7 @@ class TorchPolicy(Policy):
         :param seq_len: Sequence length when using RNN.
         :return: Tuple of AgentAction, ActionLogProbs, entropies, and output memories.
         """
-        actions, log_probs, entropies, _, memories = self.actor_critic.get_action_stats_and_value(
+        actions, log_probs, entropies, memories = self.actor_critic.get_action_stats(
             vec_obs, vis_obs, masks, memories, seq_len
         )
         return (actions, log_probs, entropies, memories)

--- a/ml-agents/mlagents/trainers/tests/torch/test_hybrid.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_hybrid.py
@@ -117,6 +117,6 @@ def test_hybrid_recurrent_sac():
         SAC_TORCH_CONFIG,
         hyperparameters=new_hyperparams,
         network_settings=new_networksettings,
-        max_steps=4000,
+        max_steps=3500,
     )
     check_environment_trains(env, {BRAIN_NAME: config})


### PR DESCRIPTION
### Proposed change(s)

Prior to ActionModel and hybrid actions, we did not evaluate the value function when doing Python inference. This improved overall training performance by ~10%. This PR restores that functionality. Furthermore, without this functionality, we would have to collect the observations of all agents inside the env manager when using a centralized critic. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
