### PR TITLE
Fixing the number of layers in the config of PyramidsRND

### DIFF
--- a/config/ppo/PyramidsRND.yaml
+++ b/config/ppo/PyramidsRND.yaml
@@ -24,6 +24,7 @@ behaviors:
         strength: 0.01
         network_settings:
           hidden_units: 64
+          num_layers: 3
         learning_rate: 0.0001
     keep_checkpoints: 5
     max_steps: 3000000


### PR DESCRIPTION
### Proposed change(s)

There used to be 3 layers but now there are 2. I did some experiments and it seems 3 layers work better.

