### PR TITLE
surface specific GRPC errors more visibly

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
 - Removed several memory allocations that happened during inference. On a test scene, this
   reduced the amount of memory allocated by approximately 25%. (#4887)
 - Properly catch permission errors when writing timer files. (#4921)
+- Unexpected gRPC exceptions during training are now logged before stopping training. If you see
+  "noisy" log, please let us know! (#4930)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed a bug that would cause an exception when `RunOptions` was deserialized via `pickle`. (#4842)

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -440,6 +440,7 @@ namespace Unity.MLAgents
             {
                 return null;
             }
+
             try
             {
                 var message = m_Client.Exchange(WrapMessage(unityOutput, 200));
@@ -455,8 +456,31 @@ namespace Unity.MLAgents
                 QuitCommandReceived?.Invoke();
                 return message.UnityInput;
             }
+            catch (RpcException rpcException)
+            {
+                // Log more verbose errors if they're something the user can possibly do something about.
+                switch (rpcException.Status.StatusCode)
+                {
+                    case StatusCode.Unavailable:
+                        // This can happen when python disconnects. Ignore it to avoid noisy logs.
+                        break;
+                    case StatusCode.ResourceExhausted:
+                        // This happens is the message body is too large. There's no way to
+                        // gracefully handle this, but at least we can show the message and the
+                        // user can try to reduce the number of agents or observation sizes.
+                        Debug.LogError($"GRPC Exception: {rpcException.Message}. Exiting communicator.");
+                        break;
+                    default:
+                        // Other unknown errors. Keep these quiet for now.
+                        break;
+                }
+                m_IsOpen = false;
+                QuitCommandReceived?.Invoke();
+                return null;
+            }
             catch
             {
+                // Fall-through for other error types
                 m_IsOpen = false;
                 QuitCommandReceived?.Invoke();
                 return null;

--- a/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/RpcCommunicator.cs
@@ -468,19 +468,21 @@ namespace Unity.MLAgents
                         // This happens is the message body is too large. There's no way to
                         // gracefully handle this, but at least we can show the message and the
                         // user can try to reduce the number of agents or observation sizes.
-                        Debug.LogError($"GRPC Exception: {rpcException.Message}. Exiting communicator.");
+                        Debug.LogError($"GRPC Exception: {rpcException.Message}. Disconnecting from trainer.");
                         break;
                     default:
-                        // Other unknown errors. Keep these quiet for now.
+                        // Other unknown errors. Log at INFO level.
+                        Debug.Log($"GRPC Exception: {rpcException.Message}. Disconnecting from trainer.");
                         break;
                 }
                 m_IsOpen = false;
                 QuitCommandReceived?.Invoke();
                 return null;
             }
-            catch
+            catch (Exception ex)
             {
                 // Fall-through for other error types
+                Debug.LogError($"GRPC Exception: {ex.Message}. Disconnecting from trainer.");
                 m_IsOpen = false;
                 QuitCommandReceived?.Invoke();
                 return null;


### PR DESCRIPTION
### Proposed change(s)
We want to ignore some GRPC errors but raise others. Currently just opting in to one error (ResourceExhausted, when the payload is too large), but I'm willing to reconsider.

Also not sure how to test this; I did it manually with some breakpoints (to confirm the `StatusCode.Unavailable` case) and modifying GridWorld with a large uncompressed sensor (to confirm `StatusCode.ResourceExhausted`),

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1719

### Types of change(s)
- [x] Bug fix

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
