### PR TITLE
[Bug Fix] Serialization of vectorActionSpace

### DIFF
--- a/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
+++ b/com.unity.ml-agents/Runtime/Policies/BrainParameters.cs
@@ -80,6 +80,7 @@ namespace Unity.MLAgents.Policies
         /// For the discrete actions: the number of branches.
         /// </value>
         [Obsolete("VectorActionSize has been deprecated, please use ActionSpec instead.")]
+        [SerializeField]
         [FormerlySerializedAs("vectorActionSize")]
         internal int[] VectorActionSize = new[] { 1 };
 
@@ -93,6 +94,7 @@ namespace Unity.MLAgents.Policies
         /// (Deprecated) Defines if the action is discrete or continuous.
         /// </summary>
         [Obsolete("VectorActionSpaceType has been deprecated, please use ActionSpec instead.")]
+        [SerializeField]
         [FormerlySerializedAs("vectorActionSpaceType")]
         internal SpaceType VectorActionSpaceType = SpaceType.Discrete;
 
@@ -129,16 +131,14 @@ namespace Unity.MLAgents.Policies
 #pragma warning disable CS0618
             if (!hasUpgradedBrainParametersWithActionSpec
                 && m_ActionSpec.NumContinuousActions == 0
-                && m_ActionSpec.BranchSizes == null)
+                && m_ActionSpec.NumDiscreteActions == 0)
             {
                 if (VectorActionSpaceType == SpaceType.Continuous)
                 {
                     m_ActionSpec.NumContinuousActions = VectorActionSize[0];
-                    m_ActionSpec.BranchSizes = null;
                 }
                 if (VectorActionSpaceType == SpaceType.Discrete)
                 {
-                    m_ActionSpec.NumContinuousActions = 0;
                     m_ActionSpec.BranchSizes = (int[])VectorActionSize.Clone();
                 }
             }

--- a/com.unity.ml-agents/Tests/Editor/Serialization.meta
+++ b/com.unity.ml-agents/Tests/Editor/Serialization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e76819646e3e4424f9c2802edbd2e41b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Tests/Editor/Serialization/TestLoadOldPrefab.cs
+++ b/com.unity.ml-agents/Tests/Editor/Serialization/TestLoadOldPrefab.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
+using Unity.MLAgents.Policies;
+
+namespace Unity.MLAgents.Tests
+{
+    [TestFixture]
+    public class TestSerialization
+    {
+        const string k_oldPrefabPath = "Packages/com.unity.ml-agents/Tests/Editor/TestModels/old_serialized_agent.prefab";
+        const int k_numVecObs = 212;
+        const int k_numContinuousActions = 39;
+
+        [Test]
+        public void TestDeserialization()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(k_oldPrefabPath);
+            var agent = GameObject.Instantiate(prefab);
+            var bp = agent.GetComponent<BehaviorParameters>();
+            Assert.AreEqual(bp.BrainParameters.ActionSpec.NumContinuousActions, k_numContinuousActions);
+            Assert.AreEqual(bp.BrainParameters.VectorObservationSize, k_numVecObs);
+        }
+
+    }
+}

--- a/com.unity.ml-agents/Tests/Editor/Serialization/TestLoadOldPrefab.cs.meta
+++ b/com.unity.ml-agents/Tests/Editor/Serialization/TestLoadOldPrefab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3070d063598144268171a468db17ddd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Tests/Editor/TestModels/old_serialized_agent.prefab
+++ b/com.unity.ml-agents/Tests/Editor/TestModels/old_serialized_agent.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5381908961062339374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5379309137663827240}
+  - component: {fileID: 5414230854946179998}
+  - component: {fileID: 8153975132613398210}
+  m_Layer: 0
+  m_Name: old_serialized_agent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5379309137663827240
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5381908961062339374}
+  m_LocalRotation: {x: -0, y: -0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!114 &5414230854946179998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5381908961062339374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d1c4e0b1822b495aa52bc52839ecb30, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BrainParameters:
+    vectorObservationSize: 212
+    numStackedVectorObservations: 1
+    vectorActionSize: 27000000
+    vectorActionDescriptions: []
+    vectorActionSpaceType: 1
+  m_Model: {fileID: 11400000, guid: 4e86a19e012da43bfa5ab97ae8089b98, type: 3}
+  m_InferenceDevice: 0
+  m_BehaviorType: 0
+  m_BehaviorName: Walker
+  TeamId: 0
+  m_UseChildSensors: 1
+  m_UseChildActuators: 1
+  m_ObservableAttributeHandling: 0
+--- !u!114 &8153975132613398210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5381908961062339374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88b6042bc9a5d4aa58d931eae49442e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  agentParameters:
+    maxStep: 0
+  hasUpgradedFromAgentParameters: 1
+  MaxStep: 0

--- a/com.unity.ml-agents/Tests/Editor/TestModels/old_serialized_agent.prefab.meta
+++ b/com.unity.ml-agents/Tests/Editor/TestModels/old_serialized_agent.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 07e2de94fa37b49c3bdf7a21857c0f73
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Proposed change(s)

Fixing bug here : https://unity.slack.com/archives/C01H5LE96RE/p1617640959055900
The issue is that internal fields are not serialized by default like public fields and that the default DiscreteBranches is no longer null but Array.Empty.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
