### PR TITLE
GAIL simple RL cheat

### DIFF
--- a/ml-agents/mlagents/trainers/tests/simple_test_envs.py
+++ b/ml-agents/mlagents/trainers/tests/simple_test_envs.py
@@ -49,8 +49,10 @@ class SimpleEnvironment(BaseEnv):
         vec_obs_size=OBS_SIZE,
         var_len_obs_size=VAR_LEN_SIZE,
         action_sizes=(1, 0),
+        gail=False,
     ):
         super().__init__()
+        self.gail = gail
         self.num_visual = num_visual
         self.num_vector = num_vector
         self.num_var_len = num_var_len
@@ -170,7 +172,10 @@ class SimpleEnvironment(BaseEnv):
         return action_mask
 
     def _compute_reward(self, name: str, done: bool) -> float:
-        if done:
+        if self.gail:
+            # Subtract large positive constant to eliminate survivor bias in GAIL
+            reward = -0.2
+        elif done:
             reward = 0.0
             for _pos in self.positions[name]:
                 reward += (SUCCESS_REWARD * _pos * self.goal[name]) / len(

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -375,7 +375,7 @@ def simple_record(tmpdir_factory):
 def test_gail(simple_record, action_sizes, trainer_config):
     demo_path = simple_record(action_sizes)
     env = SimpleEnvironment(
-        [BRAIN_NAME], action_sizes=action_sizes, step_size=0.2, gail=True
+        [BRAIN_NAME], action_sizes=action_sizes, step_size=0.3, gail=True
     )
     bc_settings = BehavioralCloningSettings(demo_path=demo_path, steps=1000)
     reward_signals = {
@@ -430,7 +430,7 @@ def test_gail_visual_sac(simple_record, action_sizes):
         num_visual=1,
         num_vector=0,
         action_sizes=action_sizes,
-        step_size=0.2,
+        step_size=0.3,
         gail=True,
     )
     bc_settings = BehavioralCloningSettings(demo_path=demo_path, steps=1000)


### PR DESCRIPTION
### Proposed change(s)

The GAIL simple rl tests have been the most brittle of all for a long time. It's possible that this is due to the survivor bias from GAIL. This adds a flag to the simple environment to subtract a positive constant when using GAIL so that the reward is always negative (but maximized when the agent imitates the demos well). This should eliminate survivor bias.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
