### PR TITLE
Remove EndEpisode from the dungeon env. (Conflicts with docs)

### DIFF
--- a/Project/Assets/ML-Agents/Examples/DungeonEscape/Scripts/DungeonEscapeEnvController.cs
+++ b/Project/Assets/ML-Agents/Examples/DungeonEscape/Scripts/DungeonEscapeEnvController.cs
@@ -149,7 +149,6 @@ public class DungeonEscapeEnvController : MonoBehaviour
     {
         baddieCol.gameObject.SetActive(false);
         m_NumberOfRemainingPlayers--;
-        agent.EndEpisode();
         agent.gameObject.SetActive(false);
         print($"{baddieCol.gameObject.name} ate {agent.transform.name}");
 

--- a/Project/Assets/ML-Agents/Examples/DungeonEscape/Scripts/DungeonEscapeEnvController.cs
+++ b/Project/Assets/ML-Agents/Examples/DungeonEscape/Scripts/DungeonEscapeEnvController.cs
@@ -130,7 +130,6 @@ public class DungeonEscapeEnvController : MonoBehaviour
         }
         else
         {
-            agent.EndEpisode();
             agent.gameObject.SetActive(false);
         }
     }


### PR DESCRIPTION
### Proposed change(s)

EndEpisode has no effect here but conflicts with our documentation https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Learning-Environment-Design-Agents.md#cooperative-behaviors-notes-and-best-practices

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
