### PR TITLE
Adding a SensorName field to BufferSensor

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Sorter/Prefabs/Area.prefab
+++ b/Project/Assets/ML-Agents/Examples/Sorter/Prefabs/Area.prefab
@@ -7073,8 +7073,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd8012d5925524537b27131fef517017, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ObservableSize: 23
-  MaxNumObservables: 20
+  m_SensorName: BufferSensor
+  m_ObservableSize: 23
+  m_MaxNumObservables: 20
 --- !u!1 &6000518840957865293
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 ### Major Changes
 #### com.unity.ml-agents (C#)
+- The `BufferSensor` and `BufferSensorComponent` have been added. They allow the Agent to observe variable number of entities. (#4909)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Minor Changes

--- a/com.unity.ml-agents/Editor/BufferSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/BufferSensorComponentEditor.cs
@@ -1,0 +1,31 @@
+using UnityEditor;
+using Unity.MLAgents.Sensors;
+
+namespace Unity.MLAgents.Editor
+{
+    [CustomEditor(typeof(BufferSensorComponent))]
+    [CanEditMultipleObjects]
+    internal class BufferSensorComponentEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var so = serializedObject;
+            so.Update();
+
+            // Drawing the BufferSensorComponent
+
+            EditorGUI.BeginDisabledGroup(!EditorUtilities.CanUpdateModelProperties());
+            {
+                // These fields affect the sensor order or observation size,
+                // So can't be changed at runtime.
+                EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_ObservableSize"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_MaxNumObservables"), true);
+            }
+            EditorGUI.EndDisabledGroup();
+
+            so.ApplyModifiedProperties();
+        }
+
+    }
+}

--- a/com.unity.ml-agents/Editor/BufferSensorComponentEditor.cs.meta
+++ b/com.unity.ml-agents/Editor/BufferSensorComponentEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b042fe65027f94c1eb38a2ee1362d38d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
@@ -7,6 +7,7 @@ namespace Unity.MLAgents.Sensors
     /// </summary>
     public class BufferSensor : ISensor, IDimensionPropertiesSensor, IBuiltInSensor
     {
+        private string m_Name;
         private int m_MaxNumObs;
         private int m_ObsSize;
         float[] m_ObservationBuffer;
@@ -15,8 +16,9 @@ namespace Unity.MLAgents.Sensors
                 DimensionProperty.VariableSize,
                 DimensionProperty.None
             };
-        public BufferSensor(int maxNumberObs, int obsSize)
+        public BufferSensor(int maxNumberObs, int obsSize, string name)
         {
+            m_Name = name;
             m_MaxNumObs = maxNumberObs;
             m_ObsSize = obsSize;
             m_ObservationBuffer = new float[m_ObsSize * m_MaxNumObs];
@@ -98,7 +100,7 @@ namespace Unity.MLAgents.Sensors
 
         public string GetName()
         {
-            return "BufferSensor";
+            return m_Name;
         }
 
         /// <inheritdoc/>

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
@@ -93,11 +93,13 @@ namespace Unity.MLAgents.Sensors
             Array.Clear(m_ObservationBuffer, 0, m_ObservationBuffer.Length);
         }
 
+        /// <inheritdoc/>
         public SensorCompressionType GetCompressionType()
         {
             return SensorCompressionType.None;
         }
 
+        /// <inheritdoc/>
         public string GetName()
         {
             return m_Name;

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
@@ -19,20 +19,32 @@ namespace Unity.MLAgents.Sensors
             get { return m_SensorName; }
             set { m_SensorName = value; }
         }
-
-        public string m_SensorName = "BufferSensor";
+        [HideInInspector, SerializeField]
+        private string m_SensorName = "BufferSensor";
 
         /// <summary>
         /// This is how many floats each entities will be represented with. This number
         /// is fixed and all entities must have the same representation.
         /// </summary>
-        public int ObservableSize;
+        public int ObservableSize
+        {
+            get { return m_ObservableSize; }
+            set { m_ObservableSize = value; }
+        }
+        [HideInInspector, SerializeField]
+        private int m_ObservableSize;
 
         /// <summary>
         /// This is the maximum number of entities the `BufferSensor` will be able to
         /// collect.
         /// </summary>
-        public int MaxNumObservables;
+        public int MaxNumObservables
+        {
+            get { return m_MaxNumObservables; }
+            set { m_MaxNumObservables = value; }
+        }
+        [HideInInspector, SerializeField]
+        private int m_MaxNumObservables;
 
         private BufferSensor m_Sensor;
 

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
@@ -9,6 +9,19 @@ namespace Unity.MLAgents.Sensors
     [AddComponentMenu("ML Agents/Buffer Sensor", (int)MenuGroup.Sensors)]
     public class BufferSensorComponent : SensorComponent
     {
+
+        /// <summary>
+        /// Name of the generated <see cref="bufferSensor"/> object.
+        /// Note that changing this at runtime does not affect how the Agent sorts the sensors.
+        /// </summary>
+        public string SensorName
+        {
+            get { return m_SensorName; }
+            set { m_SensorName = value; }
+        }
+
+        public string m_SensorName = "BufferSensor";
+
         /// <summary>
         /// This is how many floats each entities will be represented with. This number
         /// is fixed and all entities must have the same representation.
@@ -26,7 +39,7 @@ namespace Unity.MLAgents.Sensors
         /// <inheritdoc/>
         public override ISensor CreateSensor()
         {
-            m_Sensor = new BufferSensor(MaxNumObservables, ObservableSize);
+            m_Sensor = new BufferSensor(MaxNumObservables, ObservableSize, m_SensorName);
             return m_Sensor;
         }
 

--- a/com.unity.ml-agents/Tests/Editor/Sensor/BufferSensorTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Sensor/BufferSensorTest.cs
@@ -13,7 +13,7 @@ namespace Unity.MLAgents.Tests
         public void TestBufferSensor()
         {
 
-            var bufferSensor = new BufferSensor(20, 4);
+            var bufferSensor = new BufferSensor(20, 4, "testName");
             var shape = bufferSensor.GetObservationShape();
             var dimProp = bufferSensor.GetDimensionProperties();
             Assert.AreEqual(shape[0], 20);
@@ -53,6 +53,7 @@ namespace Unity.MLAgents.Tests
             var bufferComponent = agentGameObj.AddComponent<BufferSensorComponent>();
             bufferComponent.MaxNumObservables = 20;
             bufferComponent.ObservableSize = 4;
+            bufferComponent.SensorName = "TestName";
 
             var sensor = bufferComponent.CreateSensor();
             var shape = bufferComponent.GetObservationShape();
@@ -69,6 +70,8 @@ namespace Unity.MLAgents.Tests
 
             Assert.AreEqual(shape, obs.Shape);
             Assert.AreEqual(obs.DimensionProperties.Count, 2);
+
+            Assert.AreEqual(sensor.GetName(), "TestName");
 
             for (int i = 0; i < 8; i++)
             {


### PR DESCRIPTION
### Proposed change(s)

Adding a SensorName field to BufferSensor in order to have more than one BufferSensor per Agent.
Modified the changelog to include the new BufferSensor (Was missing before)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
