### PR TITLE
Masking Discrete Actions typos

### DIFF
--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -674,7 +674,7 @@ decide to perform the masked action. In order to mask an action, override the
 ```csharp
 public override void WriteDiscreteActionMask(IDiscreteActionMask actionMask)
 {
-    actionMasker.WriteMask(branch, actionIndices)
+    actionMask.WriteMask(branch, actionIndices);
 }
 ```
 
@@ -692,7 +692,7 @@ nothing"_ or _"change weapon"_ for his next decision (since action index 1 and 2
 are masked)
 
 ```csharp
-WriteMask(0, new int[2]{1,2})
+WriteMask(0, new int[2]{1,2});
 ```
 
 Notes:


### PR DESCRIPTION
Missing ";" and actionMasker should be actionMask, as far as I can tell

### Proposed change(s)

Small typos in Masking Discrete Actions

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [X] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
