### PR TITLE
[bug-fix] When agent isn't training, don't clear update buffer

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -48,7 +48,7 @@ depend on the previous behavior, you can explicitly set the Agent's `InferenceDe
 settings. Unfortunately, this may require retraining models if it changes the resulting order of the sensors
 or actuators on your system. (#5194)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-
+- Fixed a bug where the SAC replay buffer would not be saved out at the end of a run, even if `save_replay_buffer` was enabled. (#5205)
 
 ## [1.9.0-preview] - 2021-03-17
 ### Major Changes

--- a/ml-agents/mlagents/trainers/poca/trainer.py
+++ b/ml-agents/mlagents/trainers/poca/trainer.py
@@ -166,10 +166,7 @@ class POCATrainer(RLTrainer):
         )
         agent_buffer_trajectory[BufferKey.ADVANTAGES].set(global_advantages)
 
-        # Append to update buffer
-        agent_buffer_trajectory.resequence_and_append(
-            self.update_buffer, training_length=self.policy.sequence_length
-        )
+        self._append_to_update_buffer(agent_buffer_trajectory)
 
         # If this was a terminal trajectory, append stats and reset reward collection
         if trajectory.done_reached:

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -149,10 +149,8 @@ class PPOTrainer(RLTrainer):
         global_returns = list(np.mean(np.array(tmp_returns, dtype=np.float32), axis=0))
         agent_buffer_trajectory[BufferKey.ADVANTAGES].set(global_advantages)
         agent_buffer_trajectory[BufferKey.DISCOUNTED_RETURNS].set(global_returns)
-        # Append to update buffer
-        agent_buffer_trajectory.resequence_and_append(
-            self.update_buffer, training_length=self.policy.sequence_length
-        )
+
+        self._append_to_update_buffer(agent_buffer_trajectory)
 
         # If this was a terminal trajectory, append stats and reset reward collection
         if trajectory.done_reached:

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -104,11 +104,12 @@ class SACTrainer(RLTrainer):
         Save the training buffer's update buffer to a pickle file.
         """
         filename = os.path.join(self.artifact_path, "last_replay_buffer.hdf5")
-        logger.info(
-            f"Saving Experience Replay Buffer to {filename} ({os.path.getsize(filename)} bytes)"
-        )
+        logger.info(f"Saving Experience Replay Buffer to {filename}...")
         with open(filename, "wb") as file_object:
             self.update_buffer.save_to_file(file_object)
+            logger.info(
+                f"Saved Experience Replay Buffer ({os.path.getsize(filename)} bytes)."
+            )
 
     def load_replay_buffer(self) -> None:
         """

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -104,7 +104,9 @@ class SACTrainer(RLTrainer):
         Save the training buffer's update buffer to a pickle file.
         """
         filename = os.path.join(self.artifact_path, "last_replay_buffer.hdf5")
-        logger.info(f"Saving Experience Replay Buffer to {filename}")
+        logger.info(
+            f"Saving Experience Replay Buffer to {filename} ({os.path.getsize(filename)} bytes)"
+        )
         with open(filename, "wb") as file_object:
             self.update_buffer.save_to_file(file_object)
 
@@ -175,10 +177,7 @@ class SACTrainer(RLTrainer):
                 agent_buffer_trajectory[ObsUtil.get_name_at_next(i)][-1] = obs
             agent_buffer_trajectory[BufferKey.DONE][-1] = False
 
-        # Append to update buffer
-        agent_buffer_trajectory.resequence_and_append(
-            self.update_buffer, training_length=self.policy.sequence_length
-        )
+        self._append_to_update_buffer(agent_buffer_trajectory)
 
         if trajectory.done_reached:
             self._update_end_episode_stats(agent_id, self.optimizer)

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -204,7 +204,7 @@ def test_update_buffer_append():
         trainer._append_to_update_buffer(agentbuffer_trajectory)
         assert trainer.update_buffer.num_experiences == (i + 1) * time_horizon
 
-    # Check fhat if we append after stopping training, nothing happens.
+    # Check that if we append after stopping training, nothing happens.
     # We process enough trajectories to hit max steps
     trainer.set_is_policy_updating(False)
     trainer._process_trajectory(trajectory)

--- a/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
+++ b/ml-agents/mlagents/trainers/tests/test_rl_trainer.py
@@ -77,8 +77,7 @@ def test_clear_update_buffer():
 
 
 @mock.patch("mlagents.trainers.trainer.trainer.Trainer.save_model")
-@mock.patch("mlagents.trainers.trainer.rl_trainer.RLTrainer._clear_update_buffer")
-def test_advance(mocked_clear_update_buffer, mocked_save_model):
+def test_advance(mocked_save_model):
     trainer = create_rl_trainer()
     mock_policy = mock.Mock()
     trainer.add_policy("TestBrain", mock_policy)
@@ -115,9 +114,8 @@ def test_advance(mocked_clear_update_buffer, mocked_save_model):
         with pytest.raises(AgentManagerQueue.Empty):
             policy_queue.get_nowait()
 
-    # Check that the buffer has been cleared
+    # Check that no model has been saved
     assert not trainer.should_still_train
-    assert mocked_clear_update_buffer.call_count > 0
     assert mocked_save_model.call_count == 0
 
 
@@ -179,6 +177,39 @@ def test_summary_checkpoint(mock_add_checkpoint, mock_write_summary):
         for step in checkpoint_range
     ]
     mock_add_checkpoint.assert_has_calls(add_checkpoint_calls)
+
+
+def test_update_buffer_append():
+    trainer = create_rl_trainer()
+    mock_policy = mock.Mock()
+    trainer.add_policy("TestBrain", mock_policy)
+    trajectory_queue = AgentManagerQueue("testbrain")
+    policy_queue = AgentManagerQueue("testbrain")
+    trainer.subscribe_trajectory_queue(trajectory_queue)
+    trainer.publish_policy_queue(policy_queue)
+    time_horizon = 10
+    trajectory = mb.make_fake_trajectory(
+        length=time_horizon,
+        observation_specs=create_observation_specs_with_shapes([(1,)]),
+        max_step_complete=True,
+        action_spec=ActionSpec.create_discrete((2,)),
+    )
+    agentbuffer_trajectory = trajectory.to_agentbuffer()
+    assert trainer.update_buffer.num_experiences == 0
+
+    # Check that if we append, our update buffer gets longer.
+    # max_steps = 100
+    for i in range(10):
+        trainer._process_trajectory(trajectory)
+        trainer._append_to_update_buffer(agentbuffer_trajectory)
+        assert trainer.update_buffer.num_experiences == (i + 1) * time_horizon
+
+    # Check fhat if we append after stopping training, nothing happens.
+    # We process enough trajectories to hit max steps
+    trainer.set_is_policy_updating(False)
+    trainer._process_trajectory(trajectory)
+    trainer._append_to_update_buffer(agentbuffer_trajectory)
+    assert trainer.update_buffer.num_experiences == (i + 1) * time_horizon
 
 
 class RLTrainerWarningTest(unittest.TestCase):


### PR DESCRIPTION
### Proposed change(s)

Previously, we cleared the replay buffer at each timestep if the trainer was done training. This was to avoid a large memory leak if one trainer was done, but the other wasn't. However, this meant that SAC would just not have a replay buffer at the end of the run.

We now don't clear the buffer, but rather just don't append to it. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

JIRA [MLA-1251](https://jira.unity3d.com/browse/MLA-1251)

Verified with pushblock:
```
2021-03-31 11:35:27 INFO [trainer.py:110] Saving Experience Replay Buffer to results/ppo/PushBlock/last_replay_buffer.hdf5 (611283 bytes)
2021-03-31 11:35:27 INFO [trainer.py:110] Saving Experience Replay Buffer to results/ppo/PushBlock/last_replay_buffer.hdf5 (611283 bytes)
2021-03-31 11:35:27 INFO [trainer.py:110] Saving Experience Replay Buffer to results/ppo/PushBlock/last_replay_buffer.hdf5 (611283 bytes)
2021-03-31 11:35:27 INFO [trainer.py:110] Saving Experience Replay Buffer to results/ppo/PushBlock/last_replay_buffer.hdf5 (611283 bytes)
2021-03-31 11:35:27 INFO [trainer_controller.py:81] Saved Model
```


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
