### PR TITLE
[poca] Remove add_groupmate_rewards from settings

### DIFF
--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -171,7 +171,7 @@ class RewardSignalType(Enum):
 
     def to_settings(self) -> type:
         _mapping = {
-            RewardSignalType.EXTRINSIC: ExtrinsicSettings,
+            RewardSignalType.EXTRINSIC: RewardSignalSettings,
             RewardSignalType.GAIL: GAILSettings,
             RewardSignalType.CURIOSITY: CuriositySettings,
             RewardSignalType.RND: RNDSettings,
@@ -213,12 +213,6 @@ class RewardSignalSettings:
                         "encoding_size"
                     ]
         return d_final
-
-
-@attr.s(auto_attribs=True)
-class ExtrinsicSettings(RewardSignalSettings):
-    # For use with MA-POCA. Add groupmate rewards to the final extrinsic reward.
-    add_groupmate_rewards = False
 
 
 @attr.s(auto_attribs=True)
@@ -629,7 +623,7 @@ class TrainerSettings(ExportableSettings):
 
     network_settings: NetworkSettings = attr.ib(factory=NetworkSettings)
     reward_signals: Dict[RewardSignalType, RewardSignalSettings] = attr.ib(
-        factory=lambda: {RewardSignalType.EXTRINSIC: ExtrinsicSettings()}
+        factory=lambda: {RewardSignalType.EXTRINSIC: RewardSignalSettings()}
     )
     init_path: Optional[str] = None
     keep_checkpoints: int = 5

--- a/ml-agents/mlagents/trainers/tests/torch/test_poca.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_poca.py
@@ -4,7 +4,7 @@ import numpy as np
 import attr
 
 from mlagents.trainers.poca.optimizer_torch import TorchPOCAOptimizer
-from mlagents.trainers.settings import ExtrinsicSettings, RewardSignalType
+from mlagents.trainers.settings import RewardSignalSettings, RewardSignalType
 
 from mlagents.trainers.policy.torch_policy import TorchPolicy
 from mlagents.trainers.tests import mock_brain as mb
@@ -49,7 +49,7 @@ def create_test_poca_optimizer(dummy_config, use_rnn, use_discrete, use_visual):
 
     trainer_settings = attr.evolve(dummy_config)
     trainer_settings.reward_signals = {
-        RewardSignalType.EXTRINSIC: ExtrinsicSettings(strength=1.0, gamma=0.99)
+        RewardSignalType.EXTRINSIC: RewardSignalSettings(strength=1.0, gamma=0.99)
     }
 
     trainer_settings.network_settings.memory = (

--- a/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_extrinsic.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_extrinsic.py
@@ -6,7 +6,7 @@ from mlagents.trainers.torch.components.reward_providers import (
     create_reward_provider,
 )
 from mlagents_envs.base_env import BehaviorSpec, ActionSpec
-from mlagents.trainers.settings import ExtrinsicSettings, RewardSignalType
+from mlagents.trainers.settings import RewardSignalSettings, RewardSignalType
 from mlagents.trainers.tests.torch.test_reward_providers.utils import (
     create_agent_buffer,
 )
@@ -29,7 +29,7 @@ ACTIONSPEC_TWODISCRETE = ActionSpec.create_discrete((2, 3))
     ],
 )
 def test_construction(behavior_spec: BehaviorSpec) -> None:
-    settings = ExtrinsicSettings()
+    settings = RewardSignalSettings()
     settings.gamma = 0.2
     extrinsic_rp = ExtrinsicRewardProvider(behavior_spec, settings)
     assert extrinsic_rp.gamma == 0.2
@@ -48,7 +48,7 @@ def test_construction(behavior_spec: BehaviorSpec) -> None:
     ],
 )
 def test_factory(behavior_spec: BehaviorSpec) -> None:
-    settings = ExtrinsicSettings()
+    settings = RewardSignalSettings()
     extrinsic_rp = create_reward_provider(
         RewardSignalType.EXTRINSIC, behavior_spec, settings
     )
@@ -69,7 +69,7 @@ def test_factory(behavior_spec: BehaviorSpec) -> None:
 )
 def test_reward(behavior_spec: BehaviorSpec, reward: float) -> None:
     buffer = create_agent_buffer(behavior_spec, 1000, reward)
-    settings = ExtrinsicSettings()
+    settings = RewardSignalSettings()
     extrinsic_rp = ExtrinsicRewardProvider(behavior_spec, settings)
     generated_rewards = extrinsic_rp.evaluate(buffer)
     assert (generated_rewards == reward).all()
@@ -86,7 +86,7 @@ def test_reward(behavior_spec: BehaviorSpec, reward: float) -> None:
     assert (generated_rewards == 2 * reward).all()
 
     # Test groupmate rewards. Total reward should be indiv_reward + 2 * teammate_reward + group_reward
-    settings.add_groupmate_rewards = True
     extrinsic_rp = ExtrinsicRewardProvider(behavior_spec, settings)
+    extrinsic_rp.add_groupmate_rewards = True
     generated_rewards = extrinsic_rp.evaluate(buffer)
     assert (generated_rewards == 4 * reward).all()

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/extrinsic_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/extrinsic_reward_provider.py
@@ -6,7 +6,7 @@ from mlagents.trainers.torch.components.reward_providers.base_reward_provider im
     BaseRewardProvider,
 )
 from mlagents_envs.base_env import BehaviorSpec
-from mlagents.trainers.settings import ExtrinsicSettings
+from mlagents.trainers.settings import RewardSignalSettings
 
 
 class ExtrinsicRewardProvider(BaseRewardProvider):
@@ -16,9 +16,9 @@ class ExtrinsicRewardProvider(BaseRewardProvider):
     but also the team and the individual rewards of the other agents.
     """
 
-    def __init__(self, specs: BehaviorSpec, settings: ExtrinsicSettings) -> None:
+    def __init__(self, specs: BehaviorSpec, settings: RewardSignalSettings) -> None:
         super().__init__(specs, settings)
-        self._add_groupmate_rewards = settings.add_groupmate_rewards
+        self.add_groupmate_rewards = False
 
     def evaluate(self, mini_batch: AgentBuffer) -> np.ndarray:
         indiv_rewards = np.array(
@@ -29,7 +29,7 @@ class ExtrinsicRewardProvider(BaseRewardProvider):
             BufferKey.GROUPMATE_REWARDS in mini_batch
             and BufferKey.GROUP_REWARD in mini_batch
         ):
-            if self._add_groupmate_rewards:
+            if self.add_groupmate_rewards:
                 groupmate_rewards_list = mini_batch[BufferKey.GROUPMATE_REWARDS]
                 groupmate_rewards_sum = np.array(
                     [sum(_rew) for _rew in groupmate_rewards_list], dtype=np.float32


### PR DESCRIPTION
### Proposed change(s)

Remove the `add_groupmate_rewards` flag from settings.py, as it should not be user-configurable. Instead, there is a public variable on the ExtrinsicRewardProvider that is set by POCA after creation. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
