### PR TITLE
Fix for validate release links script

### DIFF
--- a/utils/validate_release_links.py
+++ b/utils/validate_release_links.py
@@ -13,7 +13,7 @@ RELEASE_PATTERN = re.compile(r"release_[0-9]+(_docs)*")
 # It matches "mlagents" and "mlagents_envs", accessible as group "package"
 # and optionally matches the version, e.g. "==1.2.3"
 PIP_INSTALL_PATTERN = re.compile(
-    r"(python -m )?pip3* install (?P<package>mlagents(_envs)?)(==[0-9]\.[0-9]\.[0-9](\.dev[0-9]+)?)?"
+    r"(python -m )?pip3* install (?P<package>mlagents(_envs)?)(==[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?)?"
 )
 TRAINER_INIT_FILE = "ml-agents/mlagents/trainers/__init__.py"
 
@@ -68,6 +68,8 @@ def test_pip_pattern():
         ("python -m pip install mlagents", True),
         ("python -m pip install mlagents==1.2.3", True),
         ("python -m pip install mlagents_envs==1.2.3", True),
+        ("python -m pip install mlagents==11.222.3333", True),
+        ("python -m pip install mlagents_envs==11.222.3333", True),
     ]:
         assert bool(PIP_INSTALL_PATTERN.search(s)) is expected
 
@@ -81,10 +83,13 @@ def test_pip_pattern():
 
 def update_pip_install_line(line, package_verion):
     match = PIP_INSTALL_PATTERN.search(line)
-    package_name = match.group("package")
-    replacement_version = f"python -m pip install {package_name}=={package_verion}"
-    updated = PIP_INSTALL_PATTERN.sub(replacement_version, line)
-    return updated
+    if match is not None:  # if there is a pip install line
+        package_name = match.group("package")
+        replacement_version = f"python -m pip install {package_name}=={package_verion}"
+        updated = PIP_INSTALL_PATTERN.sub(replacement_version, line)
+        return updated
+    else:  # Don't do anything
+        return line
 
 
 def git_ls_files() -> List[str]:


### PR DESCRIPTION
### Proposed change(s)

Fixes two minor issues with the `validate_release_links` script.
- Don't try to replace when there is no pip install line
- Match Python versions with more than one digit per number (e.g. X.YY.Z). 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
