### PR TITLE
[bug-fix] Fix memory leak when using LSTMs

### DIFF
--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -177,8 +177,9 @@ class TorchOptimizer(Optimizer):
                 current_obs, memory, sequence_length=batch.num_experiences
             )
 
-        # Store the memory for the next trajectory
-        self.critic_memory_dict[agent_id] = next_memory
+        # Store the memory for the next trajectory.
+        # Must detach from graph to preevent memory leaek
+        self.critic_memory_dict[agent_id] = next_memory.detach()
 
         next_value_estimate, _ = self.critic.critic_pass(
             next_obs, next_memory, sequence_length=1

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -166,20 +166,22 @@ class TorchOptimizer(Optimizer):
 
         # If we're using LSTM, we want to get all the intermediate memories.
         all_next_memories: Optional[AgentBufferField] = None
-        if self.policy.use_recurrent:
-            (
-                value_estimates,
-                all_next_memories,
-                next_memory,
-            ) = self._evaluate_by_sequence(current_obs, memory)
-        else:
-            value_estimates, next_memory = self.critic.critic_pass(
-                current_obs, memory, sequence_length=batch.num_experiences
-            )
 
-        # Store the memory for the next trajectory.
-        # Must detach from graph to preevent memory leaek
-        self.critic_memory_dict[agent_id] = next_memory.detach()
+        # To prevent memory leak and improve performance, evaluate with no_grad.
+        with torch.no_grad():
+            if self.policy.use_recurrent:
+                (
+                    value_estimates,
+                    all_next_memories,
+                    next_memory,
+                ) = self._evaluate_by_sequence(current_obs, memory)
+            else:
+                value_estimates, next_memory = self.critic.critic_pass(
+                    current_obs, memory, sequence_length=batch.num_experiences
+                )
+
+        # Store the memory for the next trajectory. This should NOT have a gradient.
+        self.critic_memory_dict[agent_id] = next_memory
 
         next_value_estimate, _ = self.critic.critic_pass(
             next_obs, next_memory, sequence_length=1

--- a/ml-agents/mlagents/trainers/tests/torch/test_ppo.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_ppo.py
@@ -207,6 +207,11 @@ def test_ppo_get_value_estimates(dummy_config, rnn, visual, discrete):
     run_out, final_value_out, all_memories = optimizer.get_trajectory_value_estimates(
         trajectory.to_agentbuffer(), trajectory.next_obs, done=False
     )
+    if rnn:
+        # Check that memories don't have a Torch gradient
+        for mem in optimizer.critic_memory_dict.values():
+            assert not mem.requires_grad
+
     for key, val in run_out.items():
         assert type(key) is str
         assert len(val) == 15


### PR DESCRIPTION
### Proposed change(s)

LSTMs would store the memory as a tensor, and keep a gradient. So the next time around, Torch would try to backprop through this gradient. For long episodes, this caused the graph to explode. 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
