### PR TITLE
Add weight decay to trainers/settings

### DIFF
--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -49,7 +49,9 @@ class TorchPPOOptimizer(TorchOptimizer):
         )
 
         self.optimizer = torch.optim.Adam(
-            params, lr=self.trainer_settings.hyperparameters.learning_rate
+            params,
+            lr=self.trainer_settings.hyperparameters.learning_rate,
+            weight_decay=self.trainer_settings.hyperparameters.weight_decay,
         )
         self.stats_name_to_update_name = {
             "Losses/Value Loss": "value_loss",

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -194,10 +194,14 @@ class TorchSACOptimizer(TorchOptimizer):
             self.trainer_settings.max_steps,
         )
         self.policy_optimizer = torch.optim.Adam(
-            policy_params, lr=hyperparameters.learning_rate
+            policy_params,
+            lr=hyperparameters.learning_rate,
+            weight_decay=hyperparameters.weight_decay,
         )
         self.value_optimizer = torch.optim.Adam(
-            value_params, lr=hyperparameters.learning_rate
+            value_params,
+            lr=hyperparameters.learning_rate,
+            weight_decay=hyperparameters.weight_decay,
         )
         self.entropy_optimizer = torch.optim.Adam(
             self._log_ent_coef.parameters(), lr=hyperparameters.learning_rate

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -134,6 +134,7 @@ class HyperparamSettings:
     buffer_size: int = 10240
     learning_rate: float = 3.0e-4
     learning_rate_schedule: ScheduleType = ScheduleType.CONSTANT
+    weight_decay: float = 0.0
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
### Proposed change(s)

Enables weight decay on policy/value networks in ppo/sac. I believe this will be important for the attention layer.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
