### PR TITLE
update doc for 3.8, test 3.9

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,11 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6.x, 3.7.x, 3.8.x]
-        include:
-          - python-version: 3.6.x
-          - python-version: 3.7.x
-          - python-version: 3.8.x
+        python-version: [3.6.x, 3.7.x, 3.8.x, 3.9.x]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/docs/Using-Virtual-Environment.md
+++ b/docs/Using-Virtual-Environment.md
@@ -19,8 +19,8 @@ from dependencies of other projects. This has a few advantages:
 
 ## Python Version Requirement (Required)
 
-This guide has been tested with Python 3.6 and 3.7. Python 3.8 is not supported
-at this time.
+This guide has been tested with Python 3.6 through Python 3.8. Newer versions might not
+have support for the dependent libraries, so are not recommended.
 
 ## Installing Pip (Required)
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -42,6 +42,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     zip_safe=False,


### PR DESCRIPTION
### Proposed change(s)
Venv doc was out of date; we definitely support 3.8, and 3.9 might work now too.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://forum.unity.com/threads/need-help-with-using-python-3-7-instead-of-3-8.1026019/


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
