### PR TITLE
[MLA-1818] add release tag to git packman command

### DIFF
--- a/com.unity.ml-agents.extensions/Documentation~/com.unity.ml-agents.extensions.md
+++ b/com.unity.ml-agents.extensions/Documentation~/com.unity.ml-agents.extensions.md
@@ -40,15 +40,16 @@ In Unity 2019.4 or later, open the Package Manager, hit the "+" button, and sele
 
 In the dialog that appears, enter
  ```
- git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions
+git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_14
 ```
 
 You can also edit your project's `manifest.json` directly and add the following line to the `dependencies`
 section:
 ```
-"com.unity.ml-agents.extensions": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions",
+"com.unity.ml-agents.extensions": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_14",
 ```
-See [Git dependencies](https://docs.unity3d.com/Manual/upm-git.html#subfolder) for more information.
+See [Git dependencies](https://docs.unity3d.com/Manual/upm-git.html#subfolder) for more information. Note that this
+may take several minutes to resolve the packages the first time that you add it.
 
 
 ## Requirements


### PR DESCRIPTION
### Proposed change(s)
Follow-up from https://github.com/Unity-Technologies/ml-agents/issues/5022 - we should specify the tag on the git string to use in the package manager. This should get flagged and/or updated by the usual update script each release (manually tested)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/issues/5022


### Types of change(s)
- [x] Documentation update

### Checklist
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
