### PR TITLE
[MLA-1762] reduce memory allocations from DiscreteActionOutputApplier

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
 - Removed unnecessary memory allocations in `SideChannelManager.GetSideChannelMessage()` (#4886)
 - Removed several memory allocations that happened during inference. On a test scene, this
   reduced the amount of memory allocated by approximately 25%. (#4887)
+- Removed several memory allocations that happened during inference with discrete actions. (#4922)
+
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed a bug that would cause an exception when `RunOptions` was deserialized via `pickle`. (#4842)

--- a/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
@@ -56,7 +56,7 @@ namespace Unity.MLAgents.Inference
         readonly Multinomial m_Multinomial;
         readonly ActionSpec m_ActionSpec;
         readonly int[] m_StartActionIndices;
-        readonly float[] m_cdfBuffer;
+        readonly float[] m_CdfBuffer;
 
 
         public DiscreteActionOutputApplier(ActionSpec actionSpec, int seed, ITensorAllocator allocator)
@@ -69,7 +69,7 @@ namespace Unity.MLAgents.Inference
             // Scratch space for computing the cumulative distribution function.
             // In order to reuse it, make it the size of the largest branch.
             var largestBranch = Mathf.Max(m_ActionSize);
-            m_cdfBuffer = new float[largestBranch];
+            m_CdfBuffer = new float[largestBranch];
         }
 
         public void Apply(TensorProxy tensorProxy, IList<int> actionIds, Dictionary<int, ActionBuffers> lastActions)
@@ -90,7 +90,7 @@ namespace Unity.MLAgents.Inference
                     for (var j = 0; j < m_ActionSize.Length; j++)
                     {
                         ComputeCdf(tensorProxy, agentIndex, m_StartActionIndices[j], m_ActionSize[j]);
-                        discreteBuffer[j] = m_Multinomial.Sample(m_cdfBuffer, m_ActionSize[j]);
+                        discreteBuffer[j] = m_Multinomial.Sample(m_CdfBuffer, m_ActionSize[j]);
                     }
                 }
                 agentIndex++;
@@ -100,7 +100,7 @@ namespace Unity.MLAgents.Inference
         /// <summary>
         /// Compute the cumulative distribution function for a given agent's action
         /// given the log-probabilities.
-        /// The results are stored in m_cdfBuffer, which is the size of the largest action's number of branches.
+        /// The results are stored in m_CdfBuffer, which is the size of the largest action's number of branches.
         /// </summary>
         /// <param name="logProbs"></param>
         /// <param name="batch">Index of the agent being considered</param>
@@ -120,7 +120,7 @@ namespace Unity.MLAgents.Inference
             for (var cls = 0; cls < branchSize; ++cls)
             {
                 sumProb += Mathf.Exp(logProbs.data[batch, cls + channelOffset] - maxProb);
-                m_cdfBuffer[cls] = sumProb;
+                m_CdfBuffer[cls] = sumProb;
             }
         }
     }

--- a/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ApplierImpl.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.MLAgents.Inference.Utils;
@@ -106,19 +105,19 @@ namespace Unity.MLAgents.Inference
         /// <param name="logProbs"></param>
         /// <param name="batch">Index of the agent being considered</param>
         /// <param name="channelOffset">Offset into the tensor's channel.</param>
-        /// <param name="numBranches"></param>
-        internal void ComputeCdf(TensorProxy logProbs, int batch, int channelOffset, int numBranches)
+        /// <param name="branchSize"></param>
+        internal void ComputeCdf(TensorProxy logProbs, int batch, int channelOffset, int branchSize)
         {
             // Find the class maximum
             var maxProb = float.NegativeInfinity;
-            for (var cls = 0; cls < numBranches; ++cls)
+            for (var cls = 0; cls < branchSize; ++cls)
             {
                 maxProb = Mathf.Max(logProbs.data[batch, cls + channelOffset], maxProb);
             }
 
             // Sum the log probabilities and compute CDF
             var sumProb = 0.0f;
-            for (var cls = 0; cls < numBranches; ++cls)
+            for (var cls = 0; cls < branchSize; ++cls)
             {
                 sumProb += Mathf.Exp(logProbs.data[batch, cls + channelOffset] - maxProb);
                 m_cdfBuffer[cls] = sumProb;

--- a/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 namespace Unity.MLAgents.Inference.Utils
 {
     /// <summary>
@@ -36,11 +32,11 @@ namespace Unity.MLAgents.Inference.Utils
         /// to be monotonic (always increasing). If the CMF is scaled, then the last entry in
         /// the array will be 1.0.
         /// </param>
-        /// <param name="numBranches">The number of possible branches, i.e. the effective size of the cmf array.</param>
-        /// <returns>A sampled index from the CMF ranging from 0 to numBranches-1.</returns>
-        public int Sample(float[] cmf, int numBranches)
+        /// <param name="branchSize">The number of possible branches, i.e. the effective size of the cmf array.</param>
+        /// <returns>A sampled index from the CMF ranging from 0 to branchSize-1.</returns>
+        public int Sample(float[] cmf, int branchSize)
         {
-            var p = (float)m_Random.NextDouble() * cmf[numBranches - 1];
+            var p = (float)m_Random.NextDouble() * cmf[branchSize - 1];
             var cls = 0;
             while (cmf[cls] < p)
             {

--- a/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
@@ -47,7 +47,7 @@ namespace Unity.MLAgents.Inference.Utils
             return cls;
         }
 
-        public int SampleLogProb(TensorProxy tensor, int batch)
+        public int SampleLogProb(TensorProxy tensor, int batch, int channelOffset)
         {
             // TODO check that sum(exp(probs)) == approx(1)
             var target = (float)m_Random.NextDouble();
@@ -57,7 +57,7 @@ namespace Unity.MLAgents.Inference.Utils
             var sumProb = 0.0f;
             for (var cls = 0; cls < tensor.data.channels; ++cls)
             {
-                sumProb += Mathf.Exp(tensor.data[batch, cls]);
+                sumProb += Mathf.Exp(tensor.data[batch, cls + channelOffset]);
                 if (sumProb > target)
                 {
                     return cls;

--- a/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Unity.MLAgents.Inference.Utils
@@ -34,10 +36,11 @@ namespace Unity.MLAgents.Inference.Utils
         /// to be monotonic (always increasing). If the CMF is scaled, then the last entry in
         /// the array will be 1.0.
         /// </param>
-        /// <returns>A sampled index from the CMF ranging from 0 to cmf.Length-1.</returns>
-        public int Sample(float[] cmf)
+        /// <param name="numBranches">The number of possible branches, i.e. the effective size of the cmf array.</param>
+        /// <returns>A sampled index from the CMF ranging from 0 to numBranches-1.</returns>
+        public int Sample(float[] cmf, int numBranches)
         {
-            var p = (float)m_Random.NextDouble() * cmf[cmf.Length - 1];
+            var p = (float)m_Random.NextDouble() * cmf[numBranches - 1];
             var cls = 0;
             while (cmf[cls] < p)
             {
@@ -47,25 +50,14 @@ namespace Unity.MLAgents.Inference.Utils
             return cls;
         }
 
-        public int SampleLogProb(TensorProxy tensor, int batch, int channelOffset)
+        /// <summary>
+        /// Samples from the Multinomial distribution defined by the provided cumulative
+        /// mass function.
+        /// </summary>
+        /// <returns>A sampled index from the CMF ranging from 0 to cmf.Length-1.</returns>
+        public int Sample(float[] cmf)
         {
-            // TODO check that sum(exp(probs)) == approx(1)
-            var target = (float)m_Random.NextDouble();
-
-            // Sum the log probabilities, and compute CDF as we go.
-            // When we find the target value, return immediately.
-            var sumProb = 0.0f;
-            for (var cls = 0; cls < tensor.data.channels; ++cls)
-            {
-                sumProb += Mathf.Exp(tensor.data[batch, cls + channelOffset]);
-                if (sumProb > target)
-                {
-                    return cls;
-                }
-            }
-
-            return tensor.data.channels - 1;
-
+            return Sample(cmf, cmf.Length);
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
+++ b/com.unity.ml-agents/Runtime/Inference/Utils/Multinomial.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace Unity.MLAgents.Inference.Utils
 {
     /// <summary>
@@ -43,6 +45,27 @@ namespace Unity.MLAgents.Inference.Utils
             }
 
             return cls;
+        }
+
+        public int SampleLogProb(TensorProxy tensor, int batch)
+        {
+            // TODO check that sum(exp(probs)) == approx(1)
+            var target = (float)m_Random.NextDouble();
+
+            // Sum the log probabilities, and compute CDF as we go.
+            // When we find the target value, return immediately.
+            var sumProb = 0.0f;
+            for (var cls = 0; cls < tensor.data.channels; ++cls)
+            {
+                sumProb += Mathf.Exp(tensor.data[batch, cls]);
+                if (sumProb > target)
+                {
+                    return cls;
+                }
+            }
+
+            return tensor.data.channels - 1;
+
         }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using Unity.Barracuda;
 using NUnit.Framework;
 using UnityEngine;
+using Unity.MLAgents.Actuators;
 using Unity.MLAgents.Inference;
 using Unity.MLAgents.Inference.Utils;
 
@@ -10,184 +12,39 @@ namespace Unity.MLAgents.Tests
     public class DiscreteActionOutputApplierTest
     {
         [Test]
-        public void TestEvalP()
+        public void TestDiscreteApply()
         {
-            var m = new Multinomial(2018);
+            var actionSpec = ActionSpec.MakeDiscrete(3, 2);
+            const float smallLogProb = -1000.0f;
+            const float largeLogProb = -1.0f;
 
-            var src = new TensorProxy
-            {
-                data = new Tensor(1, 3, new[] { 0.1f, 0.2f, 0.7f }),
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            var dst = new TensorProxy
-            {
-                data = new Tensor(1, 3),
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            DiscreteActionOutputApplier.Eval(src, dst, m);
-
-            float[] reference = { 2, 2, 1 };
-            for (var i = 0; i < dst.data.length; i++)
-            {
-                Assert.AreEqual(reference[i], dst.data[i]);
-                ++i;
-            }
-        }
-
-        [Test]
-        public void TestEvalLogits()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
+            var logProbs = new TensorProxy
             {
                 data = new Tensor(
-                    1,
-                    3,
-                    new[] { Mathf.Log(0.1f) - 50, Mathf.Log(0.2f) - 50, Mathf.Log(0.7f) - 50 }),
+                    2,
+                    5,
+                    new[]
+                    {
+                        smallLogProb, smallLogProb, largeLogProb, // Agent 0, branch 0
+                        smallLogProb, largeLogProb,               // Agent 0, branch 1
+                        largeLogProb, smallLogProb, smallLogProb, // Agent 1, branch 0
+                        largeLogProb, smallLogProb,               // Agent 1, branch 1
+                    }),
                 valueType = TensorProxy.TensorType.FloatingPoint
             };
 
-            var dst = new TensorProxy
-            {
-                data = new Tensor(1, 3),
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
+            var applier = new DiscreteActionOutputApplier(actionSpec, 2020, null);
+            var agentIds = new List<int> { 42, 1337 };
+            var actionBuffers = new Dictionary<int, ActionBuffers>();
+            actionBuffers[42] = new ActionBuffers(actionSpec);
+            actionBuffers[1337] = new ActionBuffers(actionSpec);
 
-            DiscreteActionOutputApplier.Eval(src, dst, m);
+            applier.Apply(logProbs, agentIds, actionBuffers);
+            Assert.AreEqual(2, actionBuffers[42].DiscreteActions[0]);
+            Assert.AreEqual(1, actionBuffers[42].DiscreteActions[1]);
 
-            float[] reference = { 2, 2, 2 };
-            for (var i = 0; i < dst.data.length; i++)
-            {
-                Assert.AreEqual(reference[i], dst.data[i]);
-                ++i;
-            }
-        }
-
-        [Test]
-        public void TestEvalBatching()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                data = new Tensor(2, 3, new[]
-                {
-                    Mathf.Log(0.1f) - 50, Mathf.Log(0.2f) - 50, Mathf.Log(0.7f) - 50,
-                    Mathf.Log(0.3f) - 25, Mathf.Log(0.4f) - 25, Mathf.Log(0.3f) - 25
-                }),
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            var dst = new TensorProxy
-            {
-                data = new Tensor(2, 3),
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            DiscreteActionOutputApplier.Eval(src, dst, m);
-
-            float[] reference = { 2, 2, 2, 0, 1, 0 };
-            for (var i = 0; i < dst.data.length; i++)
-            {
-                Assert.AreEqual(reference[i], dst.data[i]);
-                ++i;
-            }
-        }
-
-        [Test]
-        public void TestSrcInt()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.Integer
-            };
-
-            Assert.Throws<NotImplementedException>(
-                () => DiscreteActionOutputApplier.Eval(src, null, m));
-        }
-
-        [Test]
-        public void TestDstInt()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            var dst = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.Integer
-            };
-
-            Assert.Throws<ArgumentException>(
-                () => DiscreteActionOutputApplier.Eval(src, dst, m));
-        }
-
-        [Test]
-        public void TestSrcDataNull()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            var dst = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            Assert.Throws<ArgumentNullException>(
-                () => DiscreteActionOutputApplier.Eval(src, dst, m));
-        }
-
-        [Test]
-        public void TestDstDataNull()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint,
-                data = new Tensor(0, 1)
-            };
-
-            var dst = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint
-            };
-
-            Assert.Throws<ArgumentNullException>(
-                () => DiscreteActionOutputApplier.Eval(src, dst, m));
-        }
-
-        [Test]
-        public void TestUnequalBatchSize()
-        {
-            var m = new Multinomial(2018);
-
-            var src = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint,
-                data = new Tensor(1, 1)
-            };
-
-            var dst = new TensorProxy
-            {
-                valueType = TensorProxy.TensorType.FloatingPoint,
-                data = new Tensor(2, 1)
-            };
-
-            Assert.Throws<ArgumentException>(
-                () => DiscreteActionOutputApplier.Eval(src, dst, m));
+            Assert.AreEqual(0, actionBuffers[1337].DiscreteActions[0]);
+            Assert.AreEqual(0, actionBuffers[1337].DiscreteActions[1]);
         }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/DiscreteActionOutputApplierTest.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
 using Unity.Barracuda;
 using NUnit.Framework;
-using UnityEngine;
 using Unity.MLAgents.Actuators;
 using Unity.MLAgents.Inference;
-using Unity.MLAgents.Inference.Utils;
 
 namespace Unity.MLAgents.Tests
 {


### PR DESCRIPTION
### Proposed change(s)
There were several intermediate tensors and float arrays (1d and 2d) allocated on each call. This reuses a single float[] for the CDF, and eliminates the other intermediate allocations. Now for each action, we compute the CDF and sample the result directly to the output ActionBuffers.DiscreteActions.

Before:
![image](https://user-images.githubusercontent.com/6877802/107271187-b9855780-6a00-11eb-8faf-2e6ec80edcc0.png)
After:
![image](https://user-images.githubusercontent.com/6877802/107271209-c30ebf80-6a00-11eb-8ac3-03c73e9af147.png)

### Types of change(s)

- [x] Optimization
- [x] Code refactor

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)

### Other comments
