### PR TITLE
Make TrainingAnalyticsSideChannel internal

### DIFF
--- a/com.unity.ml-agents/Runtime/SideChannels/TrainingAnalyticsSideChannel.cs
+++ b/com.unity.ml-agents/Runtime/SideChannels/TrainingAnalyticsSideChannel.cs
@@ -8,7 +8,7 @@ namespace Unity.MLAgents.SideChannels
     /// <summary>
     /// Side Channel implementation for recording which training features are being used.
     /// </summary>
-    public class TrainingAnalyticsSideChannel : SideChannel
+    internal class TrainingAnalyticsSideChannel : SideChannel
     {
         const string k_TrainingAnalyticsConfigId = "b664a4a9-d86f-5a5f-95cb-e8353a7e8356";
 


### PR DESCRIPTION
Noticed TrainingAnalyticsSideChannel was missing docs on master (@surfnerd already fixed on the release branch), and realized that the class doesn't need to be public