### PR TITLE
Communicator factory

### DIFF
--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -422,12 +422,7 @@ namespace Unity.MLAgents
             var port = ReadPortFromArgs();
             if (port > 0)
             {
-                Communicator = new RpcCommunicator(
-                    new CommunicatorInitParameters
-                    {
-                        port = port
-                    }
-                );
+                Communicator = CommunicatorFactory.Create();
             }
 
             if (Communicator != null)
@@ -438,6 +433,7 @@ namespace Unity.MLAgents
                 bool initSuccessful = false;
                 var communicatorInitParams = new CommunicatorInitParameters
                 {
+                    port = port,
                     unityCommunicationVersion = k_ApiVersion,
                     unityPackageVersion = k_PackageVersion,
                     name = "AcademySingleton",

--- a/com.unity.ml-agents/Runtime/Communicator/CommunicatorFactory.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/CommunicatorFactory.cs
@@ -1,0 +1,35 @@
+namespace Unity.MLAgents
+{
+    /// <summary>
+    /// Factory class for an ICommunicator instance. This is used to the <see cref="Academy"/> at startup.
+    /// By default, on desktop platforms, an ICommunicator will be created and attempt to connect
+    /// to a trainer. This behavior can be prevented by setting <see cref="CommunicatorFactory.Enabled"/> to false
+    /// *before* the <see cref="Academy"/> is initialized.
+    /// </summary>
+    public static class CommunicatorFactory
+    {
+        static bool s_Enabled = true;
+
+        /// <summary>
+        /// Whether or not an ICommunicator instance will be created when the <see cref="Academy"/> is initialized.
+        /// Changing this has no effect after the <see cref="Academy"/> has already been initialized.
+        /// </summary>
+        public static bool Enabled
+        {
+            get => s_Enabled;
+            set => s_Enabled = value;
+        }
+
+        internal static ICommunicator Create()
+        {
+#if UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_LINUX
+            if (s_Enabled)
+            {
+                return new RpcCommunicator();
+            }
+#endif
+            // Non-desktop or disabled
+            return null;
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/Communicator/CommunicatorFactory.cs.meta
+++ b/com.unity.ml-agents/Runtime/Communicator/CommunicatorFactory.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b604cddc07e4484a2cdaba630a971ea
+timeCreated: 1613617949


### PR DESCRIPTION
### Proposed change(s)
Follow up for the "RpcCommunicator on non-desktop" compilation problems.
* Makes all of RpcCommunicator.cs empty on non-desktop.
* Adds a CommunicatorFactory that returns either an RpcCommunicator or null
* Cleans up RpcCommunicator - it was being passed `CommunicatorInitParameters` in both it's constructor and Initialize() method. It stored the former but only used the port from it.
* (possibly controversial) Setting `CommunicatorFactory.Enabled = false` will skip creating (and attempting to connect) with RpcCommunicator. This is a bit clunky but it's the only way we have to avoid trying to connect to a trainer, which could be a problem for shipping games.

### Types of change(s)
- [x] Bug fix
- [x] Code refactor


### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/master/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/master/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Migrating.md) (if applicable)

### Other comments
