### PR TITLE
non-IEnumerable interface for action masking

### DIFF
--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -48,22 +48,22 @@ public class GridAgent : Agent
 
             if (positionX == 0)
             {
-                actionMask.WriteMask(0, new[] { k_Left });
+                actionMask.SetActionEnabled(0, k_Left, false);
             }
 
             if (positionX == maxPosition)
             {
-                actionMask.WriteMask(0, new[] { k_Right });
+                actionMask.SetActionEnabled(0, k_Right, false);
             }
 
             if (positionZ == 0)
             {
-                actionMask.WriteMask(0, new[] { k_Down });
+                actionMask.SetActionEnabled(0, k_Down, false);
             }
 
             if (positionZ == maxPosition)
             {
-                actionMask.WriteMask(0, new[] { k_Up });
+                actionMask.SetActionEnabled(0, k_Up, false);
             }
         }
     }

--- a/com.unity.ml-agents/Runtime/Actuators/ActuatorDiscreteActionMask.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActuatorDiscreteActionMask.cs
@@ -42,15 +42,22 @@ namespace Unity.MLAgents.Actuators
             // Perform the masking
             foreach (var actionIndex in actionIndices)
             {
-#if DEBUG
-                if (branch >= m_NumBranches || actionIndex >= m_BranchSizes[CurrentBranchOffset + branch])
-                {
-                    throw new UnityAgentsException(
-                        "Invalid Action Masking: Action Mask is too large for specified branch.");
-                }
-#endif
-                m_CurrentMask[actionIndex + m_StartingActionIndices[CurrentBranchOffset + branch]] = true;
+                SetActionEnabled(branch, actionIndex, false);
             }
+        }
+
+        /// <inheritdoc/>
+        public void SetActionEnabled(int branch, int actionIndex, bool isEnabled)
+        {
+            LazyInitialize();
+#if DEBUG
+            if (branch >= m_NumBranches || actionIndex >= m_BranchSizes[CurrentBranchOffset + branch])
+            {
+                throw new UnityAgentsException(
+                    "Invalid Action Masking: Action Mask is too large for specified branch.");
+            }
+#endif
+            m_CurrentMask[actionIndex + m_StartingActionIndices[CurrentBranchOffset + branch]] = !isEnabled;
         }
 
         void LazyInitialize()
@@ -83,8 +90,12 @@ namespace Unity.MLAgents.Actuators
             }
         }
 
-        /// <inheritdoc/>
-        public bool[] GetMask()
+        /// <summary>
+        /// Get the current mask for an agent.
+        /// </summary>
+        /// <returns>A mask for the agent. A boolean array of length equal to the total number of
+        /// actions.</returns>
+        internal bool[] GetMask()
         {
 #if DEBUG
             if (m_CurrentMask != null)
@@ -116,7 +127,7 @@ namespace Unity.MLAgents.Actuators
         /// <summary>
         /// Resets the current mask for an agent.
         /// </summary>
-        public void ResetMask()
+        internal void ResetMask()
         {
             if (m_CurrentMask != null)
             {

--- a/com.unity.ml-agents/Runtime/Actuators/IDiscreteActionMask.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IDiscreteActionMask.cs
@@ -24,15 +24,20 @@ namespace Unity.MLAgents.Actuators
         void WriteMask(int branch, IEnumerable<int> actionIndices);
 
         /// <summary>
-        /// Get the current mask for an agent.
+        /// Set whether or not the action index for the given branch is allowed.
         /// </summary>
-        /// <returns>A mask for the agent. A boolean array of length equal to the total number of
-        /// actions.</returns>
-        bool[] GetMask();
-
-        /// <summary>
-        /// Resets the current mask for an agent.
-        /// </summary>
-        void ResetMask();
+        /// By default, all discrete actions are allowed.
+        /// If isEnabled is false, the agent will not be able to perform the actions passed as argument
+        /// at the next decision for the specified action branch. The actionIndex correspond
+        /// to the action options the agent will be unable to perform.
+        ///
+        /// See [Agents - Actions] for more information on masking actions.
+        ///
+        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_13_docs/docs/Learning-Environment-Design-Agents.md#actions
+        /// </remarks>
+        /// <param name="branch">The branch for which the actions will be masked.</param>
+        /// <param name="actionIndex">Index of the action</param>
+        /// <param name="isEnabled">Whether the action is allowed or now.</param>
+        void SetActionEnabled(int branch, int actionIndex, bool isEnabled);
     }
 }


### PR DESCRIPTION
### Proposed change(s)
This fixes a few things that bugged me about `IDiscreteActionMask:`
* Removes the `GetMask` and `ResetMask` methods - these were part of the implementation in `ActuatorDiscreteActionMask`, but they weren't meant for public use (and there was no safe way to use them in an `OnActionReceived` callback).
* Adds a method that doesn't require an `IEnumerable`. The previous approach required creating an object to pass, and also needed to allocate memory to iterate over it.
* Made what you're doing more explicit, and also undoable - "`WriteMask`" always felt vague, and I always had to look up whether I was enabling or disabling the actions.

Things I haven't done yet but would like feedback on:
* Should we remove `IDiscreteActionMask.WriteMask()`? This would be a larger interface change for anyone using it, but I think it's for the best.
* Should we stop having this as an interface and use a concrete implementation instead? Making it an interface feels strange, as there's no way for a user to implement their own version and get it passed through the system (although this could change in the future if we want to decouple the implementations.

I'm leaning towards removing `WriteMask` but keeping the interface, but wanted to discuss it further.

I haven't updated existing tests or documentation yet; wanted to get feedback on the general approach first.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1831
https://jira.unity3d.com/browse/MLA-1728


### Types of change(s)
- [x] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
