### PR TITLE
Tried to make improvements to the initialization of the hyperNetwork weights

### DIFF
--- a/ml-agents/mlagents/trainers/torch/layers.py
+++ b/ml-agents/mlagents/trainers/torch/layers.py
@@ -334,7 +334,7 @@ class HyperNetwork(torch.nn.Module):
         bound = math.sqrt(1 / (layer_size * self.input_size))
         flat_output.weight.data.uniform_(-bound, bound)
 
-        self.hypernet = torch.nn.Sequential(*layers, flat_output, LayerNorm())
+        self.hypernet = torch.nn.Sequential(*layers, LayerNorm(), flat_output)
 
         # The hypernetwork will not generate the bias of the main network layer
         self.bias = torch.nn.Parameter(torch.zeros(output_size))

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -121,6 +121,8 @@ class NetworkBody(nn.Module):
                 self.obs_types[idx] == ObservationType.GOAL
                 and self.conditioning_type != ConditioningType.DEFAULT
             ):
+                if goal_signal is not None:
+                    raise "Error"
                 goal_signal = processed_obs
 
         if len(encodes) == 0:

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -122,7 +122,7 @@ class NetworkBody(nn.Module):
                 and self.conditioning_type != ConditioningType.DEFAULT
             ):
                 if goal_signal is not None:
-                    raise "Error"
+                    raise Exception("TODO : Cannot currently handle more than one goal")
                 goal_signal = processed_obs
 
         if len(encodes) == 0:


### PR DESCRIPTION
### Proposed change(s)

I inspired myself from this paper : https://openreview.net/forum?id=H1lma24tPB
And initialized the last layer of the hypernet to be such that the weights generated follow the default initialization for the main network.


Here is the improvement on CrawlerDynamicVS  (orange is this PR, grey is the target branch): 

<img width="1308" alt="GoalDynamicCrawlerVS" src="https://user-images.githubusercontent.com/28320361/108800479-1bd57080-7548-11eb-8496-269ad8c8aa42.png">

For GoalGridWorld  (red is this PR, green is the target branch): : 
<img width="1310" alt="GoalGridWorld" src="https://user-images.githubusercontent.com/28320361/108800491-23951500-7548-11eb-8135-4e64e245ef77.png">

For GoalNav  (blue is this PR, pink is the target branch): : 

<img width="1277" alt="GoalNav" src="https://user-images.githubusercontent.com/28320361/108800502-2abc2300-7548-11eb-99ce-e67576dc27bf.png">

I **think** it closes the gap on crawler between what is on master (small) and hypernet.