### PR TITLE
fix blog link that moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ We have published a series of blog posts that are relevant for ML-Agents:
 In addition to our own documentation, here are some additional, relevant
 articles:
 
-- [A Game Developer Learns Machine Learning](https://mikecann.co.uk/machine-learning/a-game-developer-learns-machine-learning-intent/)
+- [A Game Developer Learns Machine Learning](https://mikecann.co.uk/posts/a-game-developer-learns-machine-learning-intent)
 - [Explore Unity Technologies ML-Agents Exclusively on Intel Architecture](https://software.intel.com/en-us/articles/explore-unity-technologies-ml-agents-exclusively-on-intel-architecture)
 - [ML-Agents Penguins tutorial](https://learn.unity.com/project/ml-agents-penguins)
 


### PR DESCRIPTION
### Proposed change(s)
Nightly [link checks](https://github.com/Unity-Technologies/ml-agents/runs/1655007260?check_suite_focus=true) were failing because the old link 404's now. Updated to https://mikecann.co.uk/posts/a-game-developer-learns-machine-learning-intent

### Types of change(s)
- [x] Documentation update
