### PR TITLE
Make memory contiguous

### DIFF
--- a/ml-agents/mlagents/trainers/torch/layers.py
+++ b/ml-agents/mlagents/trainers/torch/layers.py
@@ -181,8 +181,8 @@ class LSTM(MemoryModule):
         self, input_tensor: torch.Tensor, memories: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # We don't use torch.split here since it is not supported by Barracuda
-        h0 = memories[:, :, : self.hidden_size]
-        c0 = memories[:, :, self.hidden_size :]
+        h0 = memories[:, :, : self.hidden_size].contiguous()
+        c0 = memories[:, :, self.hidden_size :].contiguous()
         hidden = (h0, c0)
         lstm_out, hidden_out = self.lstm(input_tensor, hidden)
         output_mem = torch.cat(hidden_out, dim=-1)


### PR DESCRIPTION
### Proposed change(s)

Bug reported in #4761 : RuntimeError: rnn: hx is not contiguous
Fix it by calling `contiguous()` on the memories before feeding into LSTM.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
