### PR TITLE
Handle no plugins found

### DIFF
--- a/ml-agents/mlagents/plugins/stats_writer.py
+++ b/ml-agents/mlagents/plugins/stats_writer.py
@@ -43,6 +43,14 @@ def register_stats_writer_plugins(run_options: RunOptions) -> List[StatsWriter]:
     and evaluates them, and returns the list of all the StatsWriter implementations.
     """
     all_stats_writers: List[StatsWriter] = []
+    if ML_AGENTS_STATS_WRITER not in importlib_metadata.entry_points():
+        logger.warning(
+            f"Unable to find any entry points for {ML_AGENTS_STATS_WRITER}, even the default ones. "
+            "Uninstalling and reinstalling ml-agents via pip should resolve. "
+            "Using default plugins for now."
+        )
+        return get_default_stats_writers(run_options)
+
     entry_points = importlib_metadata.entry_points()[ML_AGENTS_STATS_WRITER]
 
     for entry_point in entry_points:


### PR DESCRIPTION
### Proposed change(s)
This should only be a problem if you have ml-agents installed via pip from before plugins were added, and update to after they were added, without rerunning `pip install -e ml-agents` again (which establishes the entry points).

Manually tested by
* uninstalling ml-agents
* checking out release_12 tag and installing from there
* switching to master branch and running `mlagents-learn --force` - this produces an exception.
* switching to this branch and running the same command produces the warning and allows training to start.

Exception without the fix:
```
Traceback (most recent call last):
  File "/Users/chris.elion/code/ml-agents/venv/bin/mlagents-learn", line 33, in <module>
    sys.exit(load_entry_point('mlagents', 'console_scripts', 'mlagents-learn')())
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 250, in main
    run_cli(parse_command_line())
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 246, in run_cli
    run_training(run_seed, options)
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/trainers/learn.py", line 83, in run_training
    stats_writers = register_stats_writer_plugins(options)
  File "/Users/chris.elion/code/ml-agents/ml-agents/mlagents/plugins/stats_writer.py", line 46, in register_stats_writer_plugins
    entry_points = importlib_metadata.entry_points()[ML_AGENTS_STATS_WRITER]
```
Warning with it:
```
2021-02-18 11:56:35 WARNING [stats_writer.py:47] Unable to find any entry points for mlagents.stats_writer, even the default ones. Uninstalling and reinstalling ml-agents via pip should resolve. Using default plugins for now.
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
