### PR TITLE
pass sensor dimension flags to analytics

### DIFF
--- a/com.unity.ml-agents/Runtime/Analytics/Events.cs
+++ b/com.unity.ml-agents/Runtime/Analytics/Events.cs
@@ -72,11 +72,12 @@ namespace Unity.MLAgents.Analytics
         public static EventObservationSpec FromSensor(ISensor sensor)
         {
             var shape = sensor.GetObservationShape();
+            var dimProps = (sensor as IDimensionPropertiesSensor)?.GetDimensionProperties();
             var dimInfos = new EventObservationDimensionInfo[shape.Length];
             for (var i = 0; i < shape.Length; i++)
             {
                 dimInfos[i].Size = shape[i];
-                // TODO copy flags when we have them
+                dimInfos[i].Flags = dimProps != null ? (int)dimProps[i] : 0;
             }
 
             var builtInSensorType =

--- a/com.unity.ml-agents/Tests/Editor/Analytics/InferenceAnalyticsTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Analytics/InferenceAnalyticsTests.cs
@@ -58,6 +58,8 @@ namespace Unity.MLAgents.Tests.Analytics
             Assert.AreEqual(2, continuousEvent.ObservationSpecs.Count);
             Assert.AreEqual(3, continuousEvent.ObservationSpecs[0].DimensionInfos.Length);
             Assert.AreEqual(20, continuousEvent.ObservationSpecs[0].DimensionInfos[0].Size);
+            Assert.AreEqual((int)DimensionProperty.TranslationalEquivariance, continuousEvent.ObservationSpecs[0].DimensionInfos[0].Flags);
+            Assert.AreEqual((int)DimensionProperty.None, continuousEvent.ObservationSpecs[0].DimensionInfos[2].Flags);
             Assert.AreEqual("None", continuousEvent.ObservationSpecs[0].CompressionType);
             Assert.AreEqual(Test3DSensor.k_BuiltInSensorType, continuousEvent.ObservationSpecs[0].BuiltInSensorType);
             Assert.AreNotEqual(null, continuousEvent.ModelHash);

--- a/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/ParameterLoaderTest.cs
@@ -24,7 +24,7 @@ namespace Unity.MLAgents.Tests
             return Sensor.GetObservationShape();
         }
     }
-    public class Test3DSensor : ISensor, IBuiltInSensor
+    public class Test3DSensor : ISensor, IBuiltInSensor, IDimensionPropertiesSensor
     {
         int m_Width;
         int m_Height;
@@ -76,6 +76,16 @@ namespace Unity.MLAgents.Tests
         public BuiltInSensorType GetBuiltInSensorType()
         {
             return (BuiltInSensorType)k_BuiltInSensorType;
+        }
+
+        public DimensionProperty[] GetDimensionProperties()
+        {
+            return new[]
+            {
+                DimensionProperty.TranslationalEquivariance,
+                DimensionProperty.TranslationalEquivariance,
+                DimensionProperty.None
+            };
         }
     }
 


### PR DESCRIPTION
### Proposed change(s)
We started using Dimension Properties in https://github.com/Unity-Technologies/ml-agents/pull/4909; this updates analytics to read them from the sensor (if applicable).

### Types of change(s)
- [x] New feature

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works

### Other comments
