### PR TITLE
Make GridSensor a non allocating object after initialization.

### DIFF
--- a/ML-Agents-Input-Example/Packages/packages-lock.json
+++ b/ML-Agents-Input-Example/Packages/packages-lock.json
@@ -31,7 +31,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.barracuda": {
-      "version": "1.3.0-preview",
+      "version": "1.3.1-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -99,7 +99,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.barracuda": "1.3.0-preview",
+        "com.unity.barracuda": "1.3.1-preview",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.physics": "1.0.0",

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scenes/GridFoodCollector.unity
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scenes/GridFoodCollector.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4497121, g: 0.49977785, b: 0.57563704, a: 1}
+  m_IndirectSpecularColor: {r: 0.44971168, g: 0.4997775, b: 0.57563686, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -125,6 +125,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridFoodCollectorArea
       objectReference: {fileID: 0}
+    - target: {fileID: 4137908820211030, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259834826122778, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4419274671784554, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.9
+      objectReference: {fileID: 0}
     - target: {fileID: 4688212428263696, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -169,8 +181,62 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4756368533889646, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -30.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4756368533889646, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067525015186813280, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: NumCollidersPerCell
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067525015186813280, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: EstimatedMaxCollidersPerCell
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: ChannelOffsets.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: ShowGizmos
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: ObservationPerCell
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: NumberOfObservations
+      value: 9600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837508007780682603, guid: b5339e4b990ade14f992aadf3bf8591b,
+        type: 3}
+      propertyPath: rootReference
+      value: 
+      objectReference: {fileID: 190823801}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b5339e4b990ade14f992aadf3bf8591b, type: 3}
+--- !u!1 &190823801 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1706274796045088, guid: b5339e4b990ade14f992aadf3bf8591b,
+    type: 3}
+  m_PrefabInstance: {fileID: 190823800}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &392794583
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/CountingGridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/CountingGridSensor.cs
@@ -29,7 +29,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             this.ChannelDepth = channelDepth;
             if (DetectableObjects.Length != ChannelDepth.Length)
                 throw new UnityAgentsException("The channels of a CountingGridSensor is equal to the number of detectableObjects");
-            this.gridDepthType = GridDepthType.Channel;
+            this.gridDepthType = gridDepthType;
             this.CellScaleX = cellScaleX;
             this.CellScaleZ = cellScaleZ;
             this.GridNumSideX = gridWidth;
@@ -46,12 +46,12 @@ namespace Unity.MLAgents.Extensions.Sensors
         /// <param name="foundColliders">The array of colliders</param>
         /// <param name="cellIndex">The cell index the collider is in</param>
         /// <param name="cellCenter">the center of the cell the collider is in</param>
-        protected override void ParseColliders(Collider[] foundColliders, int cellIndex, Vector3 cellCenter)
+        protected override void ParseColliders(Collider[] foundColliders, int numFound, int cellIndex, Vector3 cellCenter)
         {
             GameObject currentColliderGo = null;
             Vector3 closestColliderPoint = Vector3.zero;
 
-            for (int i = 0; i < foundColliders.Length; i++)
+            for (int i = 0; i < numFound; i++)
             {
                 currentColliderGo = foundColliders[i].gameObject;
 

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/CountingGridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/CountingGridSensor.cs
@@ -62,7 +62,7 @@ namespace Unity.MLAgents.Extensions.Sensors
                 closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
 
                 LoadObjectData(currentColliderGo, cellIndex,
-                    Vector3.Distance(closestColliderPoint, transform.position) / SphereRadius);
+                    Vector3.Distance(closestColliderPoint, transform.position) * InverseSphereRadius);
             }
         }
 

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -639,7 +639,7 @@ namespace Unity.MLAgents.Extensions.Sensors
                 Profiler.BeginSample("ClosestPointOnBounds");
                 var closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
                 Profiler.EndSample();
-                var currentDistance = Vector3.Distance(closestColliderPoint, rootReference.transform.position);
+                var currentDistance = (closestColliderPoint - rootReference.transform.position).sqrMagnitude;
 
                 Profiler.BeginSample("IndexCheck");
                 // Checks if our colliders contain a detectable object
@@ -662,7 +662,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             }
 
             if (!ReferenceEquals(closestColliderGo, null))
-                LoadObjectData(closestColliderGo, cellIndex, distance / SphereRadius);
+                LoadObjectData(closestColliderGo, cellIndex, (float)Math.Sqrt(distance) / SphereRadius));
             Profiler.EndSample();
         }
 

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -863,24 +863,6 @@ namespace Unity.MLAgents.Extensions.Sensors
                 CellActivity[toCellID] = CellActivity[fromCellID];
         }
 
-        /// <summary>Creates a copy of a float array</summary>
-        /// <returns>float[] of the original data</returns>
-        /// <param name="array">The array to copy from</parma>
-        private static float[] CreateCopy(float[] array)
-        {
-            float[] b = new float[array.Length];
-            System.Buffer.BlockCopy(array, 0, b, 0, array.Length * sizeof(float));
-            return b;
-        }
-
-        /// <summary>Utility method to find the index of a tag</summary>
-        /// <returns>Index of the tag in DetectableObjects, if it is in there</returns>
-        /// <param name="tag">The tag to search for</param>
-        public int IndexOfTag(string tag)
-        {
-            return Array.IndexOf(DetectableObjects, tag);
-        }
-
         void OnDrawGizmos()
         {
             if (ShowGizmos)
@@ -890,12 +872,12 @@ namespace Unity.MLAgents.Extensions.Sensors
 
                 Perceive();
 
-                Vector3 scale = new Vector3(CellScaleX, 1, CellScaleZ);
-                Vector3 offset = new Vector3(0, GizmoYOffset, 0);
-                Matrix4x4 oldGizmoMatrix = Gizmos.matrix;
-                Matrix4x4 cubeTransform = Gizmos.matrix;
-                for (int i = 0; i < NumCells; i++)
+                var scale = new Vector3(CellScaleX, 1, CellScaleZ);
+                var offset = new Vector3(0, GizmoYOffset, 0);
+                var oldGizmoMatrix = Gizmos.matrix;
+                for (var i = 0; i < NumCells; i++)
                 {
+                    Matrix4x4 cubeTransform;
                     if (RotateToAgent)
                     {
                         cubeTransform = Matrix4x4.TRS(CellToPoint(i) + offset, transform.rotation, scale);
@@ -917,7 +899,13 @@ namespace Unity.MLAgents.Extensions.Sensors
         }
 
         /// <inheritdoc/>
-        void ISensor.Update() { }
+        void ISensor.Update()
+        {
+            using (TimerStack.Instance.Scoped("GridSensor.Update"))
+            {
+                Perceive();
+            }
+        }
 
         /// <summary>Gets the observation shape</summary>
         /// <returns>int[] of the observation shape</returns>
@@ -932,8 +920,6 @@ namespace Unity.MLAgents.Extensions.Sensors
         {
             using (TimerStack.Instance.Scoped("GridSensor.WriteToTensor"))
             {
-                Perceive();
-
                 int index = 0;
                 for (var h = GridNumSideZ - 1; h >= 0; h--) // height
                 {

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -598,6 +598,8 @@ namespace Unity.MLAgents.Extensions.Sensors
         int BufferResizingOverlapBoxNonAlloc(Vector3 cellCenter, Vector3 halfCellScale, Quaternion rotation)
         {
             int numFound;
+            // Since we can only get a fixed number of results, requery
+            // until we're sure we can hold them all (or until we hit the max size).
             while (true)
             {
                 numFound = Physics.OverlapBoxNonAlloc(cellCenter, halfCellScale, m_CollidersPerCell, rotation, ObserveMask);

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -99,13 +99,15 @@ namespace Unity.MLAgents.Extensions.Sensors
         [Tooltip("The reference of the root of the agent. This is used to disambiguate objects with the same tag as the agent. Defaults to current GameObject")]
         public GameObject rootReference;
 
-        const int k_AbsoluteMaxCollidersPerCell = 500;
+        [Header("Collider Buffer Properties")]
+        [Tooltip("The absolute max size of the Collider buffer used in the non-allocating Physics calls.  In other words" +
+            " the Collider buffer will never grow beyond this number even if there are more Colliders in the Grid Cell.")]
+        public int AbsoluteMaxCollidersPerCell = 500;
         [Tooltip(
             "The Estimated Max Number of Colliders to expect per cell.  This number is used to " +
             "pre-allocate an array of Colliders in order to take advantage of the OverlapBoxNonAlloc " +
             "Physics API.  If the number of colliders found is >= EstimatedMaxCollidersPerCell the array " +
             "will be resized to double its current size.  The hard coded absolute size is 500.")]
-        [Range(1, k_AbsoluteMaxCollidersPerCell)]
         public int EstimatedMaxCollidersPerCell = 4;
         Collider[] m_CollidersPerCell;
 
@@ -417,7 +419,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             InitDepthType();
             InitCellPoints();
             InitPerceptionBuffer();
-            m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
+            m_CollidersPerCell = new Collider[Math.Min(AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
             // Default root reference to current game object
             if (rootReference == null)
                 rootReference = gameObject;
@@ -453,7 +455,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             else
             {
                 m_PerceptionBuffer = new float[NumberOfObservations];
-                m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
+                m_CollidersPerCell = new Collider[Math.Min(AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
             }
 
             if (ShowGizmos)
@@ -601,9 +603,9 @@ namespace Unity.MLAgents.Extensions.Sensors
             while (true)
             {
                 numFound = Physics.OverlapBoxNonAlloc(cellCenter, halfCellScale, m_CollidersPerCell, rotation, ObserveMask);
-                if (numFound == m_CollidersPerCell.Length && m_CollidersPerCell.Length < k_AbsoluteMaxCollidersPerCell)
+                if (numFound == m_CollidersPerCell.Length && m_CollidersPerCell.Length < AbsoluteMaxCollidersPerCell)
                 {
-                    m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, m_CollidersPerCell.Length * 2)];
+                    m_CollidersPerCell = new Collider[Math.Min(AbsoluteMaxCollidersPerCell, m_CollidersPerCell.Length * 2)];
                     EstimatedMaxCollidersPerCell = m_CollidersPerCell.Length;
                 }
                 else
@@ -662,7 +664,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             }
 
             if (!ReferenceEquals(closestColliderGo, null))
-                LoadObjectData(closestColliderGo, cellIndex, (float)Math.Sqrt(distance) / SphereRadius));
+                LoadObjectData(closestColliderGo, cellIndex, (float)Math.Sqrt(distance) / SphereRadius);
             Profiler.EndSample();
         }
 

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -560,11 +560,9 @@ namespace Unity.MLAgents.Extensions.Sensors
             Reset();
             using (TimerStack.Instance.Scoped("GridSensor.Perceive"))
             {
-                Array.Clear(m_CollidersPerCell, 0, m_CollidersPerCell.Length);
+                var halfCellScale = new Vector3(CellScaleX / 2f, CellScaleY, CellScaleZ / 2f);
 
-                Vector3 halfCellScale = new Vector3(CellScaleX / 2f, CellScaleY, CellScaleZ / 2f);
-
-                for (int cellIndex = 0; cellIndex < NumCells; cellIndex++)
+                for (var cellIndex = 0; cellIndex < NumCells; cellIndex++)
                 {
                     int numFound;
                     Vector3 cellCenter;
@@ -638,14 +636,10 @@ namespace Unity.MLAgents.Extensions.Sensors
                 if (ReferenceEquals(currentColliderGo, rootReference))
                     continue;
 
-                Profiler.BeginSample("ClosestPointOnBounds");
                 var closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
-                Profiler.EndSample();
                 var currentDistance = (closestColliderPoint - rootReference.transform.position).sqrMagnitude;
 
-                Profiler.BeginSample("IndexCheck");
                 // Checks if our colliders contain a detectable object
-
                 var index = -1;
                 for (var ii = 0; ii < DetectableObjects.Length; ii++)
                 {
@@ -660,7 +654,6 @@ namespace Unity.MLAgents.Extensions.Sensors
                     distance = currentDistance;
                     closestColliderGo = currentColliderGo;
                 }
-                Profiler.EndSample();
             }
 
             if (!ReferenceEquals(closestColliderGo, null))

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -805,13 +805,6 @@ namespace Unity.MLAgents.Extensions.Sensors
                                         m_PerceptionBuffer[channelHotVals.Offset + ChannelOffsets[j]] = channelValues[j];
                                     }
                                 }
-
-                                // fixed (float* buffer = m_PerceptionBuffer)
-                                // {
-                                //     var sizeInBytes = ObservationPerCell * sizeof(float);
-                                //     Buffer.MemoryCopy(channelHotVals, buffer + cellIndex * ObservationPerCell, sizeInBytes, sizeInBytes);
-                                // }
-
                                 break;
                             }
                     }

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
 using Unity.MLAgents.Sensors;
+using UnityEngine.Profiling;
 
 namespace Unity.MLAgents.Extensions.Sensors
 {
@@ -97,6 +98,18 @@ namespace Unity.MLAgents.Extensions.Sensors
         /// </summary>
         [Tooltip("The reference of the root of the agent. This is used to disambiguate objects with the same tag as the agent. Defaults to current GameObject")]
         public GameObject rootReference;
+
+        const int k_AbsoluteMaxCollidersPerCell = 500;
+        [Tooltip(
+            "The Estimated Max Number of Colliders to expect per cell.  This number is used to " +
+            "pre-allocate an array of Colliders in order to take advantage of the OverlapBoxNonAlloc " +
+            "Physics API.  If the number of colliders found is >= EstimatedMaxCollidersPerCell the array " +
+            "will be resized to double its current size.  The hard coded absolute size is 500.")]
+        [Range(1, k_AbsoluteMaxCollidersPerCell)]
+        public int EstimatedMaxCollidersPerCell = 4;
+        Collider[] m_CollidersPerCell;
+
+        float[] m_ChannelBuffer;
 
         //
         // Hidden Parameters
@@ -404,6 +417,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             InitDepthType();
             InitCellPoints();
             InitPerceptionBuffer();
+            m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
             // Default root reference to current game object
             if (rootReference == null)
                 rootReference = gameObject;
@@ -439,6 +453,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             else
             {
                 m_PerceptionBuffer = new float[NumberOfObservations];
+                m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, EstimatedMaxCollidersPerCell)];
             }
 
             if (ShowGizmos)
@@ -536,73 +551,119 @@ namespace Unity.MLAgents.Extensions.Sensors
         /// <returns>A float[] containing all of the information collected from the gridsensor</returns>
         public float[] Perceive()
         {
+            if (m_CollidersPerCell == null)
+            {
+                return Array.Empty<float>();
+            }
             Reset();
             using (TimerStack.Instance.Scoped("GridSensor.Perceive"))
             {
-                // TODO: make these part of the class
-                Collider[] foundColliders = null;
-                Vector3 cellCenter = Vector3.zero;
+                Array.Clear(m_CollidersPerCell, 0, m_CollidersPerCell.Length);
 
                 Vector3 halfCellScale = new Vector3(CellScaleX / 2f, CellScaleY, CellScaleZ / 2f);
 
                 for (int cellIndex = 0; cellIndex < NumCells; cellIndex++)
                 {
+                    int numFound;
+                    Vector3 cellCenter;
                     if (RotateToAgent)
                     {
-                        cellCenter = transform.TransformPoint(CellPoints[cellIndex]);
-                        foundColliders = Physics.OverlapBox(cellCenter, halfCellScale, transform.rotation, ObserveMask);
+                        Transform transform1;
+                        cellCenter = (transform1 = transform).TransformPoint(CellPoints[cellIndex]);
+                        numFound = BufferResizingOverlapBoxNonAlloc(cellCenter, halfCellScale, transform1.rotation);
                     }
                     else
                     {
                         cellCenter = transform.position + CellPoints[cellIndex];
-                        foundColliders = Physics.OverlapBox(cellCenter, halfCellScale, Quaternion.identity, ObserveMask);
+                        numFound = BufferResizingOverlapBoxNonAlloc(cellCenter, halfCellScale, Quaternion.identity);
                     }
 
-                    if (foundColliders != null && foundColliders.Length > 0)
+                    if (numFound > 0)
                     {
-                        ParseColliders(foundColliders, cellIndex, cellCenter);
+                        ParseColliders(m_CollidersPerCell, numFound, cellIndex, cellCenter);
                     }
                 }
             }
-
             return m_PerceptionBuffer;
+        }
+
+        /// <summary>
+        /// This method attempts to perform the Physics.OverlapBoxNonAlloc and will double the size of the Collider buffer
+        /// if the number of Colliders in the buffer after the call is equal to the length of the buffer.
+        /// </summary>
+        /// <param name="cellCenter"></param>
+        /// <param name="halfCellScale"></param>
+        /// <param name="rotation"></param>
+        /// <returns></returns>
+        int BufferResizingOverlapBoxNonAlloc(Vector3 cellCenter, Vector3 halfCellScale, Quaternion rotation)
+        {
+            int numFound;
+            while (true)
+            {
+                numFound = Physics.OverlapBoxNonAlloc(cellCenter, halfCellScale, m_CollidersPerCell, rotation, ObserveMask);
+                if (numFound == m_CollidersPerCell.Length && m_CollidersPerCell.Length < k_AbsoluteMaxCollidersPerCell)
+                {
+                    m_CollidersPerCell = new Collider[Math.Min(k_AbsoluteMaxCollidersPerCell, m_CollidersPerCell.Length * 2)];
+                    EstimatedMaxCollidersPerCell = m_CollidersPerCell.Length;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return numFound;
         }
 
         /// <summary>
         /// Parses the array of colliders found within a cell. Finds the closest gameobject to the agent root reference within the cell
         /// </summary>
         /// <param name="foundColliders">Array of the colliders found within the cell</param>
+        /// <param name="numFound">Number of colliders found.</param>
         /// <param name="cellIndex">The index of the cell</param>
         /// <param name="cellCenter">The center position of the cell</param>
-        protected virtual void ParseColliders(Collider[] foundColliders, int cellIndex, Vector3 cellCenter)
+        protected virtual void ParseColliders(Collider[] foundColliders, int numFound, int cellIndex, Vector3 cellCenter)
         {
-            GameObject currentColliderGo = null;
+            Profiler.BeginSample("GridSensor.ParseColliders");
             GameObject closestColliderGo = null;
-            Vector3 closestColliderPoint = Vector3.zero;
-            float distance = float.MaxValue;
-            float currentDistance = 0f;
+            var distance = float.MaxValue;
 
-            for (int i = 0; i < foundColliders.Length; i++)
+            for (var i = 0; i < numFound; i++)
             {
-                currentColliderGo = foundColliders[i].gameObject;
+                var currentColliderGo = foundColliders[i].gameObject;
 
                 // Continue if the current collider go is the root reference
-                if (currentColliderGo == rootReference)
+                if (ReferenceEquals(currentColliderGo, rootReference))
                     continue;
 
-                closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
-                currentDistance = Vector3.Distance(closestColliderPoint, rootReference.transform.position);
+                Profiler.BeginSample("ClosestPointOnBounds");
+                var closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
+                Profiler.EndSample();
+                var currentDistance = Vector3.Distance(closestColliderPoint, rootReference.transform.position);
 
+                Profiler.BeginSample("IndexCheck");
                 // Checks if our colliders contain a detectable object
-                if ((Array.IndexOf(DetectableObjects, currentColliderGo.tag) > -1) && (currentDistance < distance))
+
+                var index = -1;
+                for (var ii = 0; ii < DetectableObjects.Length; ii++)
+                {
+                    if (currentColliderGo.CompareTag(DetectableObjects[ii]))
+                    {
+                        index = ii;
+                        break;
+                    }
+                }
+                if (index > -1 && currentDistance < distance)
                 {
                     distance = currentDistance;
                     closestColliderGo = currentColliderGo;
                 }
+                Profiler.EndSample();
             }
 
-            if (closestColliderGo != null)
+            if (!ReferenceEquals(closestColliderGo, null))
                 LoadObjectData(closestColliderGo, cellIndex, distance / SphereRadius);
+            Profiler.EndSample();
         }
 
         /// <summary>
@@ -640,9 +701,13 @@ namespace Unity.MLAgents.Extensions.Sensors
         /// </example>
         protected virtual float[] GetObjectData(GameObject currentColliderGo, float typeIndex, float normalizedDistance)
         {
-            float[] channelValues = new float[ChannelDepth.Length];
-            channelValues[0] = typeIndex;
-            return channelValues;
+            if (m_ChannelBuffer == null)
+            {
+                m_ChannelBuffer = new float[ChannelDepth.Length];
+            }
+            Array.Clear(m_ChannelBuffer, 0, m_ChannelBuffer.Length);
+            m_ChannelBuffer[0] = typeIndex;
+            return m_ChannelBuffer;
         }
 
         /// <summary>
@@ -669,83 +734,100 @@ namespace Unity.MLAgents.Extensions.Sensors
         /// </summary>
         /// <param name="currentColliderGo">The game object that was found colliding with a certain cell</param>
         /// <param name="cellIndex">The index of the current cell</param>
-        /// <param name="normalized_distance">A float between 0 and 1 describing the ratio of
+        /// <param name="normalizedDistance">A float between 0 and 1 describing the ratio of
         ///            the distance currentColliderGo is compared to the edge of the gridsensor</param>
-        protected virtual void LoadObjectData(GameObject currentColliderGo, int cellIndex, float normalized_distance)
+        protected virtual void LoadObjectData(GameObject currentColliderGo, int cellIndex, float normalizedDistance)
         {
-            for (int i = 0; i < DetectableObjects.Length; i++)
+            Profiler.BeginSample("GridSensor.LoadObjectData");
+            unsafe
             {
-                if (currentColliderGo != null && currentColliderGo.CompareTag(DetectableObjects[i]))
+                var channelHotVals = stackalloc float[ObservationPerCell];
+                for (var i = 0; i < DetectableObjects.Length; i++)
                 {
-                    // TODO: Create the array already then set the values using "out" in GetObjectData
-                    // Using i+1 as the type index as "0" represents "empty"
-                    float[] channelValues = GetObjectData(currentColliderGo, (float)i + 1, normalized_distance);
-
-                    ValidateValues(channelValues, currentColliderGo);
-
-                    if (ShowGizmos)
+                    for (var ii = 0; ii < ObservationPerCell; ii++)
                     {
-                        Color debugRayColor = Color.white;
-                        if (DebugColors.Length > 0)
+                        channelHotVals[ii] = 0f;
+                    }
+
+                    if (!ReferenceEquals(currentColliderGo, null) && currentColliderGo.CompareTag(DetectableObjects[i]))
+                    {
+                        // TODO: Create the array already then set the values using "out" in GetObjectData
+                        // Using i+1 as the type index as "0" represents "empty"
+                        float[] channelValues = GetObjectData(currentColliderGo, (float)i + 1, normalizedDistance);
+
+                        ValidateValues(channelValues, currentColliderGo);
+                        if (ShowGizmos)
                         {
-                            debugRayColor = DebugColors[i];
+                            Color debugRayColor = Color.white;
+                            if (DebugColors.Length > 0)
+                            {
+                                debugRayColor = DebugColors[i];
+                            }
+
+                            CellActivity[cellIndex] = new Color(debugRayColor.r, debugRayColor.g, debugRayColor.b, .5f);
                         }
-                        CellActivity[cellIndex] = new Color(debugRayColor.r, debugRayColor.g, debugRayColor.b, .5f);
-                    }
 
-                    switch (gridDepthType)
-                    {
-                        case GridDepthType.Channel:
-                            /// <remarks>
-                            /// The observations are "channel based" so each grid is WxHxC where C is the number of channels
-                            /// This typically means that each channel value is normalized between 0 and 1
-                            /// If channelDepth is 1, the value is assumed normalized, else the value is normalized by the channelDepth
-                            /// The channels are then stored consecutively in PerceptionBuffer.
-                            /// NOTE: This is the only grid type that uses floating point values
-                            /// For example, if a cell contains the 3rd type of 5 possible on the 2nd team of 3 possible teams:
-                            /// channelValues = {2, 1}
-                            /// ObservationPerCell = channelValues.Length
-                            /// channelValues = {2f/5f, 1f/3f} = {.4, .33..}
-                            /// Array.Copy(channelValues, 0, PerceptionBuffer, cell_id*ObservationPerCell, ObservationPerCell);
-                            /// </remarks>
-                            for (int j = 0; j < channelValues.Length; j++)
-                            {
-                                channelValues[j] /= ChannelDepth[j];
-                            }
-                            Array.Copy(channelValues, 0, m_PerceptionBuffer, cellIndex * ObservationPerCell, ObservationPerCell);
-                            break;
-
-                        case GridDepthType.ChannelHot:
-                            /// <remarks>
-                            /// The observations are "channel hot" so each grid is WxHxD where D is the sum of all of the channel depths
-                            /// The opposite of the "channel based" case, the channel values are represented as one hot vector per channel and then concatenated together
-                            /// Thus channelDepth is assumed to be greater than 1.
-                            /// For example, if a cell contains the 3rd type of 5 possible on the 2nd team of 3 possible teams,
-                            /// channelValues = {2, 1}
-                            /// channelOffsets = {5, 3}
-                            /// ObservationPerCell = 5 + 3 = 8
-                            /// channelHotVals = {0, 0, 1, 0, 0, 0, 1, 0}
-                            /// Array.Copy(channelHotVals, 0, PerceptionBuffer, cell_id*ObservationPerCell, ObservationPerCell);
-                            /// </remarks>
-                            float[] channelHotVals = new float[ObservationPerCell];
-                            for (int j = 0; j < channelValues.Length; j++)
-                            {
-                                if (ChannelDepth[j] > 1)
+                        switch (gridDepthType)
+                        {
+                            case GridDepthType.Channel:
                                 {
-                                    channelHotVals[(int)channelValues[j] + ChannelOffsets[j]] = 1f;
-                                }
-                                else
-                                {
-                                    channelHotVals[ChannelOffsets[j]] = channelValues[j];
-                                }
-                            }
+                                    // The observations are "channel based" so each grid is WxHxC where C is the number of channels
+                                    // This typically means that each channel value is normalized between 0 and 1
+                                    // If channelDepth is 1, the value is assumed normalized, else the value is normalized by the channelDepth
+                                    // The channels are then stored consecutively in PerceptionBuffer.
+                                    // NOTE: This is the only grid type that uses floating point values
+                                    // For example, if a cell contains the 3rd type of 5 possible on the 2nd team of 3 possible teams:
+                                    // channelValues = {2, 1}
+                                    // ObservationPerCell = channelValues.Length
+                                    // channelValues = {2f/5f, 1f/3f} = {.4, .33..}
+                                    // Array.Copy(channelValues, 0, PerceptionBuffer, cell_id*ObservationPerCell, ObservationPerCell);
+                                    for (int j = 0; j < channelValues.Length; j++)
+                                    {
+                                        channelValues[j] /= ChannelDepth[j];
+                                    }
 
-                            Array.Copy(channelHotVals, 0, m_PerceptionBuffer, cellIndex * ObservationPerCell, ObservationPerCell);
-                            break;
+                                    Array.Copy(channelValues, 0, m_PerceptionBuffer, cellIndex * ObservationPerCell, ObservationPerCell);
+                                    break;
+                                }
+
+                            case GridDepthType.ChannelHot:
+                                {
+                                    // The observations are "channel hot" so each grid is WxHxD where D is the sum of all of the channel depths
+                                    // The opposite of the "channel based" case, the channel values are represented as one hot vector per channel and then concatenated together
+                                    // Thus channelDepth is assumed to be greater than 1.
+                                    // For example, if a cell contains the 3rd type of 5 possible on the 2nd team of 3 possible teams,
+                                    // channelValues = {2, 1}
+                                    // channelOffsets = {5, 3}
+                                    // ObservationPerCell = 5 + 3 = 8
+                                    // channelHotVals = {0, 0, 1, 0, 0, 0, 1, 0}
+                                    // Array.Copy(channelHotVals, 0, PerceptionBuffer, cell_id*ObservationPerCell, ObservationPerCell);
+                                    for (int j = 0; j < channelValues.Length; j++)
+                                    {
+                                        if (ChannelDepth[j] > 1)
+                                        {
+                                            channelHotVals[(int)channelValues[j] + ChannelOffsets[j]] = 1f;
+                                        }
+                                        else
+                                        {
+                                            channelHotVals[ChannelOffsets[j]] = channelValues[j];
+                                        }
+                                    }
+
+                                    fixed (float* buffer = m_PerceptionBuffer)
+                                    {
+                                        var sizeInBytes = ObservationPerCell * sizeof(float);
+                                        Buffer.MemoryCopy(channelHotVals, buffer + cellIndex * ObservationPerCell, sizeInBytes, sizeInBytes);
+                                    }
+
+                                    break;
+                                }
+                        }
+
+                        break;
                     }
-                    break;
                 }
             }
+            Profiler.EndSample();
         }
 
         /// <summary>Converts the index of the cell to the 3D point (y is zero)</summary>

--- a/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
+++ b/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
@@ -5,6 +5,7 @@
         "Unity.ML-Agents",
         "Unity.ML-Agents.Extensions.Input"
     ],
-    "includePlatforms": [],
-    "excludePlatforms": []
+    "optionalUnityReferences": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true
 }

--- a/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
+++ b/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
@@ -7,5 +7,5 @@
     ],
     "optionalUnityReferences": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": true
+    "allowUnsafeCode": false
 }

--- a/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
+++ b/com.unity.ml-agents.extensions/Runtime/Unity.ML-Agents.Extensions.asmdef
@@ -4,8 +4,5 @@
         "Unity.Barracuda",
         "Unity.ML-Agents",
         "Unity.ML-Agents.Extensions.Input"
-    ],
-    "optionalUnityReferences": [],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false
+    ]
 }


### PR DESCRIPTION
### Proposed change(s)

Make the GridSensor as non-allocating as possible.

#### Before:
<img width="949" alt="Screen Shot 2021-02-26 at 10 06 26 AM" src="https://user-images.githubusercontent.com/1356616/109337876-4e1df100-781a-11eb-882f-95a21baab69f.png">


#### Now: (only allocations are from Barracuda)
<img width="1032" alt="Screen Shot 2021-02-26 at 9 58 51 AM" src="https://user-images.githubusercontent.com/1356616/109337184-4873db80-7819-11eb-9bad-7dc8273e1044.png">


#### New UI for estimating the max number of colliders you will hit per cell:
<img width="506" alt="Screen Shot 2021-02-26 at 10 29 19 AM" src="https://user-images.githubusercontent.com/1356616/109340168-84a93b00-781d-11eb-91d5-fcecf26dc562.png">


For food collector, I let it run for a bit and saw that it never went above 4, so that's what I set it at.

Tooltips for that UI:
```
        [Header("Collider Buffer Properties")]
        [Tooltip("The absolute max size of the Collider buffer used in the non-allocating Physics calls.  In other words" +
            " the Collider buffer will never grow beyond this number even if there are more Colliders in the Grid Cell.")]
        public int AbsoluteMaxCollidersPerCell = 500;
        [Tooltip(
            "The Estimated Max Number of Colliders to expect per cell.  This number is used to " +
            "pre-allocate an array of Colliders in order to take advantage of the OverlapBoxNonAlloc " +
            "Physics API.  If the number of colliders found is >= EstimatedMaxCollidersPerCell the array " +
            "will be resized to double its current size.  The hard coded absolute size is 500.")]
        public int EstimatedMaxCollidersPerCell = 4;
```



### Types of change(s)

- [x] Bug fix. Removal of unnecessary memory allocations.
