### PR TITLE
Update versions on main post Release 15

### DIFF
--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.unity.ml-agents.extensions",
   "displayName": "ML Agents Extensions",
-  "version": "0.2.0-preview",
+  "version": "0.3.0-preview",
   "unity": "2018.4",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {
-    "com.unity.ml-agents": "1.8.1-preview"
+    "com.unity.ml-agents": "1.9.0-preview"
   }
 }

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -107,7 +107,7 @@ namespace Unity.MLAgents
         /// Unity package version of com.unity.ml-agents.
         /// This must match the version string in package.json and is checked in a unit test.
         /// </summary>
-        internal const string k_PackageVersion = "1.8.1-preview";
+        internal const string k_PackageVersion = "1.9.0-preview";
 
         const int k_EditorTrainingPort = 5004;
 

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents",
   "displayName": "ML Agents",
-  "version": "1.8.1-preview",
+  "version": "1.9.0-preview",
   "unity": "2018.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.25.0.dev0"
+__version__ = "0.26.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.25.0.dev0"
+__version__ = "0.26.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.25.0.dev0"
+__version__ = "0.26.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None


### PR DESCRIPTION
### Proposed change(s)

Update versions on main after R15 branch split. 

Note: @surfnerd I ticked the extensions package to 1.3.0. I don't have a preference on this; if we should keep it at 1.2.0 I can revert. 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
