### PR TITLE
[🐛  🔨 ] Issue 5204 : GymToUnityWrapper must call reset if done

### DIFF
--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -174,6 +174,12 @@ class UnityToGymWrapper(gym.Env):
             done (boolean/list): whether the episode has ended.
             info (dict): contains auxiliary diagnostic information.
         """
+        if self.game_over:
+            raise UnityGymException(
+                "You are calling 'step()' even though this environment has already "
+                "returned done = True. You must always call 'reset()' once you "
+                "receive 'done = True'."
+            )
         if self._flattener is not None:
             # Translate action into list
             action = self._flattener.lookup_action(action)


### PR DESCRIPTION
### Proposed change(s)

This is a fix for #5204 : When the environment is done, reset must be called, not step ! Raise a more accurate error when this happens. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
