### PR TITLE
Set torch device from commandline

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -27,6 +27,7 @@ removed when training with a player. The Editor still requires it to be clamped 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added a `--torch-device` commandline option to `mlagent-learn`, which sets the default
   [`torch.device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device) used for training. (#4888)
+- The `--cpu` commandline option had no effect and was removed. Use `--torch-device=cpu` to force CPU training. (#4888)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -25,7 +25,7 @@ removed when training with a player. The Editor still requires it to be clamped 
   Changed the namespace and file names of classes in com.unity.ml-agents.extensions. (#4849)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- Added a `--torch-device` commandline option to `mlagent-learn`, which sets the default
+- Added a `--torch-device` commandline option to `mlagents-learn`, which sets the default
   [`torch.device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device) used for training. (#4888)
 - The `--cpu` commandline option had no effect and was removed. Use `--torch-device=cpu` to force CPU training. (#4888)
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -25,6 +25,8 @@ removed when training with a player. The Editor still requires it to be clamped 
   Changed the namespace and file names of classes in com.unity.ml-agents.extensions. (#4849)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- Added a `--torch-device` commandline option to `mlagent-learn`, which sets the default
+  [`torch.device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device) used for training. (#4888)
 
 ### Bug Fixes
 #### com.unity.ml-agents (C#)

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -229,9 +229,10 @@ checkpoint_settings:
 ```
 
 #### Torch settings:
+
 ```yaml
 torch_settings:
-  device: null
+  device: cpu
 ```
 
 ### Behavior Configurations

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -188,7 +188,8 @@ using the help utility:
 mlagents-learn --help
 ```
 
-These additional CLI arguments are grouped into environment, engine and checkpoint. The available settings and example values are shown below.
+These additional CLI arguments are grouped into environment, engine, checkpoint and torch.
+The available settings and example values are shown below.
 
 #### Environment settings
 
@@ -225,6 +226,12 @@ checkpoint_settings:
   force: true
   train_model: false
   inference: false
+```
+
+#### Torch settings:
+```yaml
+torch_settings:
+  device: null
 ```
 
 ### Behavior Configurations

--- a/ml-agents/mlagents/torch_utils/__init__.py
+++ b/ml-agents/mlagents/torch_utils/__init__.py
@@ -1,3 +1,4 @@
 from mlagents.torch_utils.torch import torch as torch  # noqa
 from mlagents.torch_utils.torch import nn  # noqa
+from mlagents.torch_utils.torch import set_torch_config  # noqa
 from mlagents.torch_utils.torch import default_device  # noqa

--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -37,6 +37,7 @@ import torch  # noqa I201
 torch.set_num_threads(cpu_utils.get_num_threads_to_use())
 os.environ["KMP_BLOCKTIME"] = "0"
 
+
 _device = torch.device("cpu")
 
 
@@ -56,6 +57,9 @@ def set_torch_config(torch_settings: TorchSettings) -> None:
         torch.set_default_tensor_type(torch.FloatTensor)
     logger.info(f"default Torch device: {_device}")
 
+
+# Initialize to default settings
+set_torch_config(TorchSettings(device=None))
 
 nn = torch.nn
 

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -178,12 +178,6 @@ def _create_parser() -> argparse.ArgumentParser:
         action=DetectDefault,
     )
     argparser.add_argument(
-        "--cpu",
-        default=False,
-        action=DetectDefaultStoreTrue,
-        help="Forces training using CPU only",
-    )
-    argparser.add_argument(
         "--torch",
         default=False,
         action=RaiseRemovedWarning,

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -257,6 +257,8 @@ def _create_parser() -> argparse.ArgumentParser:
     torch_conf.add_argument(
         "--torch-device",
         default=None,
+        dest="device",
+        action=DetectDefault,
         help='Settings for the default torch.device used in training, for example, "cpu", "cuda", or "cuda:0"',
     )
     return argparser

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -252,6 +252,13 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Whether to run the Unity executable in no-graphics mode (i.e. without initializing "
         "the graphics driver. Use this only if your agents don't use visual observations.",
     )
+
+    torch_conf = argparser.add_argument_group(title="Torch Configuration")
+    torch_conf.add_argument(
+        "--torch-device",
+        default=None,
+        help='Settings for the default torch.device used in training, for example, "cpu", "cuda", or "cuda:0"',
+    )
     return argparser
 
 

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -62,6 +62,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
     :param run_options: Command line arguments for training.
     """
     with hierarchical_timer("run_training.setup"):
+        torch_utils.set_torch_config(options.torch_settings)
         checkpoint_settings = options.checkpoint_settings
         env_settings = options.env_settings
         engine_settings = options.engine_settings

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -734,6 +734,11 @@ class EngineSettings:
 
 
 @attr.s(auto_attribs=True)
+class TorchSettings:
+    device: Optional[str] = parser.get_default("torch_device")
+
+
+@attr.s(auto_attribs=True)
 class RunOptions(ExportableSettings):
     default_settings: Optional[TrainerSettings] = None
     behaviors: DefaultDict[str, TrainerSettings] = attr.ib(

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -748,6 +748,7 @@ class RunOptions(ExportableSettings):
     engine_settings: EngineSettings = attr.ib(factory=EngineSettings)
     environment_parameters: Optional[Dict[str, EnvironmentParameterSettings]] = None
     checkpoint_settings: CheckpointSettings = attr.ib(factory=CheckpointSettings)
+    torch_settings: TorchSettings = attr.ib(factory=TorchSettings)
 
     # These are options that are relevant to the run itself, and not the engine or environment.
     # They will be left here.
@@ -789,6 +790,7 @@ class RunOptions(ExportableSettings):
             "checkpoint_settings": {},
             "env_settings": {},
             "engine_settings": {},
+            "torch_settings": {},
         }
         if config_path is not None:
             configured_dict.update(load_config(config_path))
@@ -813,6 +815,8 @@ class RunOptions(ExportableSettings):
                     configured_dict["env_settings"][key] = val
                 elif key in attr.fields_dict(EngineSettings):
                     configured_dict["engine_settings"][key] = val
+                elif key in attr.fields_dict(TorchSettings):
+                    configured_dict["torch_settings"][key] = val
                 else:  # Base options
                     configured_dict[key] = val
 

--- a/ml-agents/mlagents/trainers/tests/test_torch_utils.py
+++ b/ml-agents/mlagents/trainers/tests/test_torch_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest import mock
+
+import torch  # noqa I201
+
+from mlagents.torch_utils import set_torch_config, default_device
+from mlagents.trainers.settings import TorchSettings
+
+
+@pytest.mark.parametrize(
+    "device_str, expected_type, expected_index, expected_tensor_type",
+    [
+        ("cpu", "cpu", None, torch.FloatTensor),
+        ("cuda", "cuda", None, torch.cuda.FloatTensor),
+        ("cuda:42", "cuda", 42, torch.cuda.FloatTensor),
+        ("opengl", "opengl", None, torch.FloatTensor),
+    ],
+)
+@mock.patch.object(torch, "set_default_tensor_type")
+def test_set_torch_device(
+    mock_set_default_tensor_type,
+    device_str,
+    expected_type,
+    expected_index,
+    expected_tensor_type,
+):
+    torch_settings = TorchSettings(device=device_str)
+    set_torch_config(torch_settings)
+    assert default_device().type == expected_type
+    if expected_index is None:
+        assert default_device().index is None
+    else:
+        assert default_device().index == expected_index
+    mock_set_default_tensor_type.assert_called_once_with(expected_tensor_type)

--- a/ml-agents/mlagents/trainers/tests/test_torch_utils.py
+++ b/ml-agents/mlagents/trainers/tests/test_torch_utils.py
@@ -24,11 +24,18 @@ def test_set_torch_device(
     expected_index,
     expected_tensor_type,
 ):
-    torch_settings = TorchSettings(device=device_str)
-    set_torch_config(torch_settings)
-    assert default_device().type == expected_type
-    if expected_index is None:
-        assert default_device().index is None
-    else:
-        assert default_device().index == expected_index
-    mock_set_default_tensor_type.assert_called_once_with(expected_tensor_type)
+    try:
+        torch_settings = TorchSettings(device=device_str)
+        set_torch_config(torch_settings)
+        assert default_device().type == expected_type
+        if expected_index is None:
+            assert default_device().index is None
+        else:
+            assert default_device().index == expected_index
+        mock_set_default_tensor_type.assert_called_once_with(expected_tensor_type)
+    except Exception:
+        raise
+    finally:
+        # restore the defaults
+        torch_settings = TorchSettings(device=None)
+        set_torch_config(torch_settings)


### PR DESCRIPTION
### Proposed change(s)
The torch device string can now be set from the commandline. The default behavior is the same as before: it will use cuda if it's detected, or cpu otherwise. This allows overriding the default logic (e.g. force cpu even if you support cuda), or specifying a device index if e.g. you have two different GPU types.

Also logs the device type so that it's obvious which is being used.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://forum.unity.com/threads/ml-agent-server-build-headless-with-visual-observations-and-multiple-gpus.1042456/
https://github.com/Unity-Technologies/ml-agents/issues/4876

### Types of change(s)
- [x] New feature

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
