### PR TITLE
Faster NaN masking, fix masking for visual obs

### DIFF
--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -232,7 +232,7 @@ class MultiInputNetworkBody(torch.nn.Module):
         only_first_obs_flat = torch.stack(
             [_obs.flatten(start_dim=1)[:, 0] for _obs in only_first_obs], dim=1
         )
-        # Get the msak from NaNs
+        # Get the mask from NaNs
         attn_mask = only_first_obs_flat.isnan().type(torch.FloatTensor)
         return attn_mask
 


### PR DESCRIPTION
### Proposed change(s)

Only search first index of each observation so that `torch.isnan()` goes much faster. Re-use mask to set stuff to 0 before encoding. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
