### PR TITLE
[yamato] drop 2020.1, reduce test variants, tighten triggers

### DIFF
--- a/.yamato/com.unity.ml-agents-performance.yml
+++ b/.yamato/com.unity.ml-agents-performance.yml
@@ -1,6 +1,5 @@
 test_editors:
   - version: 2019.4
-  - version: 2020.1
   - version: 2020.2
 ---
 {% for editor in test_editors %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -9,10 +9,6 @@ test_editors:
     enableCodeCoverage: !!bool true
     testProject: DevProject
     enableNoDefaultPackages: !!bool true
-  - version: 2020.1
-    enableCodeCoverage: !!bool true
-    testProject: DevProject
-    enableNoDefaultPackages: !!bool true
   - version: 2020.2
     enableCodeCoverage: !!bool true
     testProject: DevProject

--- a/.yamato/compressed-sensor-test.yml
+++ b/.yamato/compressed-sensor-test.yml
@@ -21,6 +21,7 @@ test_compressed_obs_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
+    {% if platform.extra_test == "sensor" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND
@@ -28,8 +29,9 @@ test_compressed_obs_{{ editor.version }}:
       (pull_request.changes.any match "com.unity.ml-agents/**" OR
       pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
       pull_request.changes.any match "Project/**" OR
-      pull_request.changes.any match "ml-agents/**" OR
+      pull_request.changes.any match "ml-agents/tests/yamato/**" OR
       pull_request.changes.any match "ml-agents-envs/**" OR
       pull_request.changes.any match ".yamato/compressed-sensor-test.yml") AND
       NOT pull_request.changes.all match "**/*.md"
+    {% endif %}
 {% endfor %}

--- a/.yamato/compressed-sensor-test.yml
+++ b/.yamato/compressed-sensor-test.yml
@@ -21,7 +21,7 @@ test_compressed_obs_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
-    {% if platform.extra_test == "sensor" %}
+    {% if editor.extra_test == "sensor" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND

--- a/.yamato/gym-interface-test.yml
+++ b/.yamato/gym-interface-test.yml
@@ -21,15 +21,17 @@ test_gym_interface_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
+    {% if platform.extra_test == "gym" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND
       NOT pull_request.draft AND
       (pull_request.changes.any match "com.unity.ml-agents/**" OR
       pull_request.changes.any match "Project/**" OR
-      pull_request.changes.any match "ml-agents/**" OR
+      pull_request.changes.any match "ml-agents/tests/yamato/**" OR
       pull_request.changes.any match "ml-agents-envs/**" OR
       pull_request.changes.any match "gym-unity/**" OR
       pull_request.changes.any match ".yamato/gym-interface-test.yml") AND
       NOT pull_request.changes.all match "**/*.md"
+    {% endif %}
 {% endfor %}

--- a/.yamato/gym-interface-test.yml
+++ b/.yamato/gym-interface-test.yml
@@ -21,7 +21,7 @@ test_gym_interface_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
-    {% if platform.extra_test == "gym" %}
+    {% if editor.extra_test == "gym" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND

--- a/.yamato/python-ll-api-test.yml
+++ b/.yamato/python-ll-api-test.yml
@@ -23,14 +23,16 @@ test_linux_ll_api_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
+    {% if platform.extra_test == "llapi" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND
       NOT pull_request.draft AND
       (pull_request.changes.any match "com.unity.ml-agents/**" OR
       pull_request.changes.any match "Project/**" OR
-      pull_request.changes.any match "ml-agents/**" OR
+      pull_request.changes.any match "ml-agents/tests/yamato/**" OR
       pull_request.changes.any match "ml-agents-envs/**" OR
       pull_request.changes.any match ".yamato/python-ll-api-test.yml") AND
       NOT pull_request.changes.all match "**/*.md"
+    {% endif %}
 {% endfor %}

--- a/.yamato/python-ll-api-test.yml
+++ b/.yamato/python-ll-api-test.yml
@@ -23,7 +23,7 @@ test_linux_ll_api_{{ editor.version }}:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}
   triggers:
     cancel_old_ci: true
-    {% if platform.extra_test == "llapi" %}
+    {% if editor.extra_test == "llapi" %}
     expression: |
       (pull_request.target eq "master" OR
       pull_request.target match "release.+") AND

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -1,14 +1,11 @@
 # List of editor versions for standalone-build-test and its dependencies.
-# csharp_backcompat_version is used in training-int-tests to determine the
-# older package version to run the backwards compat tests against.
+# We always run training-int-tests for all versions of the editor
+# For each "other" test, we only run it against a single version of the
+# editor to reduce the number of yamato jobs
 test_editors:
   - version: 2018.4
-    csharp_backcompat_version: 1.0.0
+    extra_test = llapi
   - version: 2019.4
-    csharp_backcompat_version: 1.0.0
-  - version: 2020.1
-    csharp_backcompat_version: 1.0.0
+    extra_test = gym
   - version: 2020.2
-    # 2020.2 moved the AssetImporters namespace
-    # but we didn't handle this until 1.2.0
-    csharp_backcompat_version: 1.2.0
+    extra_test = sensor

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -4,8 +4,8 @@
 # editor to reduce the number of yamato jobs
 test_editors:
   - version: 2018.4
-    extra_test = llapi
+    extra_test: llapi
   - version: 2019.4
-    extra_test = gym
+    extra_test: gym
   - version: 2020.2
-    extra_test = sensor
+    extra_test: sensor

--- a/.yamato/training-backcompat-tests.yml
+++ b/.yamato/training-backcompat-tests.yml
@@ -1,8 +1,9 @@
 
-test_mac_backcompat_2020.2:
-  {% capture editor_version %}2020.2{% endcapture %}
-  {% capture csharp_backcompat_version %}1.0.2{% endcapture %}
+test_mac_backcompat_2020.1:
+  {% capture editor_version %}2020.1{% endcapture %}
+  {% capture csharp_backcompat_version %}1.0.0{% endcapture %}
   # This test has to run on mac because it requires the custom build of tensorflow without AVX
+  # Test against 2020.1 because 2020.2 has to run against package version 1.2.0
   name: Test Mac Backcompat Training {{ editor_version }}
   agent:
     type: Unity::VM::osx

--- a/.yamato/training-backcompat-tests.yml
+++ b/.yamato/training-backcompat-tests.yml
@@ -1,9 +1,8 @@
 
-test_mac_backcompat_2020.1:
-  {% capture editor_version %}2020.1{% endcapture %}
-  {% capture csharp_backcompat_version %}1.0.0{% endcapture %}
+test_mac_backcompat_2020.2:
+  {% capture editor_version %}2020.2{% endcapture %}
+  {% capture csharp_backcompat_version %}1.0.2{% endcapture %}
   # This test has to run on mac because it requires the custom build of tensorflow without AVX
-  # Test against 2020.1 because 2020.2 has to run against package version 1.2.0
   name: Test Mac Backcompat Training {{ editor_version }}
   agent:
     type: Unity::VM::osx


### PR DESCRIPTION
### Proposed change(s)
* Remove 2020.1 from the list of editors to test against, now that 2020.2 is out
* For gym, LL-API, and compressed sensor tests, only test against one version of the editor.
* Tighten the triggers for these tests since they don't depend on general ml-agents code.

### Types of change(s)
- [x] CI
