### PR TITLE
remove wget and gdebi for xvfb and add to apt-get 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+# From https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
 
 RUN yes | unminimize
 
@@ -7,11 +8,9 @@ RUN wget https://packages.cloud.google.com/apt/doc/apt-key.gpg && apt-key add ap
 RUN apt-get update && \
   apt-get install -y --no-install-recommends wget curl tmux vim git gdebi-core \
   build-essential python3-pip unzip google-cloud-sdk htop mesa-utils xorg-dev xorg \
-  libglvnd-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev && \
+  libglvnd-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev xvfb && \
   wget http://security.ubuntu.com/ubuntu/pool/main/libx/libxfont/libxfont1_1.5.1-1ubuntu0.16.04.4_amd64.deb && \
-  wget http://security.ubuntu.com/ubuntu/pool/universe/x/xorg-server/xvfb_1.18.4-0ubuntu0.10_amd64.deb && \
-  yes | gdebi libxfont1_1.5.1-1ubuntu0.16.04.4_amd64.deb && \
-  yes | gdebi xvfb_1.18.4-0ubuntu0.10_amd64.deb
+  yes | gdebi libxfont1_1.5.1-1ubuntu0.16.04.4_amd64.deb
 RUN python3 -m pip install --upgrade pip
 RUN pip install setuptools==41.0.0
 


### PR DESCRIPTION
### Proposed change(s)

Cherry-pick dockerfile fixes (#4791)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
