### PR TITLE
Turns physics modules into optional dependencies.

### DIFF
--- a/.yamato/com.unity.ml-agents-coverage.yml
+++ b/.yamato/com.unity.ml-agents-coverage.yml
@@ -1,26 +1,9 @@
-test_editors:
-    - version: 2020.2
-      testProject: DevProject
-
-test_platforms:
-    - name: linux
-      type: Unity::VM
-      image: package-ci/ubuntu:stable
-      flavor: b1.medium
-
-packages:
-    - name: com.unity.ml-agents
-      assembly: Unity.ML-Agents
-      minCoveragePct: 72
-    - name: com.unity.ml-agents.extensions
-      assembly: Unity.ML-Agents.Extensions*
-      minCoveragePct: 75
+{% metadata_file .yamato/coverage_tests.metafile %}
 ---
-{% for package in packages %}
-  {% for editor in test_editors %}
-  {% for platform in test_platforms %}
-
-  {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
+{% for package in coverage_packages %}
+{% for editor in coverage_test_editors %}
+{% for platform in coverage_test_platforms %}
+{% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
 
 test_coverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     name : Coverage {{ package.name }} test {{ editor.version }} on {{ platform.name }}
@@ -48,10 +31,10 @@ test_coverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
             (pull_request.changes.any match "com.unity.ml-agents/**" OR
              pull_request.changes.any match " {{ editor.testProject }}/**" OR
             {% if package.name == "com.unity.ml-agents.extensions" %}
-              pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
+            pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
             {% endif %}
             pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
       {% endif %}
-      {% endfor %}
-  {% endfor %}
-  {% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/.yamato/com.unity.ml-agents-coverage.yml
+++ b/.yamato/com.unity.ml-agents-coverage.yml
@@ -1,0 +1,57 @@
+test_editors:
+    - version: 2020.2
+      testProject: DevProject
+
+test_platforms:
+    - name: linux
+      type: Unity::VM
+      image: package-ci/ubuntu:stable
+      flavor: b1.medium
+
+packages:
+    - name: com.unity.ml-agents
+      assembly: Unity.ML-Agents
+      minCoveragePct: 72
+    - name: com.unity.ml-agents.extensions
+      assembly: Unity.ML-Agents.Extensions*
+      minCoveragePct: 75
+---
+{% for package in packages %}
+  {% for editor in test_editors %}
+  {% for platform in test_platforms %}
+
+  {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
+
+test_coverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
+    name : Coverage {{ package.name }} test {{ editor.version }} on {{ platform.name }}
+    agent:
+        type: {{ platform.type }}
+        image: {{ platform.image }}
+        flavor: {{ platform.flavor}}
+    commands:
+        - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+        - upm-ci project test -u {{ editor.version }} --type project-tests --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ coverageOptions }} --extra-utr-arg "reruncount=2"
+        - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ package.minCoveragePct }}
+    artifacts:
+        logs:
+            paths:
+                - "upm-ci~/test-results/**/*"
+    dependencies:
+        - .yamato/com.unity.ml-agents-pack.yml#pack
+    triggers:
+        cancel_old_ci: true
+      {% if platform.name == "linux" %}
+        expression: |
+            (pull_request.target eq "main" OR
+            pull_request.target match "release.+") AND
+            NOT pull_request.draft AND
+            (pull_request.changes.any match "com.unity.ml-agents/**" OR
+             pull_request.changes.any match " {{ editor.testProject }}/**" OR
+            {% if package.name == "com.unity.ml-agents.extensions" %}
+              pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
+            {% endif %}
+            pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
+      {% endif %}
+      {% endfor %}
+  {% endfor %}
+  {% endfor %}

--- a/.yamato/com.unity.ml-agents-coverage.yml
+++ b/.yamato/com.unity.ml-agents-coverage.yml
@@ -1,6 +1,6 @@
 {% metadata_file .yamato/coverage_tests.metafile %}
 ---
-{% for package in coverage_packages %}
+{% for package in coverage_test_packages %}
 {% for editor in coverage_test_editors %}
 {% for platform in coverage_test_platforms %}
 {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}

--- a/.yamato/com.unity.ml-agents-optional-dep-tests.yml
+++ b/.yamato/com.unity.ml-agents-optional-dep-tests.yml
@@ -46,8 +46,13 @@ OptionalDependencyTests_{{ optional_dep.name }}:
                 - "upm-ci~/test-results/**/*"
     dependencies:
         - .yamato/com.unity.ml-agents-pack.yml#pack
-        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_{{ optional_dep.version }}
-        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_{{ optional_dep.version }}
+        {% for coverage_editor in coverage_test_editors %}
+        {% for coverage_plathform in coverage_test_platforms %}
+        {% for coverage_package in coverage_test_packages %}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ coverage_package.name }}_{{ coverage_platform.name }}_{{ coverage_editor.version }}
+        {% endfor %}
+        {% endfor %}
+        {% endfor %}
     triggers:
         cancel_old_ci: true
         expression: |

--- a/.yamato/com.unity.ml-agents-optional-dep-tests.yml
+++ b/.yamato/com.unity.ml-agents-optional-dep-tests.yml
@@ -1,37 +1,60 @@
-OptionalDependencyTestsLinux:
-  name : LinuxOptionalDependenciesTests
-  agent:
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
-  commands: 
-    - |
-      curl -L https://artifactory.prd.it.unity3d.com/artifactory/api/gpg/key/public | sudo apt-key add -
-      sudo sh -c "echo 'deb https://artifactory.prd.it.unity3d.com/artifactory/unity-apt-local bionic main' > /etc/apt/sources.list.d/unity.list"
-      sudo apt update
-      sudo apt install -y unity-config 
-      npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-      unity-config settings editor-path ./.Editor
-      unity-config project create opt-deps-test
-      unity-config project add dependency com.unity.ml-agents/
-      unity-config project add testable com.unity.ml-agents
-      unity-config project add dependency com.unity.modules.imageconversion@1.0.0
-      unity-config project add dependency com.unity.modules.jsonserialize@1.0.0
-      unity-config project add dependency com.unity.modules.physics@1.0.0
-      unity-config project add dependency com.unity.modules.physics2d@1.0.0
-      upm-ci project test -u 2019.4 --type project-tests --project-path opt-deps-test --package-filter com.unity.ml-agents 
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-    expression: |
-      (pull_request.target eq "main" OR
-      pull_request.target match "release.+") AND
-      NOT pull_request.draft AND
-      (pull_request.changes.any match "com.unity.ml-agents/**" OR
-      pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
+optional_deps:
+    - name: Analytics
+      project: "OptionalDepedencyTests/NoAnalyticsModule"
+      version: 2020.2
+    - name: Physics
+      project: OptionalDepedencyTests/NoPhysicsModule
+      version: 2020.2
+    - name: Physics2D
+      project: OptionalDepedencyTests/NoPhysics2DModule
+      version: 2020.2
+---
+
+  {% for optional_dep in optional_deps %}
+OptionalDependencyTests_{{ optional_dep.name }}:
+    name : Test Optional Package Dependencies {{ optional_dep.name }}
+    agent:
+        type: Unity::VM
+        image: package-ci/ubuntu:stable
+        flavor: b1.medium
+    commands:
+        - |
+            curl -L https://artifactory.prd.it.unity3d.com/artifactory/api/gpg/key/public | sudo apt-key add -
+            sudo sh -c "echo 'deb https://artifactory.prd.it.unity3d.com/artifactory/unity-apt-local bionic main' > /etc/apt/sources.list.d/unity.list"
+            sudo apt update
+            sudo apt install -y unity-config
+            npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+            unity-config settings editor-path ./.Editor
+            unity-config project create opt-deps-test
+            unity-config project add dependency com.unity.ml-agents/
+            unity-config project add testable com.unity.ml-agents
+            unity-config project add dependency com.unity.modules.imageconversion@1.0.0
+            unity-config project add dependency com.unity.modules.jsonserialize@1.0.0
+            {% unless optional_dep.name == "Physics" %}
+            unity-config project add dependency com.unity.modules.physics@1.0.0
+            {% endunless %}
+            {% unless optional_dep.name == "Physics2D" %}
+            unity-config project add dependency com.unity.modules.physics2d@1.0.0
+            {% endunless %}
+            {% unless optional_dep.name == "Analytics" %}
+            unity-config project add dependency com.unity.modules.unityanalytics@1.0.0
+            {% endunless %}
+            upm-ci project test -u {{ optional_dep.version }} --type project-tests --project-path opt-deps-test --package-filter com.unity.ml-agents
+    artifacts:
+        logs:
+            paths:
+                - "upm-ci~/test-results/**/*"
+    dependencies:
+        - .yamato/com.unity.ml-agents-pack.yml#pack
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_{{ optional_dep.version }}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_{{ optional_dep.version }}
+    triggers:
+        cancel_old_ci: true
+        expression: |
+            (pull_request.target eq "main" OR
+            pull_request.target match "release.+") AND
+            NOT pull_request.draft AND
+            (pull_request.changes.any match "com.unity.ml-agents/**" OR
+            pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
+  {% endfor %}
 

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -14,138 +14,131 @@ test_editors:
     enableNoDefaultPackages: !!bool true
 
 trunk_editor:
-  - version: trunk
-    # Workaround for MLA-1596 - need to make sure we load the right results.
-    enableCodeCoverage: !!bool false
-    testProject: DevProject
+    - version: trunk
+        # Workaround for MLA-1596 - need to make sure we load the right results.
+      enableCodeCoverage: !!bool false
+      testProject: DevProject
 
 test_platforms:
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: b1.small
-  - name: linux
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
+    - name: win
+      type: Unity::VM
+      image: package-ci/win10:stable
+      flavor: b1.large
+    - name: mac
+      type: Unity::VM::osx
+      image: package-ci/mac:stable
+      flavor: b1.small
+    - name: linux
+      type: Unity::VM
+      image: package-ci/ubuntu:stable
+      flavor: b1.medium
 
 packages:
-  - name: com.unity.ml-agents
-    assembly: Unity.ML-Agents
-    minCoveragePct: 72
-  - name: com.unity.ml-agents.extensions
-    assembly: Unity.ML-Agents.Extensions*
-    minCoveragePct: 75
+    - name: com.unity.ml-agents
+      assembly: Unity.ML-Agents
+      minCoveragePct: 72
+    - name: com.unity.ml-agents.extensions
+      assembly: Unity.ML-Agents.Extensions*
+      minCoveragePct: 75
 ---
 
 all_package_tests:
-  name: Run All Combinations of Editors/Platforms Tests
-  dependencies:
+    name: Run All Combinations of Editors/Platforms Tests
+    dependencies:
+      - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_2019.4
+      - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_2019.4
   {% for editor in test_editors %}
     {% for platform in test_platforms %}
-  - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
+      - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
   {% endfor %}
 
   {% for editor in trunk_editor %}
     {% for platform in test_platforms %}
-  - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
+      - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
   {% endfor %}
-  triggers:
-    cancel_old_ci: true
-    recurring:
-      - branch: main
-        frequency: daily
+    triggers:
+        cancel_old_ci: true
+        recurring:
+            - branch: main
+              frequency: daily
 
-{% for package in packages %}
+  {% for package in packages %}
   {% for editor in test_editors %}
-    {% for platform in test_platforms %}
+  {% for platform in test_platforms %}
 
-{% if editor.enableCodeCoverage %}
-  {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
-{% else %}
-  {% assign coverageOptions = "" %}
-{% endif %}
-
-{% if editor.enableNoDefaultPackages %}
+  {% if editor.enableNoDefaultPackages %}
   {% assign noDefaultPackagesOptions = "--extra-create-project-arg='-upmNoDefaultPackages'" %}
-{% else %}
+  {% else %}
   {% assign noDefaultPackagesOptions = "" %}
-{% endif %}
+  {% endif %}
 
 test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
-  name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ coverageOptions }} {{ noDefaultPackagesOptions }} --extra-utr-arg "reruncount=2"
-    {% if editor.enableCodeCoverage %}
-    - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ package.minCoveragePct }}
-    {% endif %}
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-    {% if platform.name == "linux" %}
-    expression: |
-      (pull_request.target eq "main" OR
-      pull_request.target match "release.+") AND
-      NOT pull_request.draft AND
-      (pull_request.changes.any match "com.unity.ml-agents/**" OR
-       pull_request.changes.any match " {{ editor.testProject }}/**" OR
-      {% if package.name == "com.unity.ml-agents.extensions" %}
-        pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
+    name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
+    agent:
+        type: {{ platform.type }}
+        image: {{ platform.image }}
+        flavor: {{ platform.flavor}}
+    commands:
+        - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+        - upm-ci project test -u {{ editor.version }} --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ noDefaultPackagesOptions }} --extra-utr-arg "reruncount=2"
+    artifacts:
+        logs:
+            paths:
+                - "upm-ci~/test-results/**/*"
+    dependencies:
+        - .yamato/com.unity.ml-agents-pack.yml#pack
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ package.name }}_linux_2019.4
+    triggers:
+        cancel_old_ci: true
+      {% if platform.name == "linux" %}
+        expression: |
+            (pull_request.target eq "main" OR
+            pull_request.target match "release.+") AND
+            NOT pull_request.draft AND
+            (pull_request.changes.any match "com.unity.ml-agents/**" OR
+             pull_request.changes.any match " {{ editor.testProject }}/**" OR
+            {% if package.name == "com.unity.ml-agents.extensions" %}
+              pull_request.changes.any match "com.unity.ml-agents.extensions/**" OR
+            {% endif %}
+            pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
       {% endif %}
-      pull_request.changes.any match ".yamato/com.unity.ml-agents-test.yml")
-    {% endif %}
-    {% endfor %}
+      {% endfor %}
   {% endfor %}
-{% endfor %}
+  {% endfor %}
 
-{% for package in packages %}
+  {% for package in packages %}
   {% for editor in trunk_editor %}
-    {% for platform in test_platforms %}
+  {% for platform in test_platforms %}
 
-{% if editor.enableCodeCoverage %}
+  {% if editor.enableCodeCoverage %}
   {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
-{% else %}
+  {% else %}
   {% assign coverageOptions = "" %}
-{% endif %}
+  {% endif %}
 test_{{ package.name }}_{{ platform.name }}_trunk:
-  name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - python3 -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
-    - unity-downloader-cli -u trunk -c editor --wait --fast
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ editor.version }} --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ coverageOptions }} --extra-create-project-arg="-upmNoDefaultPackages" --extra-utr-arg "reruncount=2"
-    {% if editor.enableCodeCoverage %}
-    - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ package.minCoveragePct }}
-    {% endif %}
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/com.unity.ml-agents-pack.yml#pack
-  triggers:
-    cancel_old_ci: true
-    {% endfor %}
+    name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
+    agent:
+        type: {{ platform.type }}
+        image: {{ platform.image }}
+        flavor: {{ platform.flavor}}
+    commands:
+        - python3 -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+        - unity-downloader-cli -u trunk -c editor --wait --fast
+        - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+        - upm-ci project test -u {{ editor.version }} --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ coverageOptions }} --extra-create-project-arg="-upmNoDefaultPackages" --extra-utr-arg "reruncount=2"
+      {% if editor.enableCodeCoverage %}
+        - python3 ml-agents/tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ package.minCoveragePct }}
+      {% endif %}
+    artifacts:
+        logs:
+            paths:
+                - "upm-ci~/test-results/**/*"
+    dependencies:
+        - .yamato/com.unity.ml-agents-pack.yml#pack
+    triggers:
+        cancel_old_ci: true
+      {% endfor %}
   {% endfor %}
-{% endfor %}
-
+  {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -1,3 +1,4 @@
+{% metadata_file .yamato/coverage_tests.metafile %}
 test_editors:
     - version: 2019.4
       enableCodeCoverage: !!bool true
@@ -45,8 +46,13 @@ packages:
 all_package_tests:
     name: Run All Combinations of Editors/Platforms Tests
     dependencies:
-        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_2019.4
-        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_2019.4
+        {% for coverage_editor in coverage_test_editors %}
+        {% for coverage_plathform in coverage_test_platforms %}
+        {% for coverage_package in coverage_test_packages %}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ coverage_package.name }}_{{ coverage_platform.name }}_{{ coverage_editor.version }}
+        {% endfor %}
+        {% endfor %}
+        {% endfor %}
         {% for editor in test_editors %}
         {% for platform in test_platforms %}
         - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
@@ -88,7 +94,13 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
                 - "upm-ci~/test-results/**/*"
     dependencies:
         - .yamato/com.unity.ml-agents-pack.yml#pack
-        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ package.name }}_linux_2019.4
+        {% for coverage_editor in coverage_test_editors %}
+        {% for coverage_plathform in coverage_test_platforms %}
+        {% for coverage_package in coverage_test_packages %}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ coverage_package.name }}_{{ coverage_platform.name }}_{{ coverage_editor.version }}
+        {% endfor %}
+        {% endfor %}
+        {% endfor %}
     triggers:
         cancel_old_ci: true
       {% if platform.name == "linux" %}
@@ -136,6 +148,13 @@ test_{{ package.name }}_{{ platform.name }}_trunk:
                 - "upm-ci~/test-results/**/*"
     dependencies:
         - .yamato/com.unity.ml-agents-pack.yml#pack
+        {% for coverage_editor in coverage_test_editors %}
+        {% for coverage_plathform in coverage_test_platforms %}
+        {% for coverage_package in coverage_test_packages %}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_{{ coverage_package.name }}_{{ coverage_platform.name }}_{{ coverage_editor.version }}
+        {% endfor %}
+        {% endfor %}
+        {% endfor %}
     triggers:
         cancel_old_ci: true
       {% endfor %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -1,17 +1,17 @@
 test_editors:
-  - version: 2019.4
-    enableCodeCoverage: !!bool true
-    # We want some scene tests to run in the DevProject, but packages there only support 2020+
-    testProject: Project
-    enableNoDefaultPackages: !!bool true
-  - version: 2020.2
-    enableCodeCoverage: !!bool true
-    testProject: DevProject
-    enableNoDefaultPackages: !!bool true
-  - version: 2021.1
-    enableCodeCoverage: !!bool true
-    testProject: DevProject
-    enableNoDefaultPackages: !!bool true
+    - version: 2019.4
+      enableCodeCoverage: !!bool true
+        # We want some scene tests to run in the DevProject, but packages there only support 2020+
+      testProject: Project
+      enableNoDefaultPackages: !!bool true
+    - version: 2020.2
+      enableCodeCoverage: !!bool true
+      testProject: DevProject
+      enableNoDefaultPackages: !!bool true
+    - version: 2021.1
+      enableCodeCoverage: !!bool true
+      testProject: DevProject
+      enableNoDefaultPackages: !!bool true
 
 trunk_editor:
     - version: trunk
@@ -45,19 +45,18 @@ packages:
 all_package_tests:
     name: Run All Combinations of Editors/Platforms Tests
     dependencies:
-      - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_2019.4
-      - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_2019.4
-  {% for editor in test_editors %}
-    {% for platform in test_platforms %}
-      - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-  {% endfor %}
-
-  {% for editor in trunk_editor %}
-    {% for platform in test_platforms %}
-      - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-  {% endfor %}
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents_linux_2019.4
+        - .yamato/com.unity.ml-agents-coverage.yml#test_coverage_com.unity.ml-agents.extensions_linux_2019.4
+        {% for editor in test_editors %}
+        {% for platform in test_platforms %}
+        - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
+        {% endfor %}
+        {% endfor %}
+        {% for editor in trunk_editor %}
+        {% for platform in test_platforms %}
+        - .yamato/com.unity.ml-agents-test.yml#test_com.unity.ml-agents_{{ platform.name }}_{{ editor.version }}
+        {% endfor %}
+        {% endfor %}
     triggers:
         cancel_old_ci: true
         recurring:
@@ -114,9 +113,9 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
 
   {% if editor.enableCodeCoverage %}
   {% capture coverageOptions %} --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+{{ package.assembly }}'{% endcapture %}
-  {% else %}
-  {% assign coverageOptions = "" %}
-  {% endif %}
+    {% else %}
+    {% assign coverageOptions = "" %}
+    {% endif %}
 test_{{ package.name }}_{{ platform.name }}_trunk:
     name : {{ package.name }} test {{ editor.version }} on {{ platform.name }}
     agent:

--- a/.yamato/coverage_tests.metafile
+++ b/.yamato/coverage_tests.metafile
@@ -1,0 +1,17 @@
+coverage_test_editors:
+    - version: 2020.2
+      testProject: DevProject
+
+coverage_test_platforms:
+    - name: linux
+      type: Unity::VM
+      image: package-ci/ubuntu:stable
+      flavor: b1.medium
+
+coverage_test_packages:
+    - name: com.unity.ml-agents
+      assembly: Unity.ML-Agents
+      minCoveragePct: 72
+    - name: com.unity.ml-agents.extensions
+      assembly: Unity.ML-Agents.Extensions*
+      minCoveragePct: 75

--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -5,6 +5,7 @@
   "unity": "2019.4",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {
-    "com.unity.ml-agents": "2.0.0-exp.1"
+    "com.unity.ml-agents": "2.0.0-exp.1",
+    "com.unity.modules.physics": "1.0.0"
   }
 }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -27,6 +27,8 @@ details.
 - The `.onnx` models input names have changed. All input placeholders will now use the prefix `obs_` removing the distinction between visual and vector observations. Models created with this version will not be usable with previous versions of the package (#5080)
 - The `.onnx` models discrete action output now contains the discrete actions values and not the logits. Models created with this version will not be usable with previous versions of the package (#5080)
 - Added ML-Agents package settings. (#5027)
+- Make com.unity.modules.unityanalytics an optional dependency. (#5109)
+- Make com.unity.modules.physics and com.unity.modules.physics2d optional dependencies. (#5112)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Bug Fixes

--- a/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
+++ b/com.unity.ml-agents/Editor/RayPerceptionSensorComponentBaseEditor.cs
@@ -10,6 +10,22 @@ namespace Unity.MLAgents.Editor
 
         protected void OnRayPerceptionInspectorGUI(bool is3d)
         {
+#if !MLA_UNITY_PHYSICS_MODULE
+            if (is3d)
+            {
+                EditorGUILayout.HelpBox("The Physics Module is not currently present.  " +
+                "Please add it to your project in order to use the Ray Perception APIs in the " +
+                $"{nameof(RayPerceptionSensorComponent3D)}", MessageType.Warning);
+            }
+#endif
+#if !MLA_UNITY_PHYSICS2D_MODULE
+            if (!is3d)
+            {
+                EditorGUILayout.HelpBox("The Physics2D Module is not currently present.  " +
+                "Please add it to your project in order to use the Ray Perception APIs in the " +
+                $"{nameof(RayPerceptionSensorComponent3D)}", MessageType.Warning);
+            }
+#endif
             var so = serializedObject;
             so.Update();
 

--- a/com.unity.ml-agents/Editor/Unity.ML-Agents.Editor.asmdef
+++ b/com.unity.ml-agents/Editor/Unity.ML-Agents.Editor.asmdef
@@ -14,5 +14,17 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS2D_MODULE"
+        }
+    ]
 }

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -87,9 +87,9 @@ namespace Unity.MLAgents
     internal class AgentVectorActuator : VectorActuator
     {
         public AgentVectorActuator(IActionReceiver actionReceiver,
-            IHeuristicProvider heuristicProvider,
-            ActionSpec actionSpec,
-            string name = "VectorActuator"
+                                   IHeuristicProvider heuristicProvider,
+                                   ActionSpec actionSpec,
+                                   string name = "VectorActuator"
         ) : base(actionReceiver, heuristicProvider, actionSpec, name)
         { }
 
@@ -692,9 +692,7 @@ namespace Unity.MLAgents
         /// <param name="reward">The new value of the reward.</param>
         public void SetReward(float reward)
         {
-#if DEBUG
             Utilities.DebugCheckNanAndInfinity(reward, nameof(reward), nameof(SetReward));
-#endif
             m_CumulativeReward += (reward - m_Reward);
             m_Reward = reward;
         }
@@ -722,26 +720,20 @@ namespace Unity.MLAgents
         /// <param name="increment">Incremental reward value.</param>
         public void AddReward(float increment)
         {
-#if DEBUG
             Utilities.DebugCheckNanAndInfinity(increment, nameof(increment), nameof(AddReward));
-#endif
             m_Reward += increment;
             m_CumulativeReward += increment;
         }
 
         internal void SetGroupReward(float reward)
         {
-#if DEBUG
             Utilities.DebugCheckNanAndInfinity(reward, nameof(reward), nameof(SetGroupReward));
-#endif
             m_GroupReward = reward;
         }
 
         internal void AddGroupReward(float increment)
         {
-#if DEBUG
             Utilities.DebugCheckNanAndInfinity(increment, nameof(increment), nameof(AddGroupReward));
-#endif
             m_GroupReward += increment;
         }
 

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -422,12 +422,13 @@ namespace Unity.MLAgents.Sensors
                 unscaledCastRadius;
 
             // Do the cast and assign the hit information for each detectable tag.
-            bool castHit;
-            float hitFraction;
-            GameObject hitObject;
+            var castHit = false;
+            var hitFraction = 1.0f;
+            GameObject hitObject = null;
 
             if (input.CastType == RayPerceptionCastType.Cast3D)
             {
+#if MLA_UNITY_PHYSICS_MODULE
                 RaycastHit rayHit;
                 if (scaledCastRadius > 0f)
                 {
@@ -444,9 +445,11 @@ namespace Unity.MLAgents.Sensors
                 // To avoid 0/0, set the fraction to 0.
                 hitFraction = castHit ? (scaledRayLength > 0 ? rayHit.distance / scaledRayLength : 0.0f) : 1.0f;
                 hitObject = castHit ? rayHit.collider.gameObject : null;
+#endif
             }
             else
             {
+#if MLA_UNITY_PHYSICS2D_MODULE
                 RaycastHit2D rayHit;
                 if (scaledCastRadius > 0f)
                 {
@@ -461,6 +464,7 @@ namespace Unity.MLAgents.Sensors
                 castHit = rayHit;
                 hitFraction = castHit ? rayHit.fraction : 1.0f;
                 hitObject = castHit ? rayHit.collider.gameObject : null;
+#endif
             }
 
             var rayOutput = new RayPerceptionOutput.RayOutput

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponent2D.cs
@@ -14,7 +14,7 @@ namespace Unity.MLAgents.Sensors
         public RayPerceptionSensorComponent2D()
         {
             // Set to the 2D defaults (just in case they ever diverge).
-            RayLayerMask = Physics2D.DefaultRaycastLayers;
+            RayLayerMask = -5;
         }
 
         /// <inheritdoc/>

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -97,9 +97,11 @@ namespace Unity.MLAgents.Sensors
             set { m_RayLength = value; UpdateSensor(); }
         }
 
+        // The value of the default layers.
+        const int k_PhysicsDefaultLayers = -5;
         [HideInInspector, SerializeField, FormerlySerializedAs("rayLayerMask")]
         [Tooltip("Controls which layers the rays can hit.")]
-        LayerMask m_RayLayerMask = Physics.DefaultRaycastLayers;
+        LayerMask m_RayLayerMask = k_PhysicsDefaultLayers;
 
         /// <summary>
         /// Controls which layers the rays can hit.

--- a/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/VectorSensor.cs
@@ -120,9 +120,7 @@ namespace Unity.MLAgents.Sensors
 
         void AddFloatObs(float obs)
         {
-#if DEBUG
             Utilities.DebugCheckNanAndInfinity(obs, nameof(obs), nameof(AddFloatObs));
-#endif
             m_Observations.Add(obs);
         }
 

--- a/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
+++ b/com.unity.ml-agents/Runtime/Unity.ML-Agents.asmdef
@@ -21,6 +21,16 @@
             "name": "com.unity.modules.unityanalytics",
             "expression": "1.0.0",
             "define": "MLA_UNITY_ANALYTICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS2D_MODULE"
         }
     ]
 }

--- a/com.unity.ml-agents/Runtime/Utilities.cs
+++ b/com.unity.ml-agents/Runtime/Utilities.cs
@@ -1,10 +1,10 @@
 using System;
+using System.Diagnostics;
 
 namespace Unity.MLAgents
 {
     internal static class Utilities
     {
-
         /// <summary>
         /// Calculates the cumulative sum of an integer array. The result array will be one element
         /// larger than the input array since it has a padded 0 at the beginning.
@@ -26,10 +26,9 @@ namespace Unity.MLAgents
             return result;
         }
 
-#if DEBUG
+        [Conditional("DEBUG")]
         internal static void DebugCheckNanAndInfinity(float value, string valueCategory, string caller)
         {
-
             if (float.IsNaN(value))
             {
                 throw new ArgumentException($"NaN {valueCategory} passed to {caller}.");
@@ -39,7 +38,5 @@ namespace Unity.MLAgents
                 throw new ArgumentException($"Inifinity {valueCategory} passed to {caller}.");
             }
         }
-#endif
     }
-
 }

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -53,6 +53,7 @@ namespace Unity.MLAgentsExamples
             Assert.IsTrue(sensorComponent.Grayscale);
         }
 
+#if MLA_UNITY_PHYSICS_MODULE
         [Test]
         public void CheckSetupRayPerceptionSensorComponent()
         {
@@ -69,5 +70,6 @@ namespace Unity.MLAgentsExamples
 
             sensorComponent.CreateSensor();
         }
+#endif
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/Unity.ML-Agents.Editor.Tests.asmdef
+++ b/com.unity.ml-agents/Tests/Editor/Unity.ML-Agents.Editor.Tests.asmdef
@@ -30,6 +30,16 @@
             "name": "com.unity.modules.unityanalytics",
             "expression": "1.0.0",
             "define": "MLA_UNITY_ANALYTICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS2D_MODULE"
         }
     ]
 }

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -1,4 +1,3 @@
-#if UNITY_INCLUDE_TESTS
 using System.Collections;
 using System.Collections.Generic;
 using Unity.MLAgents;
@@ -72,7 +71,7 @@ namespace Tests
             behaviorParams.BrainParameters.VectorObservationSize = 3;
             behaviorParams.BrainParameters.NumStackedVectorObservations = 2;
             behaviorParams.BrainParameters.VectorActionDescriptions = new[] { "Continuous1", "TestActionA", "TestActionB" };
-            behaviorParams.BrainParameters.ActionSpec = new ActionSpec(1, new []{2, 2});
+            behaviorParams.BrainParameters.ActionSpec = new ActionSpec(1, new[] { 2, 2 });
             behaviorParams.BehaviorName = "TestBehavior";
             behaviorParams.TeamId = 42;
             behaviorParams.UseChildSensors = true;
@@ -81,7 +80,7 @@ namespace Tests
 
             // Can't actually create an Agent with InferenceOnly and no model, so change back
             behaviorParams.BehaviorType = BehaviorType.Default;
-
+#if MLA_UNITY_PHSYICS_MODULE
             var sensorComponent = gameObject.AddComponent<RayPerceptionSensorComponent3D>();
             sensorComponent.SensorName = "ray3d";
             sensorComponent.DetectableTags = new List<string> { "Player", "Respawn" };
@@ -95,6 +94,7 @@ namespace Tests
 
             // ISensor isn't set up yet.
             Assert.IsNull(sensorComponent.RaySensor);
+#endif
 
 
             // Make sure we can set the behavior type correctly after the agent is initialized
@@ -109,10 +109,10 @@ namespace Tests
             decisionRequester.DecisionPeriod = 2;
             decisionRequester.TakeActionsBetweenDecisions = true;
 
-
+#if MLA_UNITY_PHSYICS_MODULE
             // Initialization should set up the sensors
             Assert.IsNotNull(sensorComponent.RaySensor);
-
+#endif
             // Let's change the inference device
             var otherDevice = behaviorParams.InferenceDevice == InferenceDevice.CPU ? InferenceDevice.GPU : InferenceDevice.CPU;
             agent.SetModel(behaviorParams.BehaviorName, behaviorParams.Model, otherDevice);
@@ -126,7 +126,7 @@ namespace Tests
 
             var actions = agent.GetStoredActionBuffers().DiscreteActions;
             // default Heuristic implementation should return zero actions.
-            Assert.AreEqual(new ActionSegment<int>(new[] {0, 0}), actions);
+            Assert.AreEqual(new ActionSegment<int>(new[] { 0, 0 }), actions);
             Assert.AreEqual(1, agent.numHeuristicCalls);
 
             Academy.Instance.EnvironmentStep();
@@ -137,4 +137,3 @@ namespace Tests
         }
     }
 }
-#endif

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
 using Unity.MLAgents.Sensors;
+using UnityEngine.TestTools;
 
 namespace Unity.MLAgents.Tests
 {
@@ -24,6 +24,18 @@ namespace Unity.MLAgents.Tests
 
     public class RayPerception3DTests
     {
+        [Test]
+        public void TestDefaultLayersAreNegativeFive()
+        {
+#if MLA_UNITY_PHYSICS_MODULE
+            Assert.IsTrue(Physics.DefaultRaycastLayers == -5);
+#endif
+#if MLA_UNITY_PHYSICS2D_MODULE
+            Assert.IsTrue(Physics2D.DefaultRaycastLayers == -5);
+#endif
+        }
+
+#if MLA_UNITY_PHYSICS_MODULE
         // Use built-in tags
         const string k_CubeTag = "Player";
         const string k_SphereTag = "Respawn";
@@ -71,6 +83,7 @@ namespace Unity.MLAgents.Tests
             sphere3.transform.position = new Vector3(0, 0, -10);
             sphere3.tag = k_SphereTag;
             sphere3.name = "sphere3";
+
 
             Physics.SyncTransforms();
         }
@@ -402,5 +415,6 @@ namespace Unity.MLAgents.Tests
                 Assert.AreEqual(-1, castOutput.RayOutputs[0].HitTagIndex);
             }
         }
+#endif
     }
 }

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/Unity.ML-Agents.Runtime.Sensor.Tests.asmdef
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/Unity.ML-Agents.Runtime.Sensor.Tests.asmdef
@@ -21,5 +21,17 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS2D_MODULE"
+        }
     ]
 }

--- a/com.unity.ml-agents/Tests/Runtime/Unity.ML-Agents.Runtime.Tests.asmdef
+++ b/com.unity.ml-agents/Tests/Runtime/Unity.ML-Agents.Runtime.Tests.asmdef
@@ -21,5 +21,17 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MLA_UNITY_PHYSICS2D_MODULE"
+        }
     ]
 }

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -7,8 +7,6 @@
   "dependencies": {
     "com.unity.barracuda": "1.3.2-preview",
     "com.unity.modules.imageconversion": "1.0.0",
-    "com.unity.modules.jsonserialize": "1.0.0",
-    "com.unity.modules.physics": "1.0.0",
-    "com.unity.modules.physics2d": "1.0.0"
+    "com.unity.modules.jsonserialize": "1.0.0"
   }
 }


### PR DESCRIPTION
### Proposed change(s)
- Make physics and physics2d optional deps.
- Update yamato tests to run coverage tests separately from the package tests.  This allows us to fail quickly if coverage is not up to par with our goals.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
#5104 (Make both physics modules optional dependencies (com.unity.modules.physics and com.unity.modules.physics2d))
[MLA-1850](https://jira.unity3d.com/browse/MLA-1850)

<img width="297" alt="Screen Shot 2021-03-15 at 8 21 24 PM" src="https://user-images.githubusercontent.com/1356616/111251233-0cd46200-85cc-11eb-851e-58d7832f766a.png">


### Types of change(s)
- [x] Code refactor

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works

### Other comments
