### PR TITLE
allow inference test timeouts (and pass from commandline)

### DIFF
--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -172,7 +172,7 @@ def run_inference(env_path: str, output_path: str, model_extension: str) -> bool
         timer_data = json.load(f)
 
     gauges = timer_data.get("gauges", {})
-    rewards = gauges.get("Override_3DBall.CumulativeReward")
+    rewards = gauges.get("Override_3DBall.CumulativeReward", {})
     max_reward = rewards.get("max")
     if max_reward is None:
         print(

--- a/ml-agents/tests/yamato/training_int_tests.py
+++ b/ml-agents/tests/yamato/training_int_tests.py
@@ -133,6 +133,11 @@ def run_inference(env_path: str, output_path: str, model_extension: str) -> bool
 
     log_output_path = f"{get_base_output_path()}/inference.{model_extension}.txt"
 
+    # 10 minutes for inference is more than enough
+    process_timeout = 10 * 60
+    # Try to gracefully exit a few seconds before that.
+    model_override_timeout = process_timeout - 15
+
     exe_path = exes[0]
     args = [
         exe_path,
@@ -147,10 +152,11 @@ def run_inference(env_path: str, output_path: str, model_extension: str) -> bool
         "1",
         "--mlagents-override-model-extension",
         model_extension,
+        "--mlagents-quit-after-seconds",
+        str(model_override_timeout),
     ]
     print(f"Starting inference with args {' '.join(args)}")
-    timeout = 15 * 60  # 15 minutes for inference is more than enough
-    res = subprocess.run(args, timeout=timeout)
+    res = subprocess.run(args, timeout=process_timeout)
     end_time = time.time()
     if res.returncode != 0:
         print("Error running inference!")


### PR DESCRIPTION
### Proposed change(s)
Inference tests can theoretically run forever. We have timeouts on the subprocess calls in yamato tests (and also in our internal CI), but we should shutdown gracefully also.

This adds a new commandline argument that is recognized by ModelOverride, and exits after the specified number of seconds.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1683

### Types of change(s)
- [x] CI
