### PR TITLE
exclude forum links

### DIFF
--- a/markdown-link-check.full.json
+++ b/markdown-link-check.full.json
@@ -13,8 +13,8 @@
             "comment": "Allow future release tags"
         },
         {
-            "pattern": "https://forum.unity.com/forums/ml-agents.453/",
-            "comment": "Not reachable from github action"
+            "pattern": "https://forum.unity.com/",
+            "comment": "Returns 307 (temporary redirect) which causes link check to fail."
         },
         {
             "pattern": "mailto:",


### PR DESCRIPTION
### Proposed change(s)
A recently added link to a forum thread is causing the nightly link check to fail. `curl`ing the link indicates it returns a 307 Temporary Redirect.

We already had an exclusion for links to the forum; this just expands the exclusion.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/runs/2163855728?check_suite_focus=true


### Types of change(s)
- [x] CI
