### PR TITLE
use Debug.AssertFormat to avoid string formatting in DEBUG

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
@@ -26,7 +26,12 @@ namespace Unity.MLAgents.Sensors
             {
                 // Check for compatibility with the other Agents' Sensors
                 // TODO make sure this only checks once per agent
-                Debug.Assert(m_SensorShapes.Count == sensors.Count, $"Number of Sensors must match. {m_SensorShapes.Count} != {sensors.Count}");
+                Debug.AssertFormat(
+                    m_SensorShapes.Count == sensors.Count,
+                    "Number of Sensors must match. {0} != {1}",
+                    m_SensorShapes.Count,
+                    sensors.Count
+                );
                 for (var i = 0; i < Mathf.Min(m_SensorShapes.Count, sensors.Count); i++)
                 {
                     var cachedShape = m_SensorShapes[i];


### PR DESCRIPTION
### Proposed change(s)
Similar to https://github.com/Unity-Technologies/ml-agents/pull/4877, avoid a string format on each agent step. Calls to this function only happen if DEBUG is defined, but this still might affect performance slightly.

### Types of change(s)
- [x ] Other (please describe)
