### PR TITLE
Fixing .contiguous missing in resnet

### DIFF
--- a/ml-agents/mlagents/trainers/torch/encoders.py
+++ b/ml-agents/mlagents/trainers/torch/encoders.py
@@ -266,6 +266,6 @@ class ResNetVisualEncoder(nn.Module):
         if not exporting_to_onnx.is_exporting():
             visual_obs = visual_obs.permute([0, 3, 1, 2])
         batch_size = visual_obs.shape[0]
-        hidden = self.sequential(visual_obs)
+        hidden = self.sequential(visual_obs).contiguous()
         before_out = hidden.view(batch_size, -1)
         return torch.relu(self.dense(before_out))


### PR DESCRIPTION
### Proposed change(s)

Attempt at fixing this bug : https://forum.unity.com/threads/how-to-add-camera-to-the-soccer-game.1037851/

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
