### PR TITLE
[coma2] Group reward reporting fix

### DIFF
--- a/ml-agents/mlagents/trainers/coma/trainer.py
+++ b/ml-agents/mlagents/trainers/coma/trainer.py
@@ -175,7 +175,8 @@ class COMATrainer(RLTrainer):
         if trajectory.done_reached:
             self._update_end_episode_stats(agent_id, self.optimizer)
             # Remove dead agents from group reward recording
-            self.collected_group_rewards.pop(agent_id)
+            if not trajectory.all_group_dones_reached:
+                self.collected_group_rewards.pop(agent_id)
 
         # If the whole team is done, average the remaining group rewards.
         if trajectory.all_group_dones_reached:

--- a/ml-agents/mlagents/trainers/coma/trainer.py
+++ b/ml-agents/mlagents/trainers/coma/trainer.py
@@ -12,7 +12,6 @@ from mlagents_envs.logging_util import get_logger
 from mlagents_envs.base_env import BehaviorSpec
 from mlagents.trainers.buffer import BufferKey, RewardSignalUtil
 from mlagents.trainers.trainer.rl_trainer import RLTrainer
-from mlagents.trainers.optimizer import Optimizer
 from mlagents.trainers.policy import Policy
 from mlagents.trainers.policy.torch_policy import TorchPolicy
 from mlagents.trainers.coma.optimizer_torch import TorchCOMAOptimizer
@@ -86,7 +85,7 @@ class COMATrainer(RLTrainer):
             agent_buffer_trajectory,
             trajectory.next_obs,
             trajectory.next_group_obs,
-            trajectory.teammate_dones_reached
+            trajectory.all_group_dones_reached
             and trajectory.done_reached
             and not trajectory.interrupted,
         )
@@ -175,6 +174,17 @@ class COMATrainer(RLTrainer):
         # If this was a terminal trajectory, append stats and reset reward collection
         if trajectory.done_reached:
             self._update_end_episode_stats(agent_id, self.optimizer)
+            # Remove dead agents from group reward recording
+            self.collected_group_rewards.pop(agent_id)
+
+        # If the whole team is done, average the remaining group rewards.
+        if trajectory.all_group_dones_reached:
+            self.stats_reporter.add_stat(
+                "Environment/Group Cumulative Reward",
+                self.collected_group_rewards.get(agent_id, 0),
+                aggregation=StatsAggregationMethod.HISTOGRAM,
+            )
+            self.collected_group_rewards.pop(agent_id)
 
     def _is_ready_update(self):
         """
@@ -285,15 +295,6 @@ class COMATrainer(RLTrainer):
         """
 
         return self.policy
-
-    def _update_end_episode_stats(self, agent_id: str, optimizer: Optimizer) -> None:
-        super()._update_end_episode_stats(agent_id, optimizer)
-        self.stats_reporter.add_stat(
-            "Environment/Team Cumulative Reward",
-            self.collected_group_rewards.get(agent_id, 0),
-            aggregation=StatsAggregationMethod.HISTOGRAM,
-        )
-        self.collected_group_rewards.pop(agent_id)
 
 
 def lambda_return(r, value_estimates, gamma=0.99, lambd=0.8, value_next=0.0):

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -164,7 +164,11 @@ class ConsoleWriter(StatsWriter):
                 log_info.append(f"Rank: {self.rank}")
 
             log_info.append(f"Mean Reward: {stats_summary.mean:0.3f}")
-            log_info.append(f"Std of Reward: {stats_summary.std:0.3f}")
+            if "Environment/Group Cumulative Reward" in values:
+                group_stats_summary = values["Environment/Group Cumulative Reward"]
+                log_info.append(f"Mean Group Reward: {group_stats_summary.mean:0.3f}")
+            else:
+                log_info.append(f"Std of Reward: {stats_summary.std:0.3f}")
             log_info.append(is_training)
 
             if self.self_play and "Self-play/ELO" in values:

--- a/ml-agents/mlagents/trainers/trajectory.py
+++ b/ml-agents/mlagents/trainers/trajectory.py
@@ -298,7 +298,7 @@ class Trajectory(NamedTuple):
         return self.steps[-1].done
 
     @property
-    def teammate_dones_reached(self) -> bool:
+    def all_group_dones_reached(self) -> bool:
         """
         Returns true if all teammates are done at the end of the trajectory.
         Combine with done_reached to check if the whole team is done.


### PR DESCRIPTION
### Proposed change(s)

Only report group rewards for agents that are still alive (don't report 0 for dying agents). 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
