### PR TITLE
Modified the model_serialization to have correct inputs and outputs

### DIFF
--- a/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
+++ b/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs
@@ -141,7 +141,7 @@ namespace Unity.MLAgents.Inference
                 if (sensor.GetObservationShape().Length == 3)
                 {
                     if (!tensorsNames.Contains(
-                        TensorNames.VisualObservationPlaceholderPrefix + visObsIndex))
+                        TensorNames.GetVisualObservationName(visObsIndex)))
                     {
                         failedModelChecks.Add(
                             "The model does not contain a Visual Observation Placeholder Input " +
@@ -152,7 +152,7 @@ namespace Unity.MLAgents.Inference
                 if (sensor.GetObservationShape().Length == 2)
                 {
                     if (!tensorsNames.Contains(
-                        TensorNames.ObservationPlaceholderPrefix + sensorIndex))
+                        TensorNames.GetObservationName(sensorIndex)))
                     {
                         failedModelChecks.Add(
                             "The model does not contain an Observation Placeholder Input " +
@@ -320,13 +320,13 @@ namespace Unity.MLAgents.Inference
                 if (sens.GetObservationShape().Length == 3)
                 {
 
-                    tensorTester[TensorNames.VisualObservationPlaceholderPrefix + visObsIndex] =
+                    tensorTester[TensorNames.GetVisualObservationName(visObsIndex)] =
                         (bp, tensor, scs, i) => CheckVisualObsShape(tensor, sens);
                     visObsIndex++;
                 }
                 if (sens.GetObservationShape().Length == 2)
                 {
-                    tensorTester[TensorNames.ObservationPlaceholderPrefix + sensorIndex] =
+                    tensorTester[TensorNames.GetObservationName(sensorIndex)] =
                         (bp, tensor, scs, i) => CheckRankTwoObsShape(tensor, sens);
                 }
             }

--- a/com.unity.ml-agents/Runtime/Inference/TensorGenerator.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorGenerator.cs
@@ -119,13 +119,13 @@ namespace Unity.MLAgents.Inference
                         // If the tensor is of rank 2, we use the index of the sensor
                         // to create the name
                         obsGen = new ObservationGenerator(allocator);
-                        obsGenName = TensorNames.ObservationPlaceholderPrefix + sensorIndex;
+                        obsGenName = TensorNames.GetObservationName(sensorIndex);
                         break;
                     case 3:
                         // If the tensor is of rank 3, we use the "visual observation
                         // index", which only counts the rank 3 sensors
                         obsGen = new ObservationGenerator(allocator);
-                        obsGenName = TensorNames.VisualObservationPlaceholderPrefix + visIndex;
+                        obsGenName = TensorNames.GetVisualObservationName(visIndex);
                         visIndex++;
                         break;
                     default:

--- a/com.unity.ml-agents/Runtime/Inference/TensorNames.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorNames.cs
@@ -9,8 +9,6 @@ namespace Unity.MLAgents.Inference
         public const string SequenceLengthPlaceholder = "sequence_length";
         public const string VectorObservationPlaceholder = "vector_observation";
         public const string RecurrentInPlaceholder = "recurrent_in";
-        public const string recurrentInPlaceholderH = "recurrent_in_h";
-        public const string recurrentInPlaceholderC = "recurrent_in_c";
         public const string VisualObservationPlaceholderPrefix = "visual_observation_";
         public const string ObservationPlaceholderPrefix = "obs_";
         public const string PreviousActionPlaceholder = "prev_action";
@@ -19,8 +17,6 @@ namespace Unity.MLAgents.Inference
 
         public const string ValueEstimateOutput = "value_estimate";
         public const string RecurrentOutput = "recurrent_out";
-        public const string recurrentOutputH = "recurrent_out_h";
-        public const string recurrentOutputC = "recurrent_out_c";
         public const string MemorySize = "memory_size";
         public const string VersionNumber = "version_number";
         public const string ContinuousActionOutputShape = "continuous_action_output_shape";
@@ -32,5 +28,21 @@ namespace Unity.MLAgents.Inference
         public const string IsContinuousControlDeprecated = "is_continuous_control";
         public const string ActionOutputDeprecated = "action";
         public const string ActionOutputShapeDeprecated = "action_output_shape";
+
+        /// <summary>
+        /// Returns the name of the visual observation with a given index
+        /// </summary>
+        public static string GetVisualObservationName(int index)
+        {
+            return VisualObservationPlaceholderPrefix + index;
+        }
+
+        /// <summary>
+        /// Returns the name of the observation with a given index
+        /// </summary>
+        public static string GetObservationName(int index)
+        {
+            return ObservationPlaceholderPrefix + index;
+        }
     }
 }

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -41,33 +41,33 @@ class exporting_to_onnx:
 
 
 class TensorNames:
-    BatchSizePlaceholder = "batch_size"
-    SequenceLengthPlaceholder = "sequence_length"
-    VectorObservationPlaceholder = "vector_observation"
-    RecurrentInPlaceholder = "recurrent_in"
-    recurrentInPlaceholderH = "recurrent_in_h"
-    recurrentInPlaceholderC = "recurrent_in_c"
-    VisualObservationPlaceholderPrefix = "visual_observation_"
-    ObservationPlaceholderPrefix = "obs_"
-    PreviousActionPlaceholder = "prev_action"
-    ActionMaskPlaceholder = "action_masks"
-    RandomNormalEpsilonPlaceholder = "epsilon"
+    batch_size_placeholder = "batch_size"
+    sequence_length_placeholder = "sequence_length"
+    vector_observation_placeholder = "vector_observation"
+    recurrent_in_placeholder = "recurrent_in"
+    recurrent_in_placeholder_h = "recurrent_in_h"
+    recurrent_in_placeholder_c = "recurrent_in_c"
+    visual_observation_placeholder_prefix = "visual_observation_"
+    observation_placeholder_prefix = "obs_"
+    previous_action_placeholder = "prev_action"
+    action_mask_placeholder = "action_masks"
+    random_normal_epsilon_placeholder = "epsilon"
 
-    ValueEstimateOutput = "value_estimate"
-    RecurrentOutput = "recurrent_out"
-    recurrentOutputH = "recurrent_out_h"
-    recurrentOutputC = "recurrent_out_c"
-    MemorySize = "memory_size"
-    VersionNumber = "version_number"
-    ContinuousActionOutputShape = "continuous_action_output_shape"
-    DiscreteActionOutputShape = "discrete_action_output_shape"
-    ContinuousActionOutput = "continuous_actions"
-    DiscreteActionOutput = "discrete_actions"
+    value_estimate_output = "value_estimate"
+    recurrent_output = "recurrent_out"
+    recurrent_output_h = "recurrent_out_h"
+    recurrent_output_c = "recurrent_out_c"
+    memory_size = "memory_size"
+    version_number = "version_number"
+    continuous_action_output_shape = "continuous_action_output_shape"
+    discrete_action_output_shape = "discrete_action_output_shape"
+    continuous_action_output = "continuous_actions"
+    discrete_action_output = "discrete_actions"
 
     # Deprecated TensorNames entries for backward compatibility
-    IsContinuousControlDeprecated = "is_continuous_control"
-    ActionOutputDeprecated = "action"
-    ActionOutputShapeDeprecated = "action_output_shape"
+    is_continuous_control_deprecated = "is_continuous_control"
+    action_output_deprecated = "action"
+    action_output_shape_deprecated = "action_output_shape"
 
 
 class ModelSerializer:
@@ -119,49 +119,53 @@ class ModelSerializer:
             dummy_memories,
         )
 
-        self.input_names = [TensorNames.VectorObservationPlaceholder]
+        self.input_names = [TensorNames.vector_observation_placeholder]
         for i in range(num_vis_obs):
             self.input_names.append(
-                TensorNames.VisualObservationPlaceholderPrefix + str(i)
+                TensorNames.visual_observation_placeholder_prefix + str(i)
             )
         for i, obs_spec in enumerate(observation_specs):
             if len(obs_spec.shape) == 2:
                 self.input_names.append(
-                    TensorNames.ObservationPlaceholderPrefix + str(i)
+                    TensorNames.observation_placeholder_prefix + str(i)
                 )
         self.input_names += [
-            TensorNames.ActionMaskPlaceholder,
-            TensorNames.RecurrentInPlaceholder,
+            TensorNames.action_mask_placeholder,
+            TensorNames.recurrent_in_placeholder,
         ]
 
         self.dynamic_axes = {name: {0: "batch"} for name in self.input_names}
 
-        self.output_names = [TensorNames.VersionNumber, TensorNames.MemorySize]
+        self.output_names = [TensorNames.version_number, TensorNames.memory_size]
         if self.policy.behavior_spec.action_spec.continuous_size > 0:
             self.output_names += [
-                TensorNames.ContinuousActionOutput,
-                TensorNames.ContinuousActionOutputShape,
+                TensorNames.continuous_action_output,
+                TensorNames.continuous_action_output_shape,
             ]
-            self.dynamic_axes.update({TensorNames.ContinuousActionOutput: {0: "batch"}})
+            self.dynamic_axes.update(
+                {TensorNames.continuous_action_output: {0: "batch"}}
+            )
         if self.policy.behavior_spec.action_spec.discrete_size > 0:
             self.output_names += [
-                TensorNames.DiscreteActionOutput,
-                TensorNames.DiscreteActionOutputShape,
+                TensorNames.discrete_action_output,
+                TensorNames.discrete_action_output_shape,
             ]
-            self.dynamic_axes.update({TensorNames.DiscreteActionOutput: {0: "batch"}})
+            self.dynamic_axes.update({TensorNames.discrete_action_output: {0: "batch"}})
         if (
             self.policy.behavior_spec.action_spec.continuous_size == 0
             or self.policy.behavior_spec.action_spec.discrete_size == 0
         ):
             self.output_names += [
-                TensorNames.ActionOutputDeprecated,
-                TensorNames.IsContinuousControlDeprecated,
-                TensorNames.ActionOutputShapeDeprecated,
+                TensorNames.action_output_deprecated,
+                TensorNames.is_continuous_control_deprecated,
+                TensorNames.action_output_shape_deprecated,
             ]
-            self.dynamic_axes.update({TensorNames.ActionOutputDeprecated: {0: "batch"}})
+            self.dynamic_axes.update(
+                {TensorNames.action_output_deprecated: {0: "batch"}}
+            )
 
         if self.policy.export_memory_size > 0:
-            self.output_names += [TensorNames.RecurrentOutput]
+            self.output_names += [TensorNames.recurrent_output]
 
     def export_policy_model(self, output_filepath: str) -> None:
         """

--- a/ml-agents/mlagents/trainers/torch/model_serialization.py
+++ b/ml-agents/mlagents/trainers/torch/model_serialization.py
@@ -45,8 +45,6 @@ class TensorNames:
     sequence_length_placeholder = "sequence_length"
     vector_observation_placeholder = "vector_observation"
     recurrent_in_placeholder = "recurrent_in"
-    recurrent_in_placeholder_h = "recurrent_in_h"
-    recurrent_in_placeholder_c = "recurrent_in_c"
     visual_observation_placeholder_prefix = "visual_observation_"
     observation_placeholder_prefix = "obs_"
     previous_action_placeholder = "prev_action"
@@ -55,8 +53,6 @@ class TensorNames:
 
     value_estimate_output = "value_estimate"
     recurrent_output = "recurrent_out"
-    recurrent_output_h = "recurrent_out_h"
-    recurrent_output_c = "recurrent_out_c"
     memory_size = "memory_size"
     version_number = "version_number"
     continuous_action_output_shape = "continuous_action_output_shape"
@@ -68,6 +64,20 @@ class TensorNames:
     is_continuous_control_deprecated = "is_continuous_control"
     action_output_deprecated = "action"
     action_output_shape_deprecated = "action_output_shape"
+
+    @staticmethod
+    def get_visual_observation_name(index: int) -> str:
+        """
+        Returns the name of the visual observation with a given index
+        """
+        return TensorNames.visual_observation_placeholder_prefix + str(index)
+
+    @staticmethod
+    def get_observation_name(index: int) -> str:
+        """
+        Returns the name of the observation with a given index
+        """
+        return TensorNames.observation_placeholder_prefix + str(index)
 
 
 class ModelSerializer:
@@ -121,14 +131,10 @@ class ModelSerializer:
 
         self.input_names = [TensorNames.vector_observation_placeholder]
         for i in range(num_vis_obs):
-            self.input_names.append(
-                TensorNames.visual_observation_placeholder_prefix + str(i)
-            )
+            self.input_names.append(TensorNames.get_visual_observation_name(i))
         for i, obs_spec in enumerate(observation_specs):
             if len(obs_spec.shape) == 2:
-                self.input_names.append(
-                    TensorNames.observation_placeholder_prefix + str(i)
-                )
+                self.input_names.append(TensorNames.get_observation_name(i))
         self.input_names += [
             TensorNames.action_mask_placeholder,
             TensorNames.recurrent_in_placeholder,

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -442,6 +442,8 @@ class SimpleActor(nn.Module, Actor):
                 self.is_continuous_int_deprecated,
                 self.act_size_vector_deprecated,
             ]
+        if self.network_body.memory_size > 0:
+            export_out += [memories_out]
         return tuple(export_out)
 
 


### PR DESCRIPTION
### Proposed change(s)

Before : 
<img width="543" alt="Screen Shot 2021-02-26 at 16 03 43" src="https://user-images.githubusercontent.com/28320361/109368002-89391800-784c-11eb-8689-f88a56980dc4.png">
And after :
<img width="518" alt="Screen Shot 2021-02-26 at 16 03 52" src="https://user-images.githubusercontent.com/28320361/109368016-90f8bc80-784c-11eb-9beb-0126d855b4d2.png">

This should not be a breaking change since the model uses the Barracuda implicit input and output names. This will be useful when Barracuda will allow us to use named tensors for LSTM.

EDIT:
Some context. Currently, Barracuda creates new names for inputs and outputs of the LSTM (see here https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/Runtime/Inference/TensorApplier.cs#L79) and we use these at inference. This means that neither RecurrentOutput nor RecurrentOutputH/C are used at all. When Barracuda switches to use the names of the ONNX model, we need to make sure that there are appropriately named inputs and outputs to the LSTM.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Slack message : https://unity.slack.com/archives/C8FECS6L9/p1614370112116900
JIRA : MLA-1807

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
