### PR TITLE
remove "discrete nan" check

### DIFF
--- a/ml-agents/mlagents/trainers/policy/policy.py
+++ b/ml-agents/mlagents/trainers/policy/policy.py
@@ -140,10 +140,6 @@ class Policy:
             has_nan = np.isnan(d)
             if has_nan:
                 raise RuntimeError("Continuous NaN action detected.")
-            d = np.sum(action.discrete)
-            has_nan = np.isnan(d)
-            if has_nan:
-                raise RuntimeError("Discrete NaN action detected.")
 
     @abstractmethod
     def update_normalization(self, vector_obs: np.ndarray) -> None:


### PR DESCRIPTION
### Proposed change(s)
Follow up from the hybrid action work - this check is unnecessary since there's no way that int32s could fail a NaN check. Probably not harmful, but at least a few wasted cycles.

Will cherry-pick to release branch after merging.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
