### PR TITLE
Logging lesson number at the beginning of training

### DIFF
--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -103,6 +103,35 @@ class EnvironmentParameterManager:
             )
         return result
 
+    def log_current_lesson(self, parameter_name: Optional[str] = None) -> None:
+        """
+        Logs the current lesson number and sampler value of the parameter with name
+        parameter_name. If no parameter_name is provided, the values and lesson
+        numbers of all parameters will be displayed.
+        """
+        if parameter_name is not None:
+            settings = self._dict_settings[parameter_name]
+            lesson_number = GlobalTrainingStatus.get_parameter_state(
+                parameter_name, StatusType.LESSON_NUM
+            )
+            lesson_name = settings.curriculum[lesson_number].name
+            lesson_value = settings.curriculum[lesson_number].value
+            logger.info(
+                f"Parameter '{parameter_name}' is in lesson '{lesson_name}' "
+                f"and has value '{lesson_value}'."
+            )
+        else:
+            for parameter_name, settings in self._dict_settings.items():
+                lesson_number = GlobalTrainingStatus.get_parameter_state(
+                    parameter_name, StatusType.LESSON_NUM
+                )
+                lesson_name = settings.curriculum[lesson_number].name
+                lesson_value = settings.curriculum[lesson_number].value
+                logger.info(
+                    f"Parameter '{parameter_name}' is in lesson '{lesson_name}' "
+                    f"and has value '{lesson_value}'."
+                )
+
     def update_lessons(
         self,
         trainer_steps: Dict[str, int],
@@ -147,13 +176,7 @@ class EnvironmentParameterManager:
                         GlobalTrainingStatus.set_parameter_state(
                             param_name, StatusType.LESSON_NUM, next_lesson_num
                         )
-                        new_lesson_name = settings.curriculum[next_lesson_num].name
-                        new_lesson_value = settings.curriculum[next_lesson_num].value
-
-                        logger.info(
-                            f"Parameter '{param_name}' has been updated to {new_lesson_value}."
-                            + f" Now in lesson '{new_lesson_name}'"
-                        )
+                        self.log_current_lesson(param_name)
                         updated = True
                         if lesson.completion_criteria.require_reset:
                             must_reset = True

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -171,6 +171,7 @@ class TrainerController:
         try:
             # Initial reset
             self._reset_env(env_manager)
+            self.param_manager.log_current_lesson()
             while self._not_done_training():
                 n_steps = self.advance(env_manager)
                 for _ in range(n_steps):


### PR DESCRIPTION
### Proposed change(s)

Add a method to `EnvironmentParameterManager` to log the current lesson number. This method can later be expanded to use another type of logging (currently just using logger.info)
Call this method at the start of training and when a lesson changes.

This results in the lesson being logged at the beginning of training, in addition to the current behavior which is to log only at lesson update.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
