### PR TITLE
[perf] Optimizations for performance

### DIFF
--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -430,7 +430,7 @@ class AgentBuffer(MutableMapping):
             * sequence_length
         )  # Sample random sequence starts
         for key in self:
-            mb_list = [self[key][i : i + sequence_length] for i in start_idxes]
+            mb_list = (self[key][i : i + sequence_length] for i in start_idxes)
             # See comparison of ways to make a list from a list of lists here:
             # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
             mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))

--- a/ml-agents/mlagents/trainers/buffer.py
+++ b/ml-agents/mlagents/trainers/buffer.py
@@ -394,10 +394,11 @@ class AgentBuffer(MutableMapping):
         s = np.arange(len(self[key_list[0]]) // sequence_length)
         np.random.shuffle(s)
         for key in key_list:
+            buffer_field = self[key]
             tmp: List[np.ndarray] = []
             for i in s:
-                tmp += self[key][i * sequence_length : (i + 1) * sequence_length]
-            self[key][:] = tmp
+                tmp += buffer_field[i * sequence_length : (i + 1) * sequence_length]
+            buffer_field.set(tmp)
 
     def make_mini_batch(self, start: int, end: int) -> "AgentBuffer":
         """
@@ -430,7 +431,8 @@ class AgentBuffer(MutableMapping):
             * sequence_length
         )  # Sample random sequence starts
         for key in self:
-            mb_list = (self[key][i : i + sequence_length] for i in start_idxes)
+            buffer_field = self[key]
+            mb_list = (buffer_field[i : i + sequence_length] for i in start_idxes)
             # See comparison of ways to make a list from a list of lists here:
             # https://stackoverflow.com/questions/952914/how-to-make-a-flat-list-out-of-list-of-lists
             mini_batch[key].set(list(itertools.chain.from_iterable(mb_list)))

--- a/ml-agents/mlagents/trainers/trajectory.py
+++ b/ml-agents/mlagents/trainers/trajectory.py
@@ -246,13 +246,13 @@ class Trajectory(NamedTuple):
                 exp.action.discrete
             )
 
-            cont_next_actions = np.zeros_like(exp.action.continuous)
-            disc_next_actions = np.zeros_like(exp.action.discrete)
-
             if not is_last_step:
                 next_action = self.steps[step + 1].action
                 cont_next_actions = next_action.continuous
                 disc_next_actions = next_action.discrete
+            else:
+                cont_next_actions = np.zeros_like(exp.action.continuous)
+                disc_next_actions = np.zeros_like(exp.action.discrete)
 
             agent_buffer_trajectory[BufferKey.NEXT_CONT_ACTION].append(
                 cont_next_actions


### PR DESCRIPTION
### Proposed change(s)

Optimizations for performance, namely:

- Don't create unneeded numpy arrays when converting trajectories. This cuts out maybe 20-30% of runtime for the conversion.
- Copy normalization by reference rather than in-place. This is much faster, especially on GPU, and we're already making the new tensors during compute anyway. 
- Use a generator comprehension rather than list comprehension in buffer sample. This is almost 50% faster for sampling

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (performance optimization)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
