### PR TITLE
[bug-fix] Fix padding for List entries in buffer

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -173,7 +173,7 @@ class AgentBufferField(list):
                     padding = []
                 else:
                     # We want to duplicate the last value in the array, multiplied by the padding_value.
-                    padding = self[-1] * self.padding_value
+                    padding = np.array(self[-1], dtype=np.float32) * self.padding_value
                 return [padding] * (training_length - leftover) + self[:]
 
             else:

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -108,7 +108,14 @@ class AgentBufferField(list):
         else:
             return return_data
 
-    def append(self, element: np.ndarray, padding_value: float = 0.0) -> None:
+    @property
+    def contains_lists(self) -> bool:
+        """
+        Checks whether this AgentBufferField contains List[np.ndarray].
+        """
+        return len(self) > 0 and isinstance(self[0], list)
+
+    def append(self, element: BufferEntry, padding_value: float = 0.0) -> None:
         """
         Adds an element to this list. Also lets you change the padding
         type, so that it can be set on append (e.g. action_masks should
@@ -162,7 +169,11 @@ class AgentBufferField(list):
                     " too large given the current number of data points."
                 )
             if batch_size * training_length > len(self):
-                padding = np.array(self[-1], dtype=np.float32) * self.padding_value
+                if self.contains_lists:
+                    padding = []
+                else:
+                    # We want to duplicate the last value in the array, multiplied by the padding_value.
+                    padding = self[-1] * self.padding_value
                 return [padding] * (training_length - leftover) + self[:]
 
             else:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -73,7 +73,11 @@ class PPOTrainer(RLTrainer):
             self.policy.update_normalization(agent_buffer_trajectory)
 
         # Get all value estimates
-        value_estimates, value_next, value_memories = self.optimizer.get_trajectory_value_estimates(
+        (
+            value_estimates,
+            value_next,
+            value_memories,
+        ) = self.optimizer.get_trajectory_value_estimates(
             agent_buffer_trajectory,
             trajectory.next_obs,
             trajectory.done_reached and not trajectory.interrupted,
@@ -180,7 +184,9 @@ class PPOTrainer(RLTrainer):
             int(self.hyperparameters.batch_size / self.policy.sequence_length), 1
         )
 
-        advantages = np.array(self.update_buffer[BufferKey.ADVANTAGES].get_batch())
+        advantages = np.array(
+            self.update_buffer[BufferKey.ADVANTAGES].get_batch(), dtype=np.float32
+        )
         self.update_buffer[BufferKey.ADVANTAGES].set(
             (advantages - advantages.mean()) / (advantages.std() + 1e-10)
         )

--- a/ml-agents/mlagents/trainers/tests/test_buffer.py
+++ b/ml-agents/mlagents/trainers/tests/test_buffer.py
@@ -101,11 +101,37 @@ def test_buffer():
             ]
         ),
     )
-    # Test group entries return Lists of Lists
-    a = agent_2_buffer[BufferKey.GROUP_CONTINUOUS_ACTION].get_batch(
-        batch_size=2, training_length=1, sequential=True
+
+    # Test padding
+    a = agent_2_buffer[ObsUtil.get_name_at(0)].get_batch(
+        batch_size=None, training_length=4, sequential=True
     )
-    for _group_entry in a:
+    assert_array(
+        np.array(a),
+        np.array(
+            [
+                [0, 0, 0],
+                [0, 0, 0],
+                [0, 0, 0],
+                [201, 202, 203],
+                [211, 212, 213],
+                [221, 222, 223],
+                [231, 232, 233],
+                [241, 242, 243],
+                [251, 252, 253],
+                [261, 262, 263],
+                [271, 272, 273],
+                [281, 282, 283],
+            ]
+        ),
+    )
+    # Test group entries return Lists of Lists. Make sure to pad properly!
+    a = agent_2_buffer[BufferKey.GROUP_CONTINUOUS_ACTION].get_batch(
+        batch_size=None, training_length=4, sequential=True
+    )
+    for _group_entry in a[:3]:
+        assert len(_group_entry) == 0
+    for _group_entry in a[3:]:
         assert len(_group_entry) == 3
 
     agent_1_buffer.reset_agent()


### PR DESCRIPTION
### Proposed change(s)

Fix issue where AgentBufferFields with List values (e.g. group obs) would pad with np.ndarray. Also fix a potential float64 array in certain versions of Python/numpy. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
