### PR TITLE
fix regex, remove deleted file from filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,6 @@ repos:
         args: [--py3-plus, --py36-plus]
         exclude: >
             (?x)^(
-                .*barracuda.py|
                 .*_pb2.py|
                 .*_pb2_grpc.py
             )$
@@ -70,7 +69,7 @@ repos:
         args: [--assume-in-merge]
     -   id: check-yaml
         # Won't handle the templating in yamato
-        exclude: \.yamato/*
+        exclude: \.yamato/.*
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.4.2


### PR DESCRIPTION
### Proposed change(s)
Two small fixes in the pre-commit config:
* The regex for `check-yaml` was wrong; this generates warnings in newer versions of pre-commit
* `pyupgrade` was filtering for `*barracuda.py` but those files are removed
