### PR TITLE
Fix bug in BrainParameter Drawer 

### DIFF
--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -143,7 +143,7 @@ namespace Unity.MLAgents.Policies
                 if (VectorActionSpaceType == SpaceType.Discrete)
                 {
                     m_ActionSpec.NumContinuousActions = 0;
-                    m_ActionSpec.BranchSizes = VectorActionSize;
+                    m_ActionSpec.BranchSizes = (int[])VectorActionSize.Clone();
                 }
 
                 hasUpgradedBrainParametersWithActionSpec = true;
@@ -157,7 +157,7 @@ namespace Unity.MLAgents.Policies
         {
             if (m_ActionSpec.NumContinuousActions == 0)
             {
-                VectorActionSize = ActionSpec.BranchSizes;
+                VectorActionSize = (int[])ActionSpec.BranchSizes.Clone();
                 VectorActionSpaceType = SpaceType.Discrete;
             }
             else if (m_ActionSpec.NumDiscreteActions == 0)


### PR DESCRIPTION
### Proposed change(s)

Fix the bug that when continuous size=0, cannot set discrete branch sizes for each branch.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
