### PR TITLE
Only if the logger level is higher than DEBUG will the subprocess print to console

### DIFF
--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -106,6 +106,8 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
         logger.debug(f"Running with args {args}")
         # Launch Unity environment
         subprocess_args = [launch_string] + args
+        # std_out_option = DEVNULL means the outputs will not be displayed on terminal.
+        # std_out_option = None is default behavior: the outputs are displayed on terminal.
         std_out_option = subprocess.DEVNULL if logger.level > DEBUG else None
         try:
             return subprocess.Popen(

--- a/ml-agents-envs/mlagents_envs/env_utils.py
+++ b/ml-agents-envs/mlagents_envs/env_utils.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from sys import platform
 from typing import Optional, List
-from mlagents_envs.logging_util import get_logger
+from mlagents_envs.logging_util import get_logger, DEBUG
 from mlagents_envs.exception import UnityEnvironmentException
 
 
@@ -106,6 +106,7 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
         logger.debug(f"Running with args {args}")
         # Launch Unity environment
         subprocess_args = [launch_string] + args
+        std_out_option = subprocess.DEVNULL if logger.level > DEBUG else None
         try:
             return subprocess.Popen(
                 subprocess_args,
@@ -115,6 +116,8 @@ def launch_executable(file_name: str, args: List[str]) -> subprocess.Popen:
                 # but may be undesirable in come cases; if so, we'll add a command-line toggle.
                 # Note that on Windows, the CTRL_C signal will still be sent.
                 start_new_session=True,
+                stdout=std_out_option,
+                stderr=std_out_option,
             )
         except PermissionError as perm:
             # This is likely due to missing read or execute permissions on file.


### PR DESCRIPTION

### Proposed change(s)

Silence these messages :
```
2021-03-31 17:32:31.273 ball[38075:23561191] Color LCD preferred device: AMD Radeon Pro 5500M (high power)
2021-03-31 17:32:31.273 ball[38075:23561191] Metal devices available: 2
2021-03-31 17:32:31.273 ball[38075:23561191] 0: AMD Radeon Pro 5500M (high power)
2021-03-31 17:32:31.273 ball[38075:23561191] 1: Intel(R) UHD Graphics 630 (low power)
2021-03-31 17:32:31.273 ball[38075:23561191] Using device AMD Radeon Pro 5500M (high power)
```
When the logging level is above debug. There messages will still be present if `--debug` is used.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
