### PR TITLE
Add LayerNorm

### DIFF
--- a/ml-agents/mlagents/trainers/tests/torch/test_layers.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_layers.py
@@ -6,6 +6,7 @@ from mlagents.trainers.torch.layers import (
     lstm_layer,
     Initialization,
     LSTM,
+    LayerNorm,
 )
 
 
@@ -57,3 +58,28 @@ def test_lstm_class():
     # Hidden size should be half of memory_size
     assert out.shape == (batch_size, seq_len, memory_size // 2)
     assert mem.shape == (1, batch_size, memory_size)
+
+
+def test_layer_norm():
+    torch.manual_seed(0)
+    torch_ln = torch.nn.LayerNorm(10, elementwise_affine=False)
+    cust_ln = LayerNorm()
+
+    sample_input = torch.rand(10)
+    assert torch.all(
+        torch.isclose(
+            torch_ln(sample_input), cust_ln(sample_input), atol=1e-5, rtol=0.0
+        )
+    )
+    sample_input = torch.rand((4, 10))
+    assert torch.all(
+        torch.isclose(
+            torch_ln(sample_input), cust_ln(sample_input), atol=1e-5, rtol=0.0
+        )
+    )
+    sample_input = torch.rand((7, 6, 10))
+    assert torch.all(
+        torch.isclose(
+            torch_ln(sample_input), cust_ln(sample_input), atol=1e-5, rtol=0.0
+        )
+    )

--- a/ml-agents/mlagents/trainers/torch/layers.py
+++ b/ml-agents/mlagents/trainers/torch/layers.py
@@ -115,6 +115,20 @@ class MemoryModule(torch.nn.Module):
         pass
 
 
+class LayerNorm(torch.nn.Module):
+    """
+    A vanilla implementation of layer normalization  https://arxiv.org/pdf/1607.06450.pdf
+    norm_x = (x - mean) / sqrt((x - mean) ^ 2)
+    This does not include the trainable parameters gamma and beta for performance speed.
+    Typically, this is norm_x * gamma + beta
+    """
+
+    def forward(self, layer_activations: torch.Tensor) -> torch.Tensor:
+        mean = torch.mean(layer_activations, dim=-1, keepdim=True)
+        var = torch.mean((layer_activations - mean) ** 2, dim=-1, keepdim=True)
+        return (layer_activations - mean) / (torch.sqrt(var + 1e-5))
+
+
 class LinearEncoder(torch.nn.Module):
     """
     Linear layers.


### PR DESCRIPTION
### Proposed change(s)

Adds layer normalization after the entity embedding and RSA block.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
