### PR TITLE
Optimizing test running time

### DIFF
--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -142,7 +142,7 @@ def test_2d_sac(action_sizes):
         SAC_TORCH_CONFIG.hyperparameters,
         buffer_init_steps=2000,
         learning_rate=0.023,
-        batch_size=1
+        batch_size=1,
     )
     config = attr.evolve(
         SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=2300

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -139,7 +139,10 @@ def test_simple_sac(action_sizes):
 def test_2d_sac(action_sizes):
     env = SimpleEnvironment([BRAIN_NAME], action_sizes=action_sizes, step_size=0.8)
     new_hyperparams = attr.evolve(
-        SAC_TORCH_CONFIG.hyperparameters, buffer_init_steps=2000, learning_rate=0.023, batch_size=1
+        SAC_TORCH_CONFIG.hyperparameters,
+        buffer_init_steps=2000,
+        learning_rate=0.023,
+        batch_size=1
     )
     config = attr.evolve(
         SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=2300

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -139,10 +139,10 @@ def test_simple_sac(action_sizes):
 def test_2d_sac(action_sizes):
     env = SimpleEnvironment([BRAIN_NAME], action_sizes=action_sizes, step_size=0.8)
     new_hyperparams = attr.evolve(
-        SAC_TORCH_CONFIG.hyperparameters, buffer_init_steps=2000
+        SAC_TORCH_CONFIG.hyperparameters, buffer_init_steps=2000, learning_rate=0.023, batch_size=1
     )
     config = attr.evolve(
-        SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=6000
+        SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=2300
     )
     check_environment_trains(env, {BRAIN_NAME: config}, success_threshold=0.8)
 


### PR DESCRIPTION
Hi,

I was able to reduce the running time of `test_2d_sac` test from 70  seconds to about 10 seconds on my local machine by changing some hyper-parameters.

I also ran the test several times to ensure that the test is not flaky.

Environment:
```
python 3.8
torch=1.7.1
numpy==1.19.5
```
Is this something that you guys will be interested in? If yes, then I can help you optimize some other tests in this repo as well. If you have any other suggestions/edits I will be happy to integrate them as well. Please let me know.

Thanks!