### PR TITLE
[🐛 🔨 ]Adding the ELO to the GlobalTrainingStatus

### DIFF
--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -129,7 +129,6 @@ class GhostTrainer(Trainer):
         self.last_swap: int = 0
         self.last_team_change: int = 0
 
-        # Chosen because it is the initial ELO in Chess
         self.initial_elo = GlobalTrainingStatus.get_parameter_state(
             self.brain_name, StatusType.ELO
         )

--- a/ml-agents/mlagents/trainers/ghost/trainer.py
+++ b/ml-agents/mlagents/trainers/ghost/trainer.py
@@ -18,6 +18,7 @@ from mlagents.trainers.behavior_id_utils import (
     BehaviorIdentifiers,
     create_name_behavior_id,
 )
+from mlagents.trainers.training_status import GlobalTrainingStatus, StatusType
 
 
 logger = get_logger(__name__)
@@ -129,7 +130,11 @@ class GhostTrainer(Trainer):
         self.last_team_change: int = 0
 
         # Chosen because it is the initial ELO in Chess
-        self.initial_elo: float = self_play_parameters.initial_elo
+        self.initial_elo = GlobalTrainingStatus.get_parameter_state(
+            self.brain_name, StatusType.ELO
+        )
+        if self.initial_elo is None:
+            self.initial_elo = self_play_parameters.initial_elo
         self.policy_elos: List[float] = [self.initial_elo] * (
             self.window + 1
         )  # for learning policy
@@ -323,6 +328,9 @@ class GhostTrainer(Trainer):
         """
         Forwarding call to wrapped trainers save_model.
         """
+        GlobalTrainingStatus.set_parameter_state(
+            self.brain_name, StatusType.ELO, self.current_elo
+        )
         self.trainer.save_model()
 
     def create_policy(

--- a/ml-agents/mlagents/trainers/training_status.py
+++ b/ml-agents/mlagents/trainers/training_status.py
@@ -20,6 +20,7 @@ class StatusType(Enum):
     STATS_METADATA = "metadata"
     CHECKPOINTS = "checkpoints"
     FINAL_CHECKPOINT = "final_checkpoint"
+    ELO = "elo"
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
### Proposed change(s)

Use the GlobalTrainingStatus to save the current ELO

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
