### PR TITLE
Fix model inference issue with Barracuda 1.2.1

### DIFF
--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -176,7 +176,7 @@ class GaussianDistribution(nn.Module):
             # mu*0 here to get the batch size implicitly since Barracuda 1.2.1
             # throws error on runtime broadcasting due to unknown reason. We
             # use this to replace torch.expand() becuase it is not supported in
-            # the verified version of Barracuda (1.0.2).
+            # the verified version of Barracuda (1.0.X).
             log_sigma = mu * 0 + self.log_sigma
         if self.tanh_squash:
             return TanhGaussianDistInstance(mu, torch.exp(log_sigma))

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -174,7 +174,7 @@ class GaussianDistribution(nn.Module):
         else:
             # Expand so that entropy matches batch size. Note that we're using
             # mu*0 here to get the batch size implicitly since Barracuda 1.2.1
-            # throws error on runtime broadcasting due to unknow reason. We
+            # throws error on runtime broadcasting due to unknown reason. We
             # use this to replace torch.expand() becuase it is not supported in
             # the verified version of Barracuda (1.0.2).
             log_sigma = mu * 0 + self.log_sigma

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -173,9 +173,11 @@ class GaussianDistribution(nn.Module):
             log_sigma = torch.clamp(self.log_sigma(inputs), min=-20, max=2)
         else:
             # Expand so that entropy matches batch size. Note that we're using
-            # torch.cat here instead of torch.expand() becuase it is not supported in the
-            # verified version of Barracuda (1.0.2).
-            log_sigma = torch.cat([self.log_sigma] * inputs.shape[0], axis=0)
+            # mu*0 here to get the batch size implicitly since Barracuda 1.2.1
+            # throws error on runtime broadcasting due to unknow reason. We
+            # use this to replace torch.expand() becuase it is not supported in
+            # the verified version of Barracuda (1.0.2).
+            log_sigma = mu * 0 + self.log_sigma
         if self.tanh_squash:
             return TanhGaussianDistInstance(mu, torch.exp(log_sigma))
         else:

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -258,9 +258,11 @@ class SimpleActor(nn.Module, Actor):
     ):
         super().__init__()
         self.action_spec = action_spec
-        self.version_number = torch.nn.Parameter(torch.Tensor([2.0]))
+        self.version_number = torch.nn.Parameter(
+            torch.Tensor([2.0]), requires_grad=False
+        )
         self.is_continuous_int_deprecated = torch.nn.Parameter(
-            torch.Tensor([int(self.action_spec.is_continuous())])
+            torch.Tensor([int(self.action_spec.is_continuous())]), requires_grad=False
         )
         self.continuous_act_size_vector = torch.nn.Parameter(
             torch.Tensor([int(self.action_spec.continuous_size)]), requires_grad=False
@@ -283,6 +285,9 @@ class SimpleActor(nn.Module, Actor):
             self.encoding_size = network_settings.memory.memory_size // 2
         else:
             self.encoding_size = network_settings.hidden_units
+        self.memory_size_vector = torch.nn.Parameter(
+            torch.Tensor([int(self.network_body.memory_size)]), requires_grad=False
+        )
 
         self.action_model = ActionModel(
             self.encoding_size,
@@ -335,10 +340,7 @@ class SimpleActor(nn.Module, Actor):
             disc_action_out,
             action_out_deprecated,
         ) = self.action_model.get_action_out(encoding, masks)
-        export_out = [
-            self.version_number,
-            torch.Tensor([self.network_body.memory_size]),
-        ]
+        export_out = [self.version_number, self.memory_size_vector]
         if self.action_spec.continuous_size > 0:
             export_out += [cont_action_out, self.continuous_act_size_vector]
         if self.action_spec.discrete_size > 0:


### PR DESCRIPTION
### Proposed change(s)

Fix the model inference issue with Barracuda 1.2.1 by getting batch size implicitly with `mu` and avoid runtime broadcasting.

Also added `memory_size_vector` in model serialization to suppress torch onnx export warning about converting tensor to python constant.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
