### PR TITLE
[Bug Fix] Fix crash if spawn is delayed in multi-env

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -32,6 +32,7 @@ removed when training with a player. The Editor still requires it to be clamped 
 - Fix a compile warning about using an obsolete enum in `GrpcExtensions.cs`. (#4812)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed a bug that would cause an exception when `RunOptions` was deserialized via `pickle`. (#4842)
+- Fixed a bug that can cause a crash if a behavior can appear during training in multi-environment training. (#4872)
 
 
 ## [1.7.2-preview] - 2020-12-22

--- a/ml-agents/mlagents/trainers/subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/subprocess_env_manager.py
@@ -310,8 +310,11 @@ class SubprocessEnvManager(EnvManager):
 
     @property
     def training_behaviors(self) -> Dict[BehaviorName, BehaviorSpec]:
-        self.env_workers[0].send(EnvironmentCommand.BEHAVIOR_SPECS)
-        return self.env_workers[0].recv().payload
+        result: Dict[BehaviorName, BehaviorSpec] = {}
+        for worker in self.env_workers:
+            worker.send(EnvironmentCommand.BEHAVIOR_SPECS)
+            result.update(worker.recv().payload)
+        return result
 
     def close(self) -> None:
         logger.debug("SubprocessEnvManager closing.")

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -105,10 +105,15 @@ class SubprocessEnvManagerTest(unittest.TestCase):
     @mock.patch(
         "mlagents.trainers.subprocess_env_manager.SubprocessEnvManager.create_worker"
     )
-    def test_training_behaviors_collects_results_from_all_envs(self, mock_create_worker):
+    def test_training_behaviors_collects_results_from_all_envs(
+        self, mock_create_worker
+    ):
         def create_worker_mock(worker_id, step_queue, env_factor, engine_c):
             return MockEnvWorker(
-                worker_id, EnvironmentResponse(EnvironmentCommand.RESET, worker_id, {f"key{worker_id}" : worker_id})
+                worker_id,
+                EnvironmentResponse(
+                    EnvironmentCommand.RESET, worker_id, {f"key{worker_id}": worker_id}
+                ),
             )
 
         mock_create_worker.side_effect = create_worker_mock
@@ -116,15 +121,13 @@ class SubprocessEnvManagerTest(unittest.TestCase):
             mock_env_factory, EngineConfig.default_config(), 4
         )
 
-        params = {"test": "params"}
         res = manager.training_behaviors
-        for i, env in enumerate(manager.env_workers):
+        for env in manager.env_workers:
             env.send.assert_called_with(EnvironmentCommand.BEHAVIOR_SPECS)
             env.recv.assert_called()
         for worker_id in range(4):
             assert f"key{worker_id}" in res
             assert res[f"key{worker_id}"] == worker_id
-
 
     @mock.patch(
         "mlagents.trainers.subprocess_env_manager.SubprocessEnvManager.create_worker"

--- a/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_subprocess_env_manager.py
@@ -105,6 +105,30 @@ class SubprocessEnvManagerTest(unittest.TestCase):
     @mock.patch(
         "mlagents.trainers.subprocess_env_manager.SubprocessEnvManager.create_worker"
     )
+    def test_training_behaviors_collects_results_from_all_envs(self, mock_create_worker):
+        def create_worker_mock(worker_id, step_queue, env_factor, engine_c):
+            return MockEnvWorker(
+                worker_id, EnvironmentResponse(EnvironmentCommand.RESET, worker_id, {f"key{worker_id}" : worker_id})
+            )
+
+        mock_create_worker.side_effect = create_worker_mock
+        manager = SubprocessEnvManager(
+            mock_env_factory, EngineConfig.default_config(), 4
+        )
+
+        params = {"test": "params"}
+        res = manager.training_behaviors
+        for i, env in enumerate(manager.env_workers):
+            env.send.assert_called_with(EnvironmentCommand.BEHAVIOR_SPECS)
+            env.recv.assert_called()
+        for worker_id in range(4):
+            assert f"key{worker_id}" in res
+            assert res[f"key{worker_id}"] == worker_id
+
+
+    @mock.patch(
+        "mlagents.trainers.subprocess_env_manager.SubprocessEnvManager.create_worker"
+    )
     def test_step_takes_steps_for_all_non_waiting_envs(self, mock_create_worker):
         mock_create_worker.side_effect = create_worker_mock
         manager = SubprocessEnvManager(


### PR DESCRIPTION
### Proposed change(s)

In an environment with 2 behaviors, if one behavior randomly spawns after some time, training with multiple environments can cause a crash.
The reason is that we try to get the behavior specs from the first environment and there is a chance the later behavior is not yet spawned in this environment. I modified the code to take an aggreate of the behavior specs of all of the environments. I tested my fix on a custom environment.

I do not know how to write a test for this bug since it involves multi environment, multi behavior with random spawning of behaviors. I am open to suggestions.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
