### PR TITLE
[MLA-1634] Remove SensorComponent.GetObservationShape()

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicSensorComponent.cs
+++ b/Project/Assets/ML-Agents/Examples/Basic/Scripts/BasicSensorComponent.cs
@@ -19,12 +19,6 @@ namespace Unity.MLAgentsExamples
         {
             return new BasicSensor(basicController);
         }
-
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            return new[] { BasicController.k_Extents };
-        }
     }
 
     /// <summary>

--- a/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs
+++ b/Project/Assets/ML-Agents/Examples/SharedAssets/Scripts/SensorBase.cs
@@ -9,7 +9,7 @@ namespace Unity.MLAgentsExamples
     {
         /// <summary>
         /// Write the observations to the output buffer. This size of the buffer will be product
-        /// of the sizes returned by <see cref="GetObservationShape"/>.
+        /// of the Shape array values returned by <see cref="ObservationSpec"/>.
         /// </summary>
         /// <param name="output"></param>
         public abstract void WriteObservation(float[] output);
@@ -28,7 +28,7 @@ namespace Unity.MLAgentsExamples
         /// <returns>The number of elements written.</returns>
         public virtual int Write(ObservationWriter writer)
         {
-            // TODO reuse buffer for similar agents, don't call GetObservationShape()
+            // TODO reuse buffer for similar agents
             var numFloats = this.ObservationSize();
             float[] buffer = new float[numFloats];
             WriteObservation(buffer);

--- a/Project/Assets/ML-Agents/TestScenes/TestCompressedTexture/TestTextureSensorComponent.cs
+++ b/Project/Assets/ML-Agents/TestScenes/TestCompressedTexture/TestTextureSensorComponent.cs
@@ -32,21 +32,5 @@ public class TestTextureSensorComponent : SensorComponent
         }
         return m_Sensor;
     }
-
-    /// <inheritdoc/>
-    public override int[] GetObservationShape()
-    {
-        var width = TestTexture.width;
-        var height = TestTexture.height;
-        var observationShape = new[] { height, width, 3 };
-
-        var stacks = ObservationStacks > 1 ? ObservationStacks : 1;
-        if (stacks > 1)
-        {
-            observationShape[2] *= stacks;
-        }
-
-        return observationShape;
-    }
 }
 

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
@@ -27,19 +27,5 @@ namespace Unity.MLAgents.Extensions.Match3
             return new Match3Sensor(board, ObservationType, SensorName);
         }
 
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            var board = GetComponent<AbstractBoard>();
-            if (board == null)
-            {
-                return System.Array.Empty<int>();
-            }
-
-            var specialSize = board.NumSpecialTypes == 0 ? 0 : board.NumSpecialTypes + 1;
-            return ObservationType == Match3ObservationType.Vector ?
-                new[] { board.Rows * board.Columns * (board.NumCellTypes + specialSize) } :
-                new[] { board.Rows, board.Columns, board.NumCellTypes + specialSize };
-        }
     }
 }

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/ArticulationBodySensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/ArticulationBodySensorComponent.cs
@@ -21,26 +21,6 @@ namespace Unity.MLAgents.Extensions.Sensors
             return new PhysicsBodySensor(RootBody, Settings, sensorName);
         }
 
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            if (RootBody == null)
-            {
-                return new[] { 0 };
-            }
-
-            // TODO static method in PhysicsBodySensor?
-            // TODO only update PoseExtractor when body changes?
-            var poseExtractor = new ArticulationBodyPoseExtractor(RootBody);
-            var numPoseObservations = poseExtractor.GetNumPoseObservations(Settings);
-            var numJointObservations = 0;
-
-            foreach(var articBody in poseExtractor.GetEnabledArticulationBodies())
-            {
-                numJointObservations += ArticulationBodyJointExtractor.NumObservations(articBody, Settings);
-            }
-            return new[] { numPoseObservations + numJointObservations };
-        }
     }
 
 }

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/GridSensor.cs
@@ -918,13 +918,6 @@ namespace Unity.MLAgents.Extensions.Sensors
         }
 
         /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            var shape = m_ObservationSpec.Shape;
-            return new int[] { shape[0], shape[1], shape[2] };
-        }
-
-        /// <inheritdoc/>
         public int Write(ObservationWriter writer)
         {
             using (TimerStack.Instance.Scoped("GridSensor.WriteToTensor"))

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/PhysicsBodySensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/PhysicsBodySensor.cs
@@ -48,7 +48,7 @@ namespace Unity.MLAgents.Extensions.Sensors
         }
 
 #if UNITY_2020_1_OR_NEWER
-        public PhysicsBodySensor(ArticulationBody rootBody, PhysicsSensorSettings settings, string sensorName=null)
+        public PhysicsBodySensor(ArticulationBody rootBody, PhysicsSensorSettings settings, string sensorName = null)
         {
             var poseExtractor = new ArticulationBodyPoseExtractor(rootBody);
             m_PoseExtractor = poseExtractor;
@@ -57,7 +57,7 @@ namespace Unity.MLAgents.Extensions.Sensors
 
             var numJointExtractorObservations = 0;
             m_JointExtractors = new List<IJointExtractor>(poseExtractor.NumEnabledPoses);
-            foreach(var articBody in poseExtractor.GetEnabledArticulationBodies())
+            foreach (var articBody in poseExtractor.GetEnabledArticulationBodies())
             {
                 var jointExtractor = new ArticulationBodyJointExtractor(articBody);
                 numJointExtractorObservations += jointExtractor.NumObservations(settings);
@@ -67,6 +67,7 @@ namespace Unity.MLAgents.Extensions.Sensors
             var numTransformObservations = m_PoseExtractor.GetNumPoseObservations(settings);
             m_ObservationSpec = ObservationSpec.Vector(numTransformObservations + numJointExtractorObservations);
         }
+
 #endif
 
         /// <inheritdoc/>
@@ -126,6 +127,5 @@ namespace Unity.MLAgents.Extensions.Sensors
         {
             return BuiltInSensorType.PhysicsBodySensor;
         }
-
     }
 }

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
@@ -45,26 +45,6 @@ namespace Unity.MLAgents.Extensions.Sensors
             return new PhysicsBodySensor(GetPoseExtractor(), Settings, _sensorName);
         }
 
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            if (RootBody == null)
-            {
-                return new[] { 0 };
-            }
-
-            var poseExtractor = GetPoseExtractor();
-            var numPoseObservations = poseExtractor.GetNumPoseObservations(Settings);
-
-            var numJointObservations = 0;
-            foreach (var rb in poseExtractor.GetEnabledRigidbodies())
-            {
-                var joint = rb.GetComponent<Joint>();
-                numJointObservations += RigidBodyJointExtractor.NumObservations(rb, joint, Settings);
-            }
-            return new[] { numPoseObservations + numJointObservations };
-        }
-
         /// <summary>
         /// Get the DisplayNodes of the hierarchy.
         /// </summary>

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
@@ -18,7 +18,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVectorObservations()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -29,9 +29,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.Vector;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3 * 3 * 2 };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3 * 3 * 2);
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             var expectedObs = new float[]
             {
@@ -46,11 +45,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVectorObservationsSpecial()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var specialString =
-                @"010
+@"010
                   200
                   000";
 
@@ -63,9 +62,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.Vector;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3 * 3 * (2 + 3) };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3 * 3 * (2 + 3));
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             var expectedObs = new float[]
             {
@@ -76,12 +74,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             SensorTestHelper.CompareObservation(sensor, expectedObs);
         }
 
-
         [Test]
         public void TestVisualObservations()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -92,9 +89,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.UncompressedVisual;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3, 3, 2 };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3, 3, 2);
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             Assert.AreEqual(SensorCompressionType.None, sensor.GetCompressionSpec().SensorCompressionType);
 
@@ -119,11 +115,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVisualObservationsSpecial()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var specialString =
-                @"010
+@"010
                   200
                   000";
 
@@ -136,9 +132,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.UncompressedVisual;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3, 3, 2 + 3 };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3, 3, 2 + 3);
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             Assert.AreEqual(SensorCompressionType.None, sensor.GetCompressionSpec().SensorCompressionType);
 
@@ -163,7 +158,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestCompressedVisualObservations()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -174,9 +169,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.CompressedVisual;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3, 3, 2 };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3, 3, 2);
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             Assert.AreEqual(SensorCompressionType.PNG, sensor.GetCompressionSpec().SensorCompressionType);
 
@@ -191,17 +185,15 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             Assert.AreEqual(expectedPng, pngData);
         }
 
-
-
         [Test]
         public void TestCompressedVisualObservationsSpecial()
         {
             var boardString =
-                @"000
+@"000
                   000
                   010";
             var specialString =
-                @"010
+@"010
                   200
                   000";
 
@@ -214,9 +206,8 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             sensorComponent.ObservationType = Match3ObservationType.CompressedVisual;
             var sensor = sensorComponent.CreateSensor();
 
-            var expectedShape = new[] { 3, 3, 2 + 3 };
-            Assert.AreEqual(expectedShape, sensorComponent.GetObservationShape());
-            Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+            var expectedShape = new InplaceArray<int>(3, 3, 2 + 3);
+            Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
 
             Assert.AreEqual(SensorCompressionType.PNG, sensor.GetCompressionSpec().SensorCompressionType);
 
@@ -229,7 +220,6 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             }
             var expectedPng = LoadPNGs(pathPrefix, 2);
             Assert.AreEqual(expectedPng, concatenatedPngData);
-
         }
 
         /// <summary>
@@ -306,7 +296,6 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
             }
 
             return bytesOut.ToArray();
-
         }
     }
 }

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
@@ -18,7 +18,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVectorObservations()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -45,11 +45,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVectorObservationsSpecial()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var specialString =
-@"010
+                @"010
                   200
                   000";
 
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVisualObservations()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -115,11 +115,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestVisualObservationsSpecial()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var specialString =
-@"010
+                @"010
                   200
                   000";
 
@@ -158,7 +158,7 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestCompressedVisualObservations()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var gameObj = new GameObject("board");
@@ -189,11 +189,11 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
         public void TestCompressedVisualObservationsSpecial()
         {
             var boardString =
-@"000
+                @"000
                   000
                   010";
             var specialString =
-@"010
+                @"010
                   200
                   000";
 

--- a/com.unity.ml-agents.extensions/Tests/Editor/Sensors/ChannelHotShapeTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Sensors/ChannelHotShapeTests.cs
@@ -34,9 +34,8 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 1 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
-
+            var expectedShape = new InplaceArray<int>(10, 10, 1);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
         }
 
 
@@ -51,9 +50,8 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 2 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
-
+            var expectedShape = new InplaceArray<int>(10, 10, 2);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
         }
 
         [Test]
@@ -66,8 +64,8 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 3 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
+            var expectedShape = new InplaceArray<int>(10, 10, 3);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
 
         }
 
@@ -81,9 +79,8 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 6 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
-
+            var expectedShape = new InplaceArray<int>(10, 10, 6);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
         }
 
     }

--- a/com.unity.ml-agents.extensions/Tests/Editor/Sensors/ChannelShapeTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Sensors/ChannelShapeTests.cs
@@ -34,8 +34,9 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 1 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
+            var expectedShape = new InplaceArray<int>(10, 10, 1);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
+
         }
 
         [Test]
@@ -48,8 +49,9 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 2 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
+            var expectedShape = new InplaceArray<int>(10, 10, 2);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
+
         }
 
         [Test]
@@ -62,8 +64,9 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 1f, 1f, 10, 10, LayerMask.GetMask("Default"), false, colors);
             gridSensor.Start();
 
-            int[] expectedShape = { 10, 10, 7 };
-            GridObsTestUtils.AssertArraysAreEqual(expectedShape, gridSensor.GetObservationShape());
+            var expectedShape = new InplaceArray<int>(10, 10, 7);
+            Assert.AreEqual(expectedShape, gridSensor.GetObservationSpec().Shape);
+
         }
     }
 }

--- a/com.unity.ml-agents.extensions/Tests/Editor/Sensors/GridSensorTestUtils.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Sensors/GridSensorTestUtils.cs
@@ -66,33 +66,6 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
             return duplicated;
         }
 
-        /// <summary>
-        /// Asserts that 2 int arrays are the same
-        /// </summary>
-        /// <param name="expected">The expected array</param>
-        /// <param name="actual">The actual array</param>
-        public static void AssertArraysAreEqual(int[] expected, int[] actual)
-        {
-            Assert.AreEqual(expected.Length, actual.Length, "Lengths are not the same");
-            for (int i = 0; i < actual.Length; i++)
-            {
-                Assert.AreEqual(expected[i], actual[i], "Got " + Array2Str(actual) + ", expected " + Array2Str(expected));
-            }
-        }
-
-        /// <summary>
-        /// Asserts that 2 float arrays are the same
-        /// </summary>
-        /// <param name="expected">The expected array</param>
-        /// <param name="actual">The actual array</param>
-        public static void AssertArraysAreEqual(float[] expected, float[] actual)
-        {
-            Assert.AreEqual(expected.Length, actual.Length, "Lengths are not the same");
-            for (int i = 0; i < actual.Length; i++)
-            {
-                Assert.AreEqual(expected[i], actual[i], "Got " + Array2Str(actual) + ", expected " + Array2Str(expected));
-            }
-        }
 
         /// <summary>
         /// Asserts that the sub-arrays of the total array are equal to specific subarrays at specific subarray indicies and equal to a default everywhere else.

--- a/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/ArticulationBodySensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/ArticulationBodySensorTests.cs
@@ -42,7 +42,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 0f, 0f, 0f, 1f // LocalSpaceRotations
             };
             SensorTestHelper.CompareObservation(sensor, expected);
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
 #endif
             };
             SensorTestHelper.CompareObservation(sensor, expected);
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
 
             // Update the settings to only process joint observations
             sensorComponent.Settings = new PhysicsSensorSettings
@@ -133,7 +133,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 0f, // joint2.force
             };
             SensorTestHelper.CompareObservation(sensor, expected);
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
         }
     }
 }

--- a/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/RigidBodySensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/RigidBodySensorTests.cs
@@ -56,7 +56,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
             // The root body is ignored since it always generates identity values
             // and there are no other bodies to generate observations.
             var expected = new float[0];
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
             SensorTestHelper.CompareObservation(sensor, expected);
         }
 
@@ -115,7 +115,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 -1f, 1f, 0f, // Attached vel
                 0f, -1f, 1f // Leaf vel
             };
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
             SensorTestHelper.CompareObservation(sensor, expected);
 
             // Update the settings to only process joint observations
@@ -136,7 +136,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 0f, 0f, 0f, // joint2.torque
             };
             SensorTestHelper.CompareObservation(sensor, expected);
-            Assert.AreEqual(expected.Length, sensorComponent.GetObservationShape()[0]);
+            Assert.AreEqual(expected.Length, sensorComponent.CreateSensor().GetObservationSpec().Shape[0]);
 
         }
     }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -22,6 +22,7 @@ details.
 and `IDimensionPropertiesSensor` interfaces were removed. (#5127)
 - `ISensor.GetCompressionType()` was removed, and `GetCompressionSpec()` was added. The `ISparseChannelSensor`
 interface was removed. (#5164)
+- The abstract method `SensorComponent.GetObservationShape()` was no longer being called, so it has been removed. (#5172)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 

--- a/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Communicator/GrpcExtensions.cs
@@ -532,7 +532,7 @@ namespace Unity.MLAgents
                 NumNetworkHiddenUnits = inputProto.NumNetworkHiddenUnits,
             };
         }
-        #endregion
 
+        #endregion
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensor.cs
@@ -110,7 +110,5 @@ namespace Unity.MLAgents.Sensors
         {
             return BuiltInSensorType.BufferSensor;
         }
-
     }
-
 }

--- a/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BufferSensorComponent.cs
@@ -55,12 +55,6 @@ namespace Unity.MLAgents.Sensors
             return m_Sensor;
         }
 
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            return new[] { MaxNumObservables, ObservableSize };
-        }
-
         /// <summary>
         /// Appends an observation to the buffer. If the buffer is full (maximum number
         /// of observation is reached) the observation will be ignored. the length of

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -197,6 +197,5 @@ namespace Unity.MLAgents.Sensors
         {
             return BuiltInSensorType.CameraSensor;
         }
-
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -118,21 +118,6 @@ namespace Unity.MLAgents.Sensors
         }
 
         /// <summary>
-        /// Computes the observation shape of the sensor.
-        /// </summary>
-        /// <returns>The observation shape of the associated <see cref="CameraSensor"/> object.</returns>
-        public override int[] GetObservationShape()
-        {
-            var stacks = ObservationStacks > 1 ? ObservationStacks : 1;
-            var cameraSensorshape = CameraSensor.GenerateShape(m_Width, m_Height, Grayscale);
-            if (stacks > 1)
-            {
-                cameraSensorshape[cameraSensorshape.Length - 1] *= stacks;
-            }
-            return cameraSensorshape;
-        }
-
-        /// <summary>
         /// Update fields that are safe to change on the Sensor at runtime.
         /// </summary>
         internal void UpdateSensor()

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -220,20 +220,6 @@ namespace Unity.MLAgents.Sensors
         }
 
         /// <summary>
-        /// Returns the observation shape for this raycast sensor which depends on the number
-        /// of tags for detected objects and the number of rays.
-        /// </summary>
-        /// <returns></returns>
-        public override int[] GetObservationShape()
-        {
-            var numRays = 2 * RaysPerDirection + 1;
-            var numTags = m_DetectableTags?.Count ?? 0;
-            var obsSize = (numTags + 2) * numRays;
-            var stacks = ObservationStacks > 1 ? ObservationStacks : 1;
-            return new[] { obsSize * stacks };
-        }
-
-        /// <summary>
         /// Get the RayPerceptionInput that is used by the <see cref="RayPerceptionSensor"/>.
         /// </summary>
         /// <returns></returns>

--- a/com.unity.ml-agents/Runtime/Sensors/Reflection/ReflectionSensorBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/Reflection/ReflectionSensorBase.cs
@@ -107,6 +107,5 @@ namespace Unity.MLAgents.Sensors.Reflection
         {
             return BuiltInSensorType.ReflectionSensor;
         }
-
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -99,7 +99,6 @@ namespace Unity.MLAgents.Sensors
             return BuiltInSensorType.RenderTextureSensor;
         }
 
-
         /// <summary>
         /// Converts a RenderTexture to a 2D texture.
         /// </summary>

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -92,22 +92,6 @@ namespace Unity.MLAgents.Sensors
             return m_Sensor;
         }
 
-        /// <inheritdoc/>
-        public override int[] GetObservationShape()
-        {
-            var width = RenderTexture != null ? RenderTexture.width : 0;
-            var height = RenderTexture != null ? RenderTexture.height : 0;
-            var observationShape = new[] { height, width, Grayscale ? 1 : 3 };
-
-            var stacks = ObservationStacks > 1 ? ObservationStacks : 1;
-            if (stacks > 1)
-            {
-                observationShape[2] *= stacks;
-            }
-
-            return observationShape;
-        }
-
         /// <summary>
         /// Update fields that are safe to change on the Sensor at runtime.
         /// </summary>

--- a/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
@@ -14,12 +14,5 @@ namespace Unity.MLAgents.Sensors
         /// </summary>
         /// <returns>Created ISensor object.</returns>
         public abstract ISensor CreateSensor();
-
-        /// <summary>
-        /// Returns the shape of the sensor observations that will be created.
-        /// </summary>
-        /// <returns>Shape of the sensor observation.</returns>
-        public abstract int[] GetObservationShape();
-
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/Analytics/TrainingAnalyticsTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Analytics/TrainingAnalyticsTest.cs
@@ -77,7 +77,6 @@ namespace Unity.MLAgents.Tests.Analytics
 #else
             Assert.IsFalse(TrainingAnalytics.EnableAnalytics());
 #endif
-
         }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/Inference/ParameterLoaderTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/Inference/ParameterLoaderTest.cs
@@ -18,13 +18,8 @@ namespace Unity.MLAgents.Tests
         {
             return Sensor;
         }
-
-        public override int[] GetObservationShape()
-        {
-            var shape = Sensor.GetObservationSpec().Shape;
-            return new int[] { shape[0], shape[1], shape[2] };
-        }
     }
+
     public class Test3DSensor : ISensor, IBuiltInSensor
     {
         int m_Width;

--- a/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
+++ b/com.unity.ml-agents/Tests/Editor/MLAgentsEditModeTest.cs
@@ -13,7 +13,6 @@ using Unity.MLAgents.Utils.Tests;
 
 namespace Unity.MLAgents.Tests
 {
-
     [TestFixture]
     public class EditModeTestGeneration
     {

--- a/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/RuntimeAPITest.cs
@@ -37,17 +37,6 @@ namespace Tests
             var wrappedSensor = wrappedComponent.CreateSensor();
             return new StackingSensor(wrappedSensor, numStacks);
         }
-
-        public override int[] GetObservationShape()
-        {
-            int[] shape = (int[])wrappedComponent.GetObservationShape().Clone();
-            for (var i = 0; i < shape.Length; i++)
-            {
-                shape[i] *= numStacks;
-            }
-
-            return shape;
-        }
     }
 
     public class RuntimeApiTest

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/BufferSensorTest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/BufferSensorTest.cs
@@ -56,7 +56,7 @@ namespace Unity.MLAgents.Tests
             bufferComponent.SensorName = "TestName";
 
             var sensor = bufferComponent.CreateSensor();
-            var shape = bufferComponent.GetObservationShape();
+            var shape = sensor.GetObservationSpec().Shape;
 
             Assert.AreEqual(shape[0], 20);
             Assert.AreEqual(shape[1], 4);
@@ -68,7 +68,7 @@ namespace Unity.MLAgents.Tests
             var obsWriter = new ObservationWriter();
             var obs = sensor.GetObservationProto(obsWriter);
 
-            Assert.AreEqual(shape, obs.Shape);
+            Assert.AreEqual(shape, InplaceArray<int>.FromList(obs.Shape));
             Assert.AreEqual(obs.DimensionProperties.Count, 2);
 
             Assert.AreEqual(sensor.GetName(), "TestName");

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorComponentTest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorComponentTest.cs
@@ -29,12 +29,9 @@ namespace Unity.MLAgents.Tests
                     cameraComponent.Grayscale = grayscale;
                     cameraComponent.CompressionType = compression;
 
-                    var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
-                    Assert.AreEqual(expectedShape, cameraComponent.GetObservationShape());
-
                     var sensor = cameraComponent.CreateSensor();
-                    var expectedShapeInplace = new InplaceArray<int>(height, width, grayscale ? 1 : 3);
-                    Assert.AreEqual(expectedShapeInplace, sensor.GetObservationSpec().Shape);
+                    var expectedShape = new InplaceArray<int>(height, width, grayscale ? 1 : 3);
+                    Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
                     Assert.AreEqual(typeof(CameraSensor), sensor.GetType());
                 }
             }

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/RenderTextureSensorComponentTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/RenderTextureSensorComponentTests.cs
@@ -26,11 +26,10 @@ namespace Unity.MLAgents.Tests
                     renderTexComponent.Grayscale = grayscale;
                     renderTexComponent.CompressionType = compression;
 
-                    var expectedShape = new[] { height, width, grayscale ? 1 : 3 };
-                    Assert.AreEqual(expectedShape, renderTexComponent.GetObservationShape());
+                    var expectedShape = new InplaceArray<int>(height, width, grayscale ? 1 : 3);
 
                     var sensor = renderTexComponent.CreateSensor();
-                    Assert.AreEqual(InplaceArray<int>.FromList(expectedShape), sensor.GetObservationSpec().Shape);
+                    Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
                     Assert.AreEqual(typeof(RenderTextureSensor), sensor.GetType());
                 }
             }

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/SensorShapeValidatorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/SensorShapeValidatorTests.cs
@@ -58,7 +58,6 @@ namespace Unity.MLAgents.Tests
 
     public class SensorShapeValidatorTests
     {
-
         [Test]
         public void TestShapesAgree()
         {
@@ -87,6 +86,7 @@ namespace Unity.MLAgents.Tests
             LogAssert.Expect(LogType.Assert, "Number of Sensors must match. 2 != 3");
             validator.ValidateSensors(sensorList1);
         }
+
         [Test]
         public void TestDimensionMismatch()
         {

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/StackingSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/StackingSensorTests.cs
@@ -166,7 +166,6 @@ namespace Unity.MLAgents.Tests
             {
                 return "Dummy";
             }
-
         }
 
         [Test]

--- a/com.unity.ml-agents/Tests/Runtime/Utils/TestClasses.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Utils/TestClasses.cs
@@ -165,6 +165,5 @@ namespace Unity.MLAgents.Utils.Tests
 
     public class TestClasses
     {
-
     }
 }

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -44,9 +44,11 @@ public override void WriteDiscreteActionMask(IDiscreteActionMask actionMask)
     actionMask.SetActionEnabled(branch, 3, false);
 }
 ```
+### IActuator changes
 - The `IActuator` interface now implements `IHeuristicProvider`.  Please add the corresponding `Heuristic(in ActionBuffers)`
 method to your custom Actuator classes.
 
+### ISensor and SensorComponent changes
 - The `ISensor.GetObservationShape()` method and `ITypedSensor`
 and `IDimensionPropertiesSensor` interfaces were removed, and `GetObservationSpec()` was added. You can use
 `ObservationSpec.Vector()` or `ObservationSpec.Visual()` to generate `ObservationSpec`s that are equivalent to
@@ -87,6 +89,8 @@ public CompressionSpec GetCompressionSpec()
     return CompressionSpec.Default();
 }
 ```
+
+- The abstract method `SensorComponent.GetObservationShape()` was removed.
 
 ## Migrating to Release 13
 ### Implementing IHeuristic in your IActuator implementations


### PR DESCRIPTION
### Proposed change(s)
This started out as a change to replace GetObservationShape() with an ObservationSpec. But we stopped calling GetObservationShape when checking models a while ago, and now just create the sensor. So remove the whole thing from the interface.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)


### Types of change(s)
- [ ] Code refactor
- [ ] Breaking change

### Checklist
- [n/a] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [n/a ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
