### PR TITLE
make sure DefaultTrainerDict is pickle-able

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -25,6 +25,7 @@ TensorBoard. Thanks to @brccabral for the contribution! (#4816)
 #### com.unity.ml-agents (C#)
 - Fix a compile warning about using an obsolete enum in `GrpcExtensions.cs`. (#4812)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- Fixed a bug that would cause an exception when `RunOptions` was deserialized via `pickle`. (#4842)
 
 
 ## [1.7.2-preview] - 2020-12-22

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -682,7 +682,8 @@ class TrainerSettings(ExportableSettings):
     class DefaultTrainerDict(collections.defaultdict):
         def __init__(self, *args):
             # Depending on how this is called, args may have the defaultdict
-            # callable at the start of the list or not.
+            # callable at the start of the list or not. In particular, unpickling
+            # will pass [TrainerSettings].
             if args and args[0] == TrainerSettings:
                 super().__init__(*args)
             else:

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -681,6 +681,8 @@ class TrainerSettings(ExportableSettings):
 
     class DefaultTrainerDict(collections.defaultdict):
         def __init__(self, *args):
+            # Depending on how this is called, args may have the defaultdict
+            # callable at the start of the list or not.
             if args and args[0] == TrainerSettings:
                 super().__init__(*args)
             else:

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -681,7 +681,10 @@ class TrainerSettings(ExportableSettings):
 
     class DefaultTrainerDict(collections.defaultdict):
         def __init__(self, *args):
-            super().__init__(TrainerSettings, *args)
+            if args and args[0] == TrainerSettings:
+                super().__init__(*args)
+            else:
+                super().__init__(TrainerSettings, *args)
 
         def __missing__(self, key: Any) -> "TrainerSettings":
             if TrainerSettings.default_override is not None:

--- a/ml-agents/mlagents/trainers/tests/test_settings.py
+++ b/ml-agents/mlagents/trainers/tests/test_settings.py
@@ -1,5 +1,6 @@
 import attr
 import cattr
+import pickle
 import pytest
 import yaml
 
@@ -516,3 +517,10 @@ def test_default_settings():
     test1_settings.max_steps = 1
     test1_settings.network_settings.hidden_units == default_settings_cls.network_settings.hidden_units
     check_if_different(test1_settings, default_settings_cls)
+
+
+def test_pickle():
+    # Make sure RunOptions is pickle-able.
+    run_options = RunOptions()
+    p = pickle.dumps(run_options)
+    pickle.loads(p)


### PR DESCRIPTION
### Proposed change(s)
In the current form, the DefaultTrainerDict can't be deserialized from pickle (and thus can't be passed to a worker process from the subprocess module, which I'm trying to do in https://github.com/Unity-Technologies/ml-agents/pull/4780). It appears that the initializer needs to be able to take both forms of arguments; I'm not sure if there's a cleaner way to do this.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Added in https://github.com/Unity-Technologies/ml-agents/pull/4448

### Types of change(s)
- [x] Bug fix

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)