### PR TITLE
[🐛 🔨 ] Fixing the GymWrapper Logging issue

### DIFF
--- a/ml-agents-envs/mlagents_envs/logging_util.py
+++ b/ml-agents-envs/mlagents_envs/logging_util.py
@@ -1,4 +1,5 @@
 import logging  # noqa I251
+import sys
 
 CRITICAL = logging.CRITICAL
 FATAL = logging.FATAL
@@ -20,10 +21,14 @@ def get_logger(name: str) -> logging.Logger:
     specified by set_log_level()
     """
     logger = logging.getLogger(name=name)
-
     # If we've already set the log level, make sure new loggers use it
     if _log_level != NOTSET:
         logger.setLevel(_log_level)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     # Keep track of this logger so that we can change the log level later
     _loggers.add(logger)
@@ -36,11 +41,6 @@ def set_log_level(log_level: int) -> None:
     """
     global _log_level
     _log_level = log_level
-
-    # Configure the log format.
-    # In theory, this would be sufficient, but if another library calls logging.basicConfig
-    # first, it doesn't have any effect.
-    logging.basicConfig(level=_log_level, format=LOG_FORMAT, datefmt=DATE_FORMAT)
 
     for logger in _loggers:
         logger.setLevel(log_level)


### PR DESCRIPTION
### Proposed change(s)

Fixing [This bug](https://github.com/Unity-Technologies/ml-agents/issues/4987)

I made sure mlagents-learn was still printing the right things and made sure importing `UnityToGymWrapper` did not cause issues : 

This code :
```
import logging
import sys

from gym_unity.envs import UnityToGymWrapper

def create_logger(name, loglevel):
    logger = logging.getLogger(name)
    logger.setLevel(loglevel)
    handler = logging.StreamHandler(stream=sys.stdout)
    formatter = logging.Formatter(fmt=f'%(asctime)s - {name} - %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
    handler.setFormatter(formatter)
    logger.addHandler(handler)
    return logger

if __name__ == "__main__":
    logger = create_logger(name="USER LOGGER", loglevel=logging.INFO)
    for i in range(10):
        logger.info(f"i={i}")
```

Now prints to console only once per logger.info calls.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
