### PR TITLE
Load individual elements if state dict load fails

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -29,10 +29,10 @@ produces two `Match3Sensor`s (unless there are no special types). Previously tra
 sizes and will need to be retrained. (#5181)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- The `--resume` flag now supports resuming experimennts with additional reward providers or
+- The `--resume` flag now supports resuming experiments with additional reward providers or
  loading partial models if the network architecture has changed. See
  [here](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Training-ML-Agents.md#loading-an-existing-model)
- for more details.
+ for more details. (#5213)
 
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -29,6 +29,9 @@ produces two `Match3Sensor`s (unless there are no special types). Previously tra
 sizes and will need to be retrained. (#5181)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- The `--resume` flag now supports loading partial models if the architecture has changed. See
+ [here](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Training-ML-Agents.md#loading-an-existing-model)
+ for more details.
 
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -29,7 +29,8 @@ produces two `Match3Sensor`s (unless there are no special types). Previously tra
 sizes and will need to be retrained. (#5181)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- The `--resume` flag now supports loading partial models if the architecture has changed. See
+- The `--resume` flag now supports resuming experimennts with additional reward providers or
+ loading partial models if the network architecture has changed. See
  [here](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Training-ML-Agents.md#loading-an-existing-model)
  for more details.
 

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -117,6 +117,13 @@ Python by using both the `--resume` and `--inference` flags. Note that if you
 want to run inference in Unity, you should use the
 [Unity Inference Engine](Getting-Started.md#running-a-pre-trained-model).
 
+Additionally, if the network architecture changes, you may still load an existing model,
+and ML-Agents will only load the parts of the model that haven't changed. For instance,
+if you add a new reward signal, the existing model will load but the new reward signal
+will be initialized from scratch. If you have a model with a visual encoder (CNN) but
+change the `hidden_units`, the CNN will be loaded but the body of the network will be
+initialized from scratch.
+
 Alternatively, you might want to start a new training run but _initialize_ it
 using an already-trained model. You may want to do this, for instance, if your
 environment changed and you want a new model, but the old behavior is still

--- a/docs/Training-ML-Agents.md
+++ b/docs/Training-ML-Agents.md
@@ -118,7 +118,7 @@ want to run inference in Unity, you should use the
 [Unity Inference Engine](Getting-Started.md#running-a-pre-trained-model).
 
 Additionally, if the network architecture changes, you may still load an existing model,
-and ML-Agents will only load the parts of the model that haven't changed. For instance,
+but ML-Agents will only load the parts of the model it can load and ignore all others. For instance,
 if you add a new reward signal, the existing model will load but the new reward signal
 will be initialized from scratch. If you have a model with a visual encoder (CNN) but
 change the `hidden_units`, the CNN will be loaded but the body of the network will be

--- a/ml-agents-envs/mlagents_envs/logging_util.py
+++ b/ml-agents-envs/mlagents_envs/logging_util.py
@@ -1,4 +1,5 @@
 import logging  # noqa I251
+import sys
 
 CRITICAL = logging.CRITICAL
 FATAL = logging.FATAL
@@ -20,10 +21,14 @@ def get_logger(name: str) -> logging.Logger:
     specified by set_log_level()
     """
     logger = logging.getLogger(name=name)
-
     # If we've already set the log level, make sure new loggers use it
     if _log_level != NOTSET:
         logger.setLevel(_log_level)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     # Keep track of this logger so that we can change the log level later
     _loggers.add(logger)
@@ -36,11 +41,6 @@ def set_log_level(log_level: int) -> None:
     """
     global _log_level
     _log_level = log_level
-
-    # Configure the log format.
-    # In theory, this would be sufficient, but if another library calls logging.basicConfig
-    # first, it doesn't have any effect.
-    logging.basicConfig(level=_log_level, format=LOG_FORMAT, datefmt=DATE_FORMAT)
 
     for logger in _loggers:
         logger.setLevel(log_level)

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -96,12 +96,12 @@ class TorchModelSaver(BaseModelSaver):
                     logger.warning(f"Failed to load directly for module {name}.")
                     for mod_element in mod.state_dict():
                         try:
-                            logger.warning(f"Copying {mod_element}")
+                            logger.debug(f"Copying {mod_element}")
                             mod.state_dict()[mod_element].copy_(
                                 saved_state_dict[name][mod_element]
                             )
                         except Exception:
-                            logger.warning(
+                            logger.debug(
                                 f"{mod_element} was not found or is not loadable (changed shape). Initializing."
                             )
                 else:

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -94,23 +94,19 @@ class TorchModelSaver(BaseModelSaver):
             except Exception:
                 if name in saved_state_dict:
                     logger.warning(f"Failed to load directly for module {name}.")
-                    if isinstance(mod, torch.optim.Adam):
-                        logger.warning(f"Ignoring state for optimizer {name}.")
-
-                    else:
-                        for mod_element in mod.state_dict():
-                            if mod_element in saved_state_dict[name]:
-                                logger.warning(f"Copying {mod_element}")
-                                mod.state_dict()[mod_element].copy_(
-                                    saved_state_dict[name][mod_element]
-                                )
-                            else:
-                                logger.warning(
-                                    f"{mod_element} was not found in the saved module {name}. This will be initialized."
-                                )
+                    for mod_element in mod.state_dict():
+                        try:
+                            logger.warning(f"Copying {mod_element}")
+                            mod.state_dict()[mod_element].copy_(
+                                saved_state_dict[name][mod_element]
+                            )
+                        except Exception:
+                            logger.warning(
+                                f"{mod_element} was not found or is not loadable (changed shape). Initializing."
+                            )
                 else:
                     logger.warning(
-                        f"The module {name} was not found in the checkpoint. This will be initialized."
+                        f"The module {name} was not found in the checkpoint. Initializing."
                     )
 
         if reset_global_steps:

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -113,7 +113,7 @@ class TorchModelSaver(BaseModelSaver):
             # function because it is not an nn.Module.
             # RuntimeError is raised by PyTorch if there  is a size mismatch between modules
             # of the same name. This will still partially assign values to those layers that
-            # have no changed shape.
+            # have not changed shape.
             except (KeyError, ValueError, RuntimeError) as err:
                 logger.warning(f"Failed to load for module {name}. Initializing")
                 logger.debug(f"Module loading error : {err}")

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -99,7 +99,7 @@ class TorchModelSaver(BaseModelSaver):
                     )
                 if unexpected_keys:
                     logger.warning(
-                        f"Did not expect these keys {unexpected_keys} in checkpoint. Initializing"
+                        f"Did not expect these keys {unexpected_keys} in checkpoint. Ignoring"
                     )
 
             except (KeyError, TypeError):

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -111,7 +111,7 @@ class TorchModelSaver(BaseModelSaver):
             # ValueError is raised by the optimizer's load_state_dict if the parameters have
             # have changed. Note, the optimizer uses a completely different load_state_dict
             # function because it is not an nn.Module.
-            # RuntimeError is raised by PyTorch if there  is a size mismatch between modules
+            # RuntimeError is raised by PyTorch if there is a size mismatch between modules
             # of the same name. This will still partially assign values to those layers that
             # have not changed shape.
             except (KeyError, ValueError, RuntimeError) as err:

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -95,15 +95,16 @@ class TorchModelSaver(BaseModelSaver):
                 )
                 if missing_keys:
                     logger.warning(
-                        f"Did not find these keys {missing_keys} in checkpoint. Initializing"
+                        f"Did not find these keys {missing_keys} in checkpoint. Initializing."
                     )
                 if unexpected_keys:
                     logger.warning(
-                        f"Did not expect these keys {unexpected_keys} in checkpoint. Ignoring"
+                        f"Did not expect these keys {unexpected_keys} in checkpoint. Ignoring."
                     )
 
-            except (KeyError, TypeError):
+            except (KeyError, TypeError, RuntimeError) as err:
                 logger.warning(f"Failed to load for module {name}. Initializing")
+                logger.debug(f"Module loading error : {err}")
 
         if reset_global_steps:
             policy.set_step(0)

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -90,13 +90,18 @@ class TorchModelSaver(BaseModelSaver):
 
         for name, mod in modules.items():
             try:
-                missing_keys, _ = mod.load_state_dict(
+                missing_keys, unexpected_keys = mod.load_state_dict(
                     saved_state_dict[name], strict=False
                 )
                 if missing_keys:
                     logger.warning(
                         f"Did not find these keys {missing_keys} in checkpoint. Initializing"
                     )
+                if unexpected_keys:
+                    logger.warning(
+                        f"Did not expect these keys {unexpected_keys} in checkpoint. Initializing"
+                    )
+
             except (KeyError, TypeError):
                 logger.warning(f"Failed to load for module {name}. Initializing")
 

--- a/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
+++ b/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
@@ -101,11 +101,19 @@ def test_load_policy_different_hidden_units(tmp_path, vis_encode_type):
     # asserts convolutions have different parameters before load
     for conv1, conv2 in zip(conv_params, conv_params2):
         assert not torch.equal(conv1, conv2)
+    # asserts layers still  have different dimensions
+    for mod1, mod2 in zip(policy.actor.parameters(), policy2.actor.parameters()):
+        if mod1.shape[0] == 12:
+            assert mod2.shape[0] == 10
     model_saver2.register(policy2)
     model_saver2.initialize_or_load(policy2)
     # asserts convolutions have same parameters after load
     for conv1, conv2 in zip(conv_params, conv_params2):
         assert torch.equal(conv1, conv2)
+    # asserts layers still  have different dimensions
+    for mod1, mod2 in zip(policy.actor.parameters(), policy2.actor.parameters()):
+        if mod1.shape[0] == 12:
+            assert mod2.shape[0] == 10
 
 
 @pytest.mark.parametrize(

--- a/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
+++ b/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
@@ -12,6 +12,8 @@ from mlagents.trainers.poca.optimizer_torch import TorchPOCAOptimizer
 from mlagents.trainers.model_saver.torch_model_saver import TorchModelSaver
 from mlagents.trainers.settings import (
     TrainerSettings,
+    NetworkSettings,
+    EncoderType,
     PPOSettings,
     SACSettings,
     POCASettings,
@@ -68,6 +70,42 @@ def test_load_save_policy(tmp_path):
     _compare_two_policies(policy2, policy3)
     # Assert that the steps are 0.
     assert policy3.get_current_step() == 0
+
+
+@pytest.mark.parametrize("vis_encode_type", ["resnet", "nature_cnn", "match3"])
+def test_load_policy_different_hidden_units(tmp_path, vis_encode_type):
+    path1 = os.path.join(tmp_path, "runid1")
+    trainer_params = TrainerSettings()
+    trainer_params.network_settings = NetworkSettings(
+        hidden_units=12, vis_encode_type=EncoderType(vis_encode_type)
+    )
+    policy = create_policy_mock(trainer_params, use_visual=True)
+    conv_params = [mod for mod in policy.actor.parameters() if len(mod.shape) > 2]
+
+    model_saver = TorchModelSaver(trainer_params, path1)
+    model_saver.register(policy)
+    model_saver.initialize_or_load(policy)
+    policy.set_step(2000)
+
+    mock_brain_name = "MockBrain"
+    model_saver.save_checkpoint(mock_brain_name, 2000)
+
+    # Try load from this path
+    trainer_params2 = TrainerSettings()
+    trainer_params2.network_settings = NetworkSettings(
+        hidden_units=10, vis_encode_type=EncoderType(vis_encode_type)
+    )
+    model_saver2 = TorchModelSaver(trainer_params2, path1, load=True)
+    policy2 = create_policy_mock(trainer_params2, use_visual=True)
+    conv_params2 = [mod for mod in policy2.actor.parameters() if len(mod.shape) > 2]
+    # asserts convolutions have different parameters before load
+    for conv1, conv2 in zip(conv_params, conv_params2):
+        assert not torch.equal(conv1, conv2)
+    model_saver2.register(policy2)
+    model_saver2.initialize_or_load(policy2)
+    # asserts convolutions have same parameters after load
+    for conv1, conv2 in zip(conv_params, conv_params2):
+        assert torch.equal(conv1, conv2)
 
 
 @pytest.mark.parametrize(

--- a/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
+++ b/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
@@ -110,7 +110,7 @@ def test_load_policy_different_hidden_units(tmp_path, vis_encode_type):
     # asserts convolutions have same parameters after load
     for conv1, conv2 in zip(conv_params, conv_params2):
         assert torch.equal(conv1, conv2)
-    # asserts layers still  have different dimensions
+    # asserts layers still have different dimensions
     for mod1, mod2 in zip(policy.actor.parameters(), policy2.actor.parameters()):
         if mod1.shape[0] == 12:
             assert mod2.shape[0] == 10

--- a/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
+++ b/ml-agents/mlagents/trainers/tests/torch/saver/test_saver.py
@@ -101,7 +101,7 @@ def test_load_policy_different_hidden_units(tmp_path, vis_encode_type):
     # asserts convolutions have different parameters before load
     for conv1, conv2 in zip(conv_params, conv_params2):
         assert not torch.equal(conv1, conv2)
-    # asserts layers still  have different dimensions
+    # asserts layers still have different dimensions
     for mod1, mod2 in zip(policy.actor.parameters(), policy2.actor.parameters()):
         if mod1.shape[0] == 12:
             assert mod2.shape[0] == 10


### PR DESCRIPTION
### Proposed change(s)

Addressing the issue of being unable to resume with GAIL/reward providers in general. If the load fails, this will copy matching elements individually and produce a lot of logger warnings as such:

```
2021-04-01 12:29:22 WARNING [torch_model_saver.py:102] Did not expect these keys ['action_model._continuous_distribution.log_sigma', 'action_model._continuous_distribution.mu.weight', 'action_model._continuous_distribution.mu.bias'] in checkpoint. Initializing
2021-04-01 12:29:22 WARNING [torch_model_saver.py:106] Failed to load for module Optimizer:value_optimizer. Initializing
2021-04-01 12:29:22 WARNING [torch_model_saver.py:98] Did not find these keys ['value_heads.value_heads.curiosity.weight', 'value_heads.value_heads.curiosity.bias', 'value_heads.value_heads.gail.weight', 'value_heads.value_heads.gail.bias'] in checkpoint. Initializing
2021-04-01 12:29:22 WARNING [torch_model_saver.py:102] Did not expect these keys ['value_heads.value_heads.extrinsic.weight', 'value_heads.value_heads.extrinsic.bias', 'value_heads.value_heads.rnd.weight', 'value_heads.value_heads.rnd.bias'] in checkpoint. Initializing
2021-04-01 12:29:22 WARNING [torch_model_saver.py:106] Failed to load for module Module:Curiosity. Initializing
2021-04-01 12:29:22 WARNING [torch_model_saver.py:106] Failed to load for module Module:GAIL. Initializing
2021-04-01 12:29:22 INFO [torch_model_saver.py:116] Resuming training from step 42896.
```

TODO:

- tests

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
