### PR TITLE
[bug-fix] Move POCA critic to default device

### DIFF
--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -4,7 +4,7 @@ from mlagents.trainers.torch.components.reward_providers.extrinsic_reward_provid
 )
 import numpy as np
 import math
-from mlagents.torch_utils import torch
+from mlagents.torch_utils import torch, default_device
 
 from mlagents.trainers.buffer import (
     AgentBuffer,
@@ -155,6 +155,8 @@ class TorchPOCAOptimizer(TorchOptimizer):
             network_settings=trainer_settings.network_settings,
             action_spec=policy.behavior_spec.action_spec,
         )
+        # Move to GPU if needed
+        self._critic.to(default_device())
 
         params = list(self.policy.actor.parameters()) + list(self.critic.parameters())
         self.hyperparameters: POCASettings = cast(

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -269,6 +269,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
         )
         # Get the mask from NaNs
         attn_mask = only_first_obs_flat.isnan().type(torch.FloatTensor)
+        print(attn_mask.get_device(), only_first_obs_flat.get_device())
         return attn_mask
 
     def _copy_and_remove_nans_from_obs(
@@ -281,10 +282,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
         for i_agent, single_agent_obs in enumerate(all_obs):
             no_nan_obs = []
             for obs in single_agent_obs:
-                # Clone to same device as obs
-                with torch.cuda.device_of(obs):
-                    new_obs = obs.clone()
-                    print(obs.get_device(), new_obs.get_device())
+                new_obs = obs.clone()
                 new_obs[
                     attention_mask.type(torch.BoolTensor)[:, i_agent], ::
                 ] = 0.0  # Remoove NaNs fast

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Dict, Tuple, Optional, Union
 import abc
 
-from mlagents.torch_utils import torch, nn, default_device
+from mlagents.torch_utils import torch, nn
 
 from mlagents_envs.base_env import ActionSpec, ObservationSpec
 from mlagents.trainers.torch.action_model import ActionModel
@@ -281,8 +281,10 @@ class MultiAgentNetworkBody(torch.nn.Module):
         for i_agent, single_agent_obs in enumerate(all_obs):
             no_nan_obs = []
             for obs in single_agent_obs:
-                with default_device():
+                # Clone to same device as obs
+                with torch.cuda.device_of(obs):
                     new_obs = obs.clone()
+                    print(obs.get_device(), new_obs.get_device())
                 new_obs[
                     attention_mask.type(torch.BoolTensor)[:, i_agent], ::
                 ] = 0.0  # Remoove NaNs fast

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Dict, Tuple, Optional, Union
 import abc
 
-from mlagents.torch_utils import torch, nn
+from mlagents.torch_utils import torch, nn, default_device
 
 from mlagents_envs.base_env import ActionSpec, ObservationSpec
 from mlagents.trainers.torch.action_model import ActionModel
@@ -281,7 +281,8 @@ class MultiAgentNetworkBody(torch.nn.Module):
         for i_agent, single_agent_obs in enumerate(all_obs):
             no_nan_obs = []
             for obs in single_agent_obs:
-                new_obs = obs.clone()
+                with default_device():
+                    new_obs = obs.clone()
                 new_obs[
                     attention_mask.type(torch.BoolTensor)[:, i_agent], ::
                 ] = 0.0  # Remoove NaNs fast

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -268,8 +268,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
             [_obs.flatten(start_dim=1)[:, 0] for _obs in only_first_obs], dim=1
         )
         # Get the mask from NaNs
-        attn_mask = only_first_obs_flat.isnan().type(torch.FloatTensor)
-        print(attn_mask.get_device(), only_first_obs_flat.get_device())
+        attn_mask = only_first_obs_flat.isnan().float()
         return attn_mask
 
     def _copy_and_remove_nans_from_obs(

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -283,7 +283,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
             for obs in single_agent_obs:
                 new_obs = obs.clone()
                 new_obs[
-                    attention_mask.type(torch.BoolTensor)[:, i_agent], ::
+                    attention_mask.bool()[:, i_agent], ::
                 ] = 0.0  # Remoove NaNs fast
                 no_nan_obs.append(new_obs)
             obs_with_no_nans.append(no_nan_obs)


### PR DESCRIPTION
### Proposed change(s)

Move POCA critic to default device. Was failing Yamato GPU test without this. Needs to be cherry-picked into R15.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
