### PR TITLE
ignore yamato dir for pytest checks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,8 @@ on:
     - 'test_constraints*.txt'
     - 'test_requirements.txt'
     - '.github/workflows/pytest.yml'
+    paths-ignore:
+    - 'ml-agents/tests/yamato/**'
   push:
     branches: [master]
 


### PR DESCRIPTION
### Proposed change(s)
Small testing improvement - the scripts under `tests/yamato` are only run by yamato (as the name implies) so we don't need to run pytest when they change. This would save some pytest runs on e.g. https://github.com/Unity-Technologies/ml-agents/pull/4813

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths
