### PR TITLE
Change default barracuda behavior

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -32,6 +32,9 @@ interface was removed. (#5164)
 - Added ML-Agents package settings. (#5027)
 - Make com.unity.modules.unityanalytics an optional dependency. (#5109)
 - Make com.unity.modules.physics and com.unity.modules.physics2d optional dependencies. (#5112)
+- The default `InferenceDevice` is now `InferenceDevice.Default`, which is equivalent to `InferenceDevice.Burst`. If you
+depend on the previous behavior, you can explicitly set the Agent's `InferenceDevice` to `InferenceDevice.CPU`. (#5175)
+
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ### Bug Fixes

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -617,7 +617,7 @@ namespace Unity.MLAgents
         public void SetModel(
             string behaviorName,
             NNModel model,
-            InferenceDevice inferenceDevice = InferenceDevice.CPU)
+            InferenceDevice inferenceDevice = InferenceDevice.Default)
         {
             if (behaviorName == m_PolicyFactory.BehaviorName &&
                 model == m_PolicyFactory.Model &&

--- a/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
@@ -83,6 +83,7 @@ namespace Unity.MLAgents.Inference
                     case InferenceDevice.Burst:
                         executionDevice = WorkerFactory.Type.CSharpBurst;
                         break;
+                    case InferenceDevice.Default: // fallthrough
                     default:
                         executionDevice = WorkerFactory.Type.CSharpBurst;
                         break;

--- a/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BarracudaPolicy.cs
@@ -13,10 +13,9 @@ namespace Unity.MLAgents.Policies
     public enum InferenceDevice
     {
         /// <summary>
-        /// CPU inference. Corresponds to in WorkerFactory.Type.CSharp Barracuda.
-        /// Burst is recommended instead; this is kept for legacy compatibility.
+        /// Default inference. This is currently the same as Burst, but may change in the future.
         /// </summary>
-        CPU = 0,
+        Default = 0,
 
         /// <summary>
         /// GPU inference. Corresponds to WorkerFactory.Type.ComputePrecompiled in Barracuda.
@@ -27,6 +26,12 @@ namespace Unity.MLAgents.Policies
         /// CPU inference using Burst. Corresponds to WorkerFactory.Type.CSharpBurst in Barracuda.
         /// </summary>
         Burst = 2,
+
+        /// <summary>
+        /// CPU inference. Corresponds to in WorkerFactory.Type.CSharp Barracuda.
+        /// Burst is recommended instead; this is kept for legacy compatibility.
+        /// </summary>
+        CPU = 3,
     }
 
     /// <summary>

--- a/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BehaviorParameters.cs
@@ -109,7 +109,7 @@ namespace Unity.MLAgents.Policies
         }
 
         [HideInInspector, SerializeField]
-        InferenceDevice m_InferenceDevice = InferenceDevice.Burst;
+        InferenceDevice m_InferenceDevice = InferenceDevice.Default;
 
         /// <summary>
         /// How inference is performed for this Agent's model.


### PR DESCRIPTION
### Proposed change(s)
https://github.com/Unity-Technologies/ml-agents/pull/4925 added InferenceDevice.Burst, but we couldn't change the behavior of assets that use InferenceDevice.CPU in a minor release.

This renames the 0 value of InferenceDevice, which will behave the same as InferenceDevice.Burst. It's still possible to force the old behavior as a fallback (and if you're setting InferenceDevice.CPU in code, this doesn't change anything).

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)
- [x] Code refactor
- [x] Breaking change

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
