### PR TITLE
Uncomment obsolete attributes, fix warnings

### DIFF
--- a/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
@@ -156,7 +156,7 @@ namespace Unity.MLAgents.Actuators
         /// <param name="destination">A float array to pack actions into whose length is greater than or
         /// equal to the addition of the Lengths of this objects <see cref="ContinuousActions"/> and
         /// <see cref="DiscreteActions"/> segments.</param>
-        /// [Obsolete("PackActions has been deprecated.")]
+        [Obsolete("PackActions has been deprecated.")]
         public void PackActions(in float[] destination)
         {
             Debug.Assert(destination.Length >= ContinuousActions.Length + DiscreteActions.Length,

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -886,7 +886,11 @@ namespace Unity.MLAgents
         /// <seealso cref="IActionReceiver.OnActionReceived"/>
         public virtual void Heuristic(in ActionBuffers actionsOut)
         {
-            // For backward compatibility
+            // Disable deprecation warnings to we can call the legacy overload.
+#pragma warning disable CS0618
+
+            // The default implementation of Heuristic calls the
+            // obsolete version for backward compatibility
             switch (m_PolicyFactory.BrainParameters.VectorActionSpaceType)
             {
                 case SpaceType.Continuous:
@@ -904,6 +908,8 @@ namespace Unity.MLAgents
                     actionsOut.ContinuousActions.Clear();
                     break;
             }
+#pragma warning restore CS0618
+
         }
 
         /// <summary>
@@ -1151,7 +1157,10 @@ namespace Unity.MLAgents
             {
                 m_ActionMasker = new DiscreteActionMasker(actionMask);
             }
+            // Disable deprecation warnings to we can call the legacy overload.
+#pragma warning disable CS0618
             CollectDiscreteActionMasks(m_ActionMasker);
+#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -1232,7 +1241,10 @@ namespace Unity.MLAgents
             {
                 m_LegacyActionCache = Array.ConvertAll(actions.DiscreteActions.Array, x => (float)x);
             }
+            // Disable deprecation warnings to we can call the legacy overload.
+#pragma warning disable CS0618
             OnActionReceived(m_LegacyActionCache);
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -886,7 +886,7 @@ namespace Unity.MLAgents
         /// <seealso cref="IActionReceiver.OnActionReceived"/>
         public virtual void Heuristic(in ActionBuffers actionsOut)
         {
-            // Disable deprecation warnings to we can call the legacy overload.
+            // Disable deprecation warnings so we can call the legacy overload.
 #pragma warning disable CS0618
 
             // The default implementation of Heuristic calls the
@@ -1157,7 +1157,7 @@ namespace Unity.MLAgents
             {
                 m_ActionMasker = new DiscreteActionMasker(actionMask);
             }
-            // Disable deprecation warnings to we can call the legacy overload.
+            // Disable deprecation warnings so we can call the legacy overload.
 #pragma warning disable CS0618
             CollectDiscreteActionMasks(m_ActionMasker);
 #pragma warning restore CS0618
@@ -1241,7 +1241,7 @@ namespace Unity.MLAgents
             {
                 m_LegacyActionCache = Array.ConvertAll(actions.DiscreteActions.Array, x => (float)x);
             }
-            // Disable deprecation warnings to we can call the legacy overload.
+            // Disable deprecation warnings so we can call the legacy overload.
 #pragma warning disable CS0618
             OnActionReceived(m_LegacyActionCache);
 #pragma warning restore CS0618

--- a/com.unity.ml-agents/Runtime/Agent.deprecated.cs
+++ b/com.unity.ml-agents/Runtime/Agent.deprecated.cs
@@ -9,6 +9,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="WriteDiscreteActionMask"/> instead.
         /// </summary>
         /// <param name="actionMasker"></param>
+        [Obsolete("CollectDiscreteActionMasks has been deprecated, please the WriteDiscreteActionMask.")]
         public virtual void CollectDiscreteActionMasks(DiscreteActionMasker actionMasker)
         {
         }
@@ -17,6 +18,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="Heuristic(in ActionBuffers)"/> instead.
         /// </summary>
         /// <param name="actionsOut"></param>
+        [Obsolete("The float[] version of Heuristic has been deprecated, please the ActionBuffers version instead.")]
         public virtual void Heuristic(float[] actionsOut)
         {
             Debug.LogWarning("Heuristic method called but not implemented. Returning placeholder actions.");
@@ -27,6 +29,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="OnActionReceived(ActionBuffers)"/> instead.
         /// </summary>
         /// <param name="vectorAction"></param>
+        [Obsolete("The float[] version of OnActionReceived has been deprecated, please the ActionBuffers version instead.")]
         public virtual void OnActionReceived(float[] vectorAction) { }
 
         /// <summary>
@@ -36,7 +39,7 @@ namespace Unity.MLAgents
         /// The last action that was decided by the Agent (or null if no decision has been made).
         /// </returns>
         /// <seealso cref="OnActionReceived(ActionBuffers)"/>
-        // [Obsolete("GetAction has been deprecated, please use GetStoredActionBuffers, Or GetStoredDiscreteActions.")]
+        [Obsolete("GetAction has been deprecated, please use GetStoredActionBuffers instead.")]
         public float[] GetAction()
         {
             var storedAction = m_Info.storedVectorActions;

--- a/com.unity.ml-agents/Runtime/Agent.deprecated.cs
+++ b/com.unity.ml-agents/Runtime/Agent.deprecated.cs
@@ -9,7 +9,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="WriteDiscreteActionMask"/> instead.
         /// </summary>
         /// <param name="actionMasker"></param>
-        [Obsolete("CollectDiscreteActionMasks has been deprecated, please the WriteDiscreteActionMask.")]
+        [Obsolete("CollectDiscreteActionMasks has been deprecated, please use WriteDiscreteActionMask.")]
         public virtual void CollectDiscreteActionMasks(DiscreteActionMasker actionMasker)
         {
         }
@@ -18,7 +18,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="Heuristic(in ActionBuffers)"/> instead.
         /// </summary>
         /// <param name="actionsOut"></param>
-        [Obsolete("The float[] version of Heuristic has been deprecated, please the ActionBuffers version instead.")]
+        [Obsolete("The float[] version of Heuristic has been deprecated, please use the ActionBuffers version instead.")]
         public virtual void Heuristic(float[] actionsOut)
         {
             Debug.LogWarning("Heuristic method called but not implemented. Returning placeholder actions.");
@@ -29,7 +29,7 @@ namespace Unity.MLAgents
         /// Deprecated, use <see cref="OnActionReceived(ActionBuffers)"/> instead.
         /// </summary>
         /// <param name="vectorAction"></param>
-        [Obsolete("The float[] version of OnActionReceived has been deprecated, please the ActionBuffers version instead.")]
+        [Obsolete("The float[] version of OnActionReceived has been deprecated, please use the ActionBuffers version instead.")]
         public virtual void OnActionReceived(float[] vectorAction) { }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -101,6 +101,8 @@ namespace Unity.MLAgents
         /// <param name="isTraining">Whether or not the Brain is training.</param>
         public static BrainParametersProto ToProto(this BrainParameters bp, string name, bool isTraining)
         {
+            // Disable deprecation warnings to we can set legacy fields
+#pragma warning disable CS0618
             var brainParametersProto = new BrainParametersProto
             {
                 VectorActionSpaceTypeDeprecated = (SpaceTypeProto)bp.VectorActionSpaceType,
@@ -116,6 +118,7 @@ namespace Unity.MLAgents
             {
                 brainParametersProto.VectorActionDescriptionsDeprecated.AddRange(bp.VectorActionDescriptions);
             }
+#pragma warning restore CS0618
             return brainParametersProto;
         }
 

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -101,7 +101,7 @@ namespace Unity.MLAgents
         /// <param name="isTraining">Whether or not the Brain is training.</param>
         public static BrainParametersProto ToProto(this BrainParameters bp, string name, bool isTraining)
         {
-            // Disable deprecation warnings to we can set legacy fields
+            // Disable deprecation warnings so we can set legacy fields
 #pragma warning disable CS0618
             var brainParametersProto = new BrainParametersProto
             {

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -117,7 +117,7 @@ namespace Unity.MLAgents.Policies
         /// <returns> A new BrainParameter object with the same values as the original.</returns>
         public BrainParameters Clone()
         {
-            // Disable deprecation warnings to we can read/write the old fields.
+            // Disable deprecation warnings so we can read/write the old fields.
 #pragma warning disable CS0618
             return new BrainParameters
             {
@@ -136,7 +136,7 @@ namespace Unity.MLAgents.Policies
         /// </summary>
         private void UpdateToActionSpec()
         {
-            // Disable deprecation warnings to we can read the old fields.
+            // Disable deprecation warnings so we can read the old fields.
 #pragma warning disable CS0618
             if (!hasUpgradedBrainParametersWithActionSpec
                 && m_ActionSpec.NumContinuousActions == 0
@@ -162,7 +162,7 @@ namespace Unity.MLAgents.Policies
         /// </summary>
         private void SyncDeprecatedActionFields()
         {
-            // Disable deprecation warnings to we can read the old fields.
+            // Disable deprecation warnings so we can read the old fields.
 #pragma warning disable CS0618
 
             if (m_ActionSpec.NumContinuousActions == 0)

--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Policies
         /// the action.
         /// For the discrete action space: the number of branches in the action space.
         /// </value>
-        /// [Obsolete("VectorActionSize has been deprecated, please use ActionSpec instead.")]
+        [Obsolete("VectorActionSize has been deprecated, please use ActionSpec instead.")]
         [FormerlySerializedAs("vectorActionSize")]
         public int[] VectorActionSize = new[] { 1 };
 
@@ -91,7 +91,7 @@ namespace Unity.MLAgents.Policies
         /// <summary>
         /// (Deprecated) Defines if the action is discrete or continuous.
         /// </summary>
-        /// [Obsolete("VectorActionSpaceType has been deprecated, please use ActionSpec instead.")]
+        [Obsolete("VectorActionSpaceType has been deprecated, please use ActionSpec instead.")]
         [FormerlySerializedAs("vectorActionSpaceType")]
         public SpaceType VectorActionSpaceType = SpaceType.Discrete;
 
@@ -102,7 +102,7 @@ namespace Unity.MLAgents.Policies
         /// <summary>
         /// (Deprecated) The number of actions specified by this Brain.
         /// </summary>
-        /// [Obsolete("NumActions has been deprecated, please use ActionSpec instead.")]
+        [Obsolete("NumActions has been deprecated, please use ActionSpec instead.")]
         public int NumActions
         {
             get
@@ -117,6 +117,8 @@ namespace Unity.MLAgents.Policies
         /// <returns> A new BrainParameter object with the same values as the original.</returns>
         public BrainParameters Clone()
         {
+            // Disable deprecation warnings to we can read/write the old fields.
+#pragma warning disable CS0618
             return new BrainParameters
             {
                 VectorObservationSize = VectorObservationSize,
@@ -126,6 +128,7 @@ namespace Unity.MLAgents.Policies
                 VectorActionSize = (int[])VectorActionSize.Clone(),
                 VectorActionSpaceType = VectorActionSpaceType,
             };
+#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -133,6 +136,8 @@ namespace Unity.MLAgents.Policies
         /// </summary>
         private void UpdateToActionSpec()
         {
+            // Disable deprecation warnings to we can read the old fields.
+#pragma warning disable CS0618
             if (!hasUpgradedBrainParametersWithActionSpec
                 && m_ActionSpec.NumContinuousActions == 0
                 && m_ActionSpec.BranchSizes == null)
@@ -149,6 +154,7 @@ namespace Unity.MLAgents.Policies
                 }
             }
             hasUpgradedBrainParametersWithActionSpec = true;
+#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -156,6 +162,9 @@ namespace Unity.MLAgents.Policies
         /// </summary>
         private void SyncDeprecatedActionFields()
         {
+            // Disable deprecation warnings to we can read the old fields.
+#pragma warning disable CS0618
+
             if (m_ActionSpec.NumContinuousActions == 0)
             {
                 VectorActionSize = (int[])ActionSpec.BranchSizes.Clone();
@@ -170,6 +179,7 @@ namespace Unity.MLAgents.Policies
             {
                 VectorActionSize = null;
             }
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -711,7 +711,7 @@ namespace Unity.MLAgents.Tests
             Assert.AreEqual(numSteps, agent1.sensor1.numWriteCalls);
             Assert.AreEqual(numSteps, agent1.sensor2.numCompressedCalls);
 
-            // Disable deprecation warnings to we can read/write the old fields.
+            // Disable deprecation warnings so we can read/write the old fields.
 #pragma warning disable CS0618
 
             // Make sure the Heuristic method read the observation and set the action

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -711,8 +711,16 @@ namespace Unity.MLAgents.Tests
             Assert.AreEqual(numSteps, agent1.sensor1.numWriteCalls);
             Assert.AreEqual(numSteps, agent1.sensor2.numCompressedCalls);
 
+            // Disable deprecation warnings to we can read/write the old fields.
+#pragma warning disable CS0618
+
             // Make sure the Heuristic method read the observation and set the action
             Assert.AreEqual(agent1.collectObservationsCallsForEpisode, agent1.GetAction()[0]);
+            Assert.AreEqual(
+                agent1.collectObservationsCallsForEpisode,
+                agent1.GetStoredActionBuffers().ContinuousActions[0]
+            );
+#pragma warning restore CS0618
         }
     }
 


### PR DESCRIPTION
### Proposed change(s)
Several fields have [Obsolete] commented out, which doesn't do anything. This comments them back in, and fixes any places where we were using them (fortunately just places where we explicitly were going for backwards compatibility).

Might need to update the migration guide.

Will cherrypick to release branch.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1604


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
