### PR TITLE
Renaming Goal to GoalSignal

### DIFF
--- a/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Observation.cs
+++ b/com.unity.ml-agents/Runtime/Grpc/CommunicatorObjects/Observation.cs
@@ -35,10 +35,10 @@ namespace Unity.MLAgents.CommunicatorObjects {
             "b25fdHlwZRgHIAEoDjIqLmNvbW11bmljYXRvcl9vYmplY3RzLk9ic2VydmF0",
             "aW9uVHlwZVByb3RvEgwKBG5hbWUYCCABKAkaGQoJRmxvYXREYXRhEgwKBGRh",
             "dGEYASADKAJCEgoQb2JzZXJ2YXRpb25fZGF0YSopChRDb21wcmVzc2lvblR5",
-            "cGVQcm90bxIICgROT05FEAASBwoDUE5HEAEqRgoUT2JzZXJ2YXRpb25UeXBl",
-            "UHJvdG8SCwoHREVGQVVMVBAAEggKBEdPQUwQARIKCgZSRVdBUkQQAhILCgdN",
-            "RVNTQUdFEANCJaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11bmljYXRvck9iamVj",
-            "dHNiBnByb3RvMw=="));
+            "cGVQcm90bxIICgROT05FEAASBwoDUE5HEAEqQAoUT2JzZXJ2YXRpb25UeXBl",
+            "UHJvdG8SCwoHREVGQVVMVBAAEg8KC0dPQUxfU0lHTkFMEAEiBAgCEAIiBAgD",
+            "EANCJaoCIlVuaXR5Lk1MQWdlbnRzLkNvbW11bmljYXRvck9iamVjdHNiBnBy",
+            "b3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Unity.MLAgents.CommunicatorObjects.CompressionTypeProto), typeof(global::Unity.MLAgents.CommunicatorObjects.ObservationTypeProto), }, new pbr::GeneratedClrTypeInfo[] {
@@ -56,9 +56,7 @@ namespace Unity.MLAgents.CommunicatorObjects {
 
   internal enum ObservationTypeProto {
     [pbr::OriginalName("DEFAULT")] Default = 0,
-    [pbr::OriginalName("GOAL")] Goal = 1,
-    [pbr::OriginalName("REWARD")] Reward = 2,
-    [pbr::OriginalName("MESSAGE")] Message = 3,
+    [pbr::OriginalName("GOAL_SIGNAL")] GoalSignal = 1,
   }
 
   #endregion

--- a/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ISensor.cs
@@ -58,7 +58,7 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// Collected observations contain goal information.
         /// </summary>
-        Goal = 1,
+        GoalSignal = 1,
     }
 
     /// <summary>

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorTest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorTest.cs
@@ -50,9 +50,9 @@ namespace Unity.MLAgents.Tests
             sensor = new CameraSensor(camera, width, height, true, "TestCameraSensor", SensorCompressionType.None, ObservationType.Default);
             spec = sensor.GetObservationSpec();
             Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.Default);
-            sensor = new CameraSensor(camera, width, height, true, "TestCameraSensor", SensorCompressionType.None, ObservationType.Goal);
+            sensor = new CameraSensor(camera, width, height, true, "TestCameraSensor", SensorCompressionType.None, ObservationType.GoalSignal);
             spec = sensor.GetObservationSpec();
-            Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.Goal);
+            Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.GoalSignal);
         }
     }
 }

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/VectorSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/VectorSensorTests.cs
@@ -51,9 +51,9 @@ namespace Unity.MLAgents.Tests
             sensor = new VectorSensor(1, observationType: ObservationType.Default);
             spec = sensor.GetObservationSpec();
             Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.Default);
-            sensor = new VectorSensor(1, observationType: ObservationType.Goal);
+            sensor = new VectorSensor(1, observationType: ObservationType.GoalSignal);
             spec = sensor.GetObservationSpec();
-            Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.Goal);
+            Assert.AreEqual((int)spec.ObservationType, (int)ObservationType.GoalSignal);
         }
 
         [Test]

--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -486,7 +486,7 @@ class ObservationType(Enum):
     # Observation information is generic.
     DEFAULT = 0
     # Observation contains goal information for current task.
-    GOAL = 1
+    GOAL_SIGNAL = 1
 
 
 class ObservationSpec(NamedTuple):

--- a/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.py
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mlagents_envs/communicator_objects/observation.proto',
   package='communicator_objects',
   syntax='proto3',
-  serialized_pb=_b('\n4mlagents_envs/communicator_objects/observation.proto\x12\x14\x63ommunicator_objects\"\x8f\x03\n\x10ObservationProto\x12\r\n\x05shape\x18\x01 \x03(\x05\x12\x44\n\x10\x63ompression_type\x18\x02 \x01(\x0e\x32*.communicator_objects.CompressionTypeProto\x12\x19\n\x0f\x63ompressed_data\x18\x03 \x01(\x0cH\x00\x12\x46\n\nfloat_data\x18\x04 \x01(\x0b\x32\x30.communicator_objects.ObservationProto.FloatDataH\x00\x12\"\n\x1a\x63ompressed_channel_mapping\x18\x05 \x03(\x05\x12\x1c\n\x14\x64imension_properties\x18\x06 \x03(\x05\x12\x44\n\x10observation_type\x18\x07 \x01(\x0e\x32*.communicator_objects.ObservationTypeProto\x12\x0c\n\x04name\x18\x08 \x01(\t\x1a\x19\n\tFloatData\x12\x0c\n\x04\x64\x61ta\x18\x01 \x03(\x02\x42\x12\n\x10observation_data*)\n\x14\x43ompressionTypeProto\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03PNG\x10\x01*F\n\x14ObservationTypeProto\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\x08\n\x04GOAL\x10\x01\x12\n\n\x06REWARD\x10\x02\x12\x0b\n\x07MESSAGE\x10\x03\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
+  serialized_pb=_b('\n4mlagents_envs/communicator_objects/observation.proto\x12\x14\x63ommunicator_objects\"\x8f\x03\n\x10ObservationProto\x12\r\n\x05shape\x18\x01 \x03(\x05\x12\x44\n\x10\x63ompression_type\x18\x02 \x01(\x0e\x32*.communicator_objects.CompressionTypeProto\x12\x19\n\x0f\x63ompressed_data\x18\x03 \x01(\x0cH\x00\x12\x46\n\nfloat_data\x18\x04 \x01(\x0b\x32\x30.communicator_objects.ObservationProto.FloatDataH\x00\x12\"\n\x1a\x63ompressed_channel_mapping\x18\x05 \x03(\x05\x12\x1c\n\x14\x64imension_properties\x18\x06 \x03(\x05\x12\x44\n\x10observation_type\x18\x07 \x01(\x0e\x32*.communicator_objects.ObservationTypeProto\x12\x0c\n\x04name\x18\x08 \x01(\t\x1a\x19\n\tFloatData\x12\x0c\n\x04\x64\x61ta\x18\x01 \x03(\x02\x42\x12\n\x10observation_data*)\n\x14\x43ompressionTypeProto\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03PNG\x10\x01*@\n\x14ObservationTypeProto\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\x0f\n\x0bGOAL_SIGNAL\x10\x01\"\x04\x08\x02\x10\x02\"\x04\x08\x03\x10\x03\x42%\xaa\x02\"Unity.MLAgents.CommunicatorObjectsb\x06proto3')
 )
 
 _COMPRESSIONTYPEPROTO = _descriptor.EnumDescriptor(
@@ -57,22 +57,14 @@ _OBSERVATIONTYPEPROTO = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='GOAL', index=1, number=1,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='REWARD', index=2, number=2,
-      options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='MESSAGE', index=3, number=3,
+      name='GOAL_SIGNAL', index=1, number=1,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
   serialized_start=523,
-  serialized_end=593,
+  serialized_end=587,
 )
 _sym_db.RegisterEnumDescriptor(_OBSERVATIONTYPEPROTO)
 
@@ -80,9 +72,7 @@ ObservationTypeProto = enum_type_wrapper.EnumTypeWrapper(_OBSERVATIONTYPEPROTO)
 NONE = 0
 PNG = 1
 DEFAULT = 0
-GOAL = 1
-REWARD = 2
-MESSAGE = 3
+GOAL_SIGNAL = 1
 
 
 

--- a/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.pyi
+++ b/ml-agents-envs/mlagents_envs/communicator_objects/observation_pb2.pyi
@@ -64,13 +64,9 @@ class ObservationTypeProto(builtin___int):
     @classmethod
     def items(cls) -> typing___List[typing___Tuple[builtin___str, 'ObservationTypeProto']]: ...
     DEFAULT = typing___cast('ObservationTypeProto', 0)
-    GOAL = typing___cast('ObservationTypeProto', 1)
-    REWARD = typing___cast('ObservationTypeProto', 2)
-    MESSAGE = typing___cast('ObservationTypeProto', 3)
+    GOAL_SIGNAL = typing___cast('ObservationTypeProto', 1)
 DEFAULT = typing___cast('ObservationTypeProto', 0)
-GOAL = typing___cast('ObservationTypeProto', 1)
-REWARD = typing___cast('ObservationTypeProto', 2)
-MESSAGE = typing___cast('ObservationTypeProto', 3)
+GOAL_SIGNAL = typing___cast('ObservationTypeProto', 1)
 
 class ObservationProto(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...

--- a/protobuf-definitions/proto/mlagents_envs/communicator_objects/observation.proto
+++ b/protobuf-definitions/proto/mlagents_envs/communicator_objects/observation.proto
@@ -10,9 +10,9 @@ enum CompressionTypeProto {
 
 enum ObservationTypeProto {
     DEFAULT = 0;
-    GOAL = 1;
-    REWARD = 2;
-    MESSAGE = 3;
+    GOAL_SIGNAL = 1;
+    reserved 2; // Reserved for potential "reward" type
+    reserved 3; // Reserved for potential "message" type
 }
 
 message ObservationProto {


### PR DESCRIPTION
### Proposed change(s)

Renamed the ObservationType GOAL to GOAL_SIGNAL
Removed the proto observation types that were unused.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
