### PR TITLE
Make step in trainer private

### DIFF
--- a/ml-agents/mlagents/trainers/poca/trainer.py
+++ b/ml-agents/mlagents/trainers/poca/trainer.py
@@ -287,7 +287,7 @@ class POCATrainer(RLTrainer):
         self.model_saver.initialize_or_load()
 
         # Needed to resume loads properly
-        self.step = policy.get_current_step()
+        self._step = policy.get_current_step()
 
     def get_policy(self, name_behavior_id: str) -> Policy:
         """

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -263,7 +263,7 @@ class PPOTrainer(RLTrainer):
         self.model_saver.initialize_or_load()
 
         # Needed to resume loads properly
-        self.step = policy.get_current_step()
+        self._step = policy.get_current_step()
 
     def get_policy(self, name_behavior_id: str) -> Policy:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -67,7 +67,7 @@ class SACTrainer(RLTrainer):
         self.hyperparameters: SACSettings = cast(
             SACSettings, trainer_settings.hyperparameters
         )
-        self.step = 0
+        self._step = 0
 
         # Don't divide by zero
         self.update_steps = 1
@@ -188,7 +188,7 @@ class SACTrainer(RLTrainer):
         """
         return (
             self.update_buffer.num_experiences >= self.hyperparameters.batch_size
-            and self.step >= self.hyperparameters.buffer_init_steps
+            and self._step >= self.hyperparameters.buffer_init_steps
         )
 
     @timed
@@ -251,9 +251,9 @@ class SACTrainer(RLTrainer):
 
         batch_update_stats: Dict[str, list] = defaultdict(list)
         while (
-            self.step - self.hyperparameters.buffer_init_steps
+            self._step - self.hyperparameters.buffer_init_steps
         ) / self.update_steps > self.steps_per_update:
-            logger.debug(f"Updating SAC policy at step {self.step}")
+            logger.debug(f"Updating SAC policy at step {self._step}")
             buffer = self.update_buffer
             if self.update_buffer.num_experiences >= self.hyperparameters.batch_size:
                 sampled_minibatch = buffer.sample_mini_batch(
@@ -305,12 +305,12 @@ class SACTrainer(RLTrainer):
         )
         batch_update_stats: Dict[str, list] = defaultdict(list)
         while (
-            self.step - self.hyperparameters.buffer_init_steps
+            self._step - self.hyperparameters.buffer_init_steps
         ) / self.reward_signal_update_steps > self.reward_signal_steps_per_update:
             # Get minibatches for reward signal update if needed
             reward_signal_minibatches = {}
             for name in self.optimizer.reward_signals.keys():
-                logger.debug(f"Updating {name} at step {self.step}")
+                logger.debug(f"Updating {name} at step {self._step}")
                 if name != "extrinsic":
                     reward_signal_minibatches[name] = buffer.sample_mini_batch(
                         self.hyperparameters.batch_size,
@@ -355,11 +355,11 @@ class SACTrainer(RLTrainer):
         self.model_saver.initialize_or_load()
 
         # Needed to resume loads properly
-        self.step = policy.get_current_step()
+        self._step = policy.get_current_step()
         # Assume steps were updated at the correct ratio before
-        self.update_steps = int(max(1, self.step / self.steps_per_update))
+        self.update_steps = int(max(1, self._step / self.steps_per_update))
         self.reward_signal_update_steps = int(
-            max(1, self.step / self.reward_signal_steps_per_update)
+            max(1, self._step / self.reward_signal_steps_per_update)
         )
 
     def get_policy(self, name_behavior_id: str) -> Policy:

--- a/ml-agents/mlagents/trainers/trainer/rl_trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/rl_trainer.py
@@ -152,10 +152,10 @@ class RLTrainer(Trainer):
             logger.warning(
                 "Trainer has multiple policies, but default behavior only saves the first."
             )
-        checkpoint_path = self.model_saver.save_checkpoint(self.brain_name, self.step)
+        checkpoint_path = self.model_saver.save_checkpoint(self.brain_name, self._step)
         export_ext = "onnx"
         new_checkpoint = ModelCheckpoint(
-            int(self.step),
+            int(self._step),
             f"{checkpoint_path}.{export_ext}",
             self._policy_mean_reward(),
             time.time(),
@@ -199,7 +199,7 @@ class RLTrainer(Trainer):
         Increment the step count of the trainer
         :param n_steps: number of steps to increment the step count by
         """
-        self.step += n_steps
+        self._step += n_steps
         self._next_summary_step = self._get_next_interval_step(self.summary_freq)
         self._next_save_step = self._get_next_interval_step(
             self.trainer_settings.checkpoint_interval
@@ -213,7 +213,7 @@ class RLTrainer(Trainer):
         Get the next step count that should result in an action.
         :param interval: The interval between actions.
         """
-        return self.step + (interval - self.step % interval)
+        return self._step + (interval - self._step % interval)
 
     def _write_summary(self, step: int) -> None:
         """

--- a/ml-agents/mlagents/trainers/trainer/trainer.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer.py
@@ -45,7 +45,7 @@ class Trainer(abc.ABC):
         self._reward_buffer: Deque[float] = deque(maxlen=reward_buff_cap)
         self.policy_queues: List[AgentManagerQueue[Policy]] = []
         self.trajectory_queues: List[AgentManagerQueue[Trajectory]] = []
-        self.step: int = 0
+        self._step: int = 0
         self.artifact_path = artifact_path
         self.summary_freq = self.trainer_settings.summary_freq
         self.policies: Dict[str, Policy] = {}
@@ -78,7 +78,7 @@ class Trainer(abc.ABC):
         Returns the number of steps the trainer has performed
         :return: the step count of the trainer
         """
-        return self.step
+        return self._step
 
     @property
     def threaded(self) -> bool:


### PR DESCRIPTION
### Proposed change(s)

Make `step` in trainer private. Public method is called `get_step()`

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
