### PR TITLE
[MLA-1880] Raycast sensor interface improvements

### DIFF
--- a/Project/ProjectSettings/ProjectSettings.asset
+++ b/Project/ProjectSettings/ProjectSettings.asset
@@ -125,7 +125,8 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: 1.0
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/Project/ProjectSettings/ProjectSettings.asset
+++ b/Project/ProjectSettings/ProjectSettings.asset
@@ -125,8 +125,7 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: 1.0
-  preloadedAssets:
-  - {fileID: 0}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -39,8 +39,9 @@ sizes and will need to be retrained. (#5181)
 - Make com.unity.modules.physics and com.unity.modules.physics2d optional dependencies. (#5112)
 - The default `InferenceDevice` is now `InferenceDevice.Default`, which is equivalent to `InferenceDevice.Burst`. If you
 depend on the previous behavior, you can explicitly set the Agent's `InferenceDevice` to `InferenceDevice.CPU`. (#5175)
- - Added support for `Goal Signal` as a type of observation. Trainers can now use HyperNetworks to process `Goal Signal`. Trainers with HyperNetworks are more effective at solving multiple tasks. (#5142, #5159, #5149)
- - Modified the [GridWorld environment](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Learning-Environment-Examples.md#gridworld) to use the new `Goal Signal` feature. (#5193)
+- Added support for `Goal Signal` as a type of observation. Trainers can now use HyperNetworks to process `Goal Signal`. Trainers with HyperNetworks are more effective at solving multiple tasks. (#5142, #5159, #5149)
+- Modified the [GridWorld environment](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Learning-Environment-Examples.md#gridworld) to use the new `Goal Signal` feature. (#5193)
+- `RaycastPerceptionSensor` now caches its raycast results; they can be accessed via `RayPerceptionSensor.RayPerceptionOutput`. (#5222)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -200,7 +200,6 @@ namespace Unity.MLAgents.Sensors
             /// </remarks>
             public float ScaledCastRadius;
 
-
             /// <summary>
             /// Writes the ray output information to a subset of the float array.  Each element in the rayAngles array
             /// determines a sublist of data to the observation. The sublist contains the observation data for a single cast.
@@ -246,6 +245,9 @@ namespace Unity.MLAgents.Sensors
         RayPerceptionInput m_RayPerceptionInput;
         internal RayPerceptionOutput m_rayPerceptionOutput;
 
+        /// <summary>
+        /// Time.frameCount at the last time Update() was called. This is only used for display in gizmos.
+        /// </summary>
         int m_DebugLastFrameCount;
 
         internal int DebugLastFrameCount
@@ -265,11 +267,16 @@ namespace Unity.MLAgents.Sensors
 
             SetNumObservations(rayInput.OutputSize());
 
-            if (Application.isEditor)
-            {
-                m_DebugLastFrameCount = Time.frameCount;
-            }
+            m_DebugLastFrameCount = Time.frameCount;
             m_rayPerceptionOutput = new RayPerceptionOutput();
+        }
+
+        /// <summary>
+        /// The most recent raycast results.
+        /// </summary>
+        public RayPerceptionOutput RayPerceptionOutput
+        {
+            get { return m_rayPerceptionOutput; }
         }
 
         void SetNumObservations(int numObservations)

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -243,7 +243,7 @@ namespace Unity.MLAgents.Sensors
         string m_Name;
 
         RayPerceptionInput m_RayPerceptionInput;
-        internal RayPerceptionOutput m_rayPerceptionOutput;
+        RayPerceptionOutput m_RayPerceptionOutput;
 
         /// <summary>
         /// Time.frameCount at the last time Update() was called. This is only used for display in gizmos.
@@ -268,7 +268,7 @@ namespace Unity.MLAgents.Sensors
             SetNumObservations(rayInput.OutputSize());
 
             m_DebugLastFrameCount = Time.frameCount;
-            m_rayPerceptionOutput = new RayPerceptionOutput();
+            m_RayPerceptionOutput = new RayPerceptionOutput();
         }
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace Unity.MLAgents.Sensors
         /// </summary>
         public RayPerceptionOutput RayPerceptionOutput
         {
-            get { return m_rayPerceptionOutput; }
+            get { return m_RayPerceptionOutput; }
         }
 
         void SetNumObservations(int numObservations)
@@ -319,7 +319,7 @@ namespace Unity.MLAgents.Sensors
                 // For each ray, write the information to the observation buffer
                 for (var rayIndex = 0; rayIndex < numRays; rayIndex++)
                 {
-                    m_rayPerceptionOutput.RayOutputs[rayIndex].ToFloatArray(numDetectableTags, rayIndex, m_Observations);
+                    m_RayPerceptionOutput.RayOutputs[rayIndex].ToFloatArray(numDetectableTags, rayIndex, m_Observations);
                 }
 
                 // Finally, add the observations to the ObservationWriter
@@ -334,15 +334,15 @@ namespace Unity.MLAgents.Sensors
             m_DebugLastFrameCount = Time.frameCount;
             var numRays = m_RayPerceptionInput.Angles.Count;
 
-            if (m_rayPerceptionOutput.RayOutputs == null || m_rayPerceptionOutput.RayOutputs.Length != numRays)
+            if (m_RayPerceptionOutput.RayOutputs == null || m_RayPerceptionOutput.RayOutputs.Length != numRays)
             {
-                m_rayPerceptionOutput.RayOutputs = new RayPerceptionOutput.RayOutput[numRays];
+                m_RayPerceptionOutput.RayOutputs = new RayPerceptionOutput.RayOutput[numRays];
             }
 
             // For each ray, do the casting and save the results.
             for (var rayIndex = 0; rayIndex < numRays; rayIndex++)
             {
-                m_rayPerceptionOutput.RayOutputs[rayIndex] = PerceiveSingleRay(m_RayPerceptionInput, rayIndex);
+                m_RayPerceptionOutput.RayOutputs[rayIndex] = PerceiveSingleRay(m_RayPerceptionInput, rayIndex);
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -252,18 +252,28 @@ namespace Unity.MLAgents.Sensors
             }
         }
 
+        internal int SensorObservationAge()
+        {
+            if (m_RaySensor != null)
+            {
+                return Time.frameCount - m_RaySensor.DebugLastFrameCount;
+            }
+
+            return 0;
+        }
+
         void OnDrawGizmosSelected()
         {
-            if (m_RaySensor?.debugDisplayInfo?.rayInfos != null)
+            if (m_RaySensor?.m_rayPerceptionOutput?.RayOutputs != null)
             {
                 // If we have cached debug info from the sensor, draw that.
                 // Draw "old" observations in a lighter color.
                 // Since the agent may not step every frame, this helps de-emphasize "stale" hit information.
-                var alpha = Mathf.Pow(.5f, m_RaySensor.debugDisplayInfo.age);
+                var alpha = Mathf.Pow(.5f, SensorObservationAge());
 
-                foreach (var rayInfo in m_RaySensor.debugDisplayInfo.rayInfos)
+                foreach (var rayInfo in m_RaySensor.m_rayPerceptionOutput.RayOutputs)
                 {
-                    DrawRaycastGizmos(rayInfo.rayOutput, alpha);
+                    DrawRaycastGizmos(rayInfo, alpha);
                 }
             }
             else
@@ -276,9 +286,8 @@ namespace Unity.MLAgents.Sensors
                 rayInput.DetectableTags = null;
                 for (var rayIndex = 0; rayIndex < rayInput.Angles.Count; rayIndex++)
                 {
-                    DebugDisplayInfo.RayInfo debugRay;
-                    RayPerceptionSensor.PerceiveSingleRay(rayInput, rayIndex, out debugRay);
-                    DrawRaycastGizmos(debugRay.rayOutput);
+                    var rayOutput = RayPerceptionSensor.PerceiveSingleRay(rayInput, rayIndex);
+                    DrawRaycastGizmos(rayOutput);
                 }
             }
         }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -264,14 +264,14 @@ namespace Unity.MLAgents.Sensors
 
         void OnDrawGizmosSelected()
         {
-            if (m_RaySensor?.m_rayPerceptionOutput?.RayOutputs != null)
+            if (m_RaySensor?.RayPerceptionOutput?.RayOutputs != null)
             {
                 // If we have cached debug info from the sensor, draw that.
                 // Draw "old" observations in a lighter color.
                 // Since the agent may not step every frame, this helps de-emphasize "stale" hit information.
                 var alpha = Mathf.Pow(.5f, SensorObservationAge());
 
-                foreach (var rayInfo in m_RaySensor.m_rayPerceptionOutput.RayOutputs)
+                foreach (var rayInfo in m_RaySensor.RayPerceptionOutput.RayOutputs)
                 {
                     DrawRaycastGizmos(rayInfo, alpha);
                 }

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -263,7 +263,7 @@ namespace Unity.MLAgents.Sensors
 
                 foreach (var rayInfo in m_RaySensor.debugDisplayInfo.rayInfos)
                 {
-                    DrawRaycastGizmos(rayInfo, alpha);
+                    DrawRaycastGizmos(rayInfo.rayOutput, alpha);
                 }
             }
             else
@@ -278,7 +278,7 @@ namespace Unity.MLAgents.Sensors
                 {
                     DebugDisplayInfo.RayInfo debugRay;
                     RayPerceptionSensor.PerceiveSingleRay(rayInput, rayIndex, out debugRay);
-                    DrawRaycastGizmos(debugRay);
+                    DrawRaycastGizmos(debugRay.rayOutput);
                 }
             }
         }
@@ -286,24 +286,24 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// Draw the debug information from the sensor (if available).
         /// </summary>
-        void DrawRaycastGizmos(DebugDisplayInfo.RayInfo rayInfo, float alpha = 1.0f)
+        void DrawRaycastGizmos(RayPerceptionOutput.RayOutput rayOutput, float alpha = 1.0f)
         {
-            var startPositionWorld = rayInfo.worldStart;
-            var endPositionWorld = rayInfo.worldEnd;
+            var startPositionWorld = rayOutput.StartPositionWorld;
+            var endPositionWorld = rayOutput.EndPositionWorld;
             var rayDirection = endPositionWorld - startPositionWorld;
-            rayDirection *= rayInfo.rayOutput.HitFraction;
+            rayDirection *= rayOutput.HitFraction;
 
             // hit fraction ^2 will shift "far" hits closer to the hit color
-            var lerpT = rayInfo.rayOutput.HitFraction * rayInfo.rayOutput.HitFraction;
+            var lerpT = rayOutput.HitFraction * rayOutput.HitFraction;
             var color = Color.Lerp(rayHitColor, rayMissColor, lerpT);
             color.a *= alpha;
             Gizmos.color = color;
             Gizmos.DrawRay(startPositionWorld, rayDirection);
 
             // Draw the hit point as a sphere. If using rays to cast (0 radius), use a small sphere.
-            if (rayInfo.rayOutput.HasHit)
+            if (rayOutput.HasHit)
             {
-                var hitRadius = Mathf.Max(rayInfo.castRadius, .05f);
+                var hitRadius = Mathf.Max(rayOutput.ScaledCastRadius, .05f);
                 Gizmos.DrawWireSphere(startPositionWorld + rayDirection, hitRadius);
             }
         }

--- a/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
+++ b/com.unity.ml-agents/Tests/Editor/PublicAPI/PublicApiValidation.cs
@@ -69,6 +69,11 @@ namespace Unity.MLAgentsExamples
             sensorComponent.ObservationStacks = 2;
 
             sensorComponent.CreateSensors();
+
+            var sensor = sensorComponent.RaySensor;
+            sensor.Update();
+            var outputs = sensor.RayPerceptionOutput;
+            Assert.AreEqual(outputs.RayOutputs.Length, 2*sensorComponent.RaysPerDirection + 1);
         }
 #endif
     }

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
@@ -107,6 +107,7 @@ namespace Unity.MLAgents.Tests
             {
                 perception.SphereCastRadius = castRadius;
                 var sensor = perception.CreateSensors()[0];
+                sensor.Update();
 
                 var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationSpec().Shape[0], expectedObs);
@@ -166,6 +167,7 @@ namespace Unity.MLAgents.Tests
             perception.DetectableTags.Add(k_SphereTag);
 
             var sensor = perception.CreateSensors()[0];
+            sensor.Update();
             var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
             Assert.AreEqual(sensor.GetObservationSpec().Shape[0], expectedObs);
             var outputBuffer = new float[expectedObs];
@@ -214,6 +216,7 @@ namespace Unity.MLAgents.Tests
                 perception.RayLayerMask = layerMask;
 
                 var sensor = perception.CreateSensors()[0];
+                sensor.Update();
                 var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationSpec().Shape[0], expectedObs);
                 var outputBuffer = new float[expectedObs];
@@ -260,6 +263,7 @@ namespace Unity.MLAgents.Tests
             {
                 perception.SphereCastRadius = castRadius;
                 var sensor = perception.CreateSensors()[0];
+                sensor.Update();
 
                 var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationSpec().Shape[0], expectedObs);
@@ -309,6 +313,7 @@ namespace Unity.MLAgents.Tests
                 // Set the layer mask to either the default, or one that ignores the close cube's layer
 
                 var sensor = perception.CreateSensors()[0];
+                sensor.Update();
                 var expectedObs = (2 * perception.RaysPerDirection + 1) * (perception.DetectableTags.Count + 2);
                 Assert.AreEqual(sensor.GetObservationSpec().Shape[0], expectedObs);
                 var outputBuffer = new float[expectedObs];


### PR DESCRIPTION
### Proposed change(s)
Public-facing change: 
* Adds `RayPerceptionSensor.RayPerceptionOutput`, which contains the most recent ray hit information. This can be used to for additional game logic as needed.
* Adds new fields to `RayOutput`: `StartPositionWorld`, `EndPositionWorld`, `ScaledRayLength`, and `ScaledCastRadius`.

Internal changes:
* Get rid of DebugDisplayInfo - all of its info is now on `RayOutput`, except for the frame that the results were queried, which is now stored as `m_DebugLastFrameCount`
* Raycasts now happen in the Update() call, which always happens before the Write().

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Based on feedback from several forum posts:

Forum threads:

- ["i want to do an if statement inside my agent script to say if the ray cast hits an object with the tag enemy then do something"](https://forum.unity.com/threads/getting-the-detectable-tags-from-ray-perception-sensor-script.834733/)
- ["does the ray perception 3d component get the distance to the object it impacted? I need my agents to get the distance to that object"](https://forum.unity.com/threads/ray-perception-sensor-component-3d-distance.867223/)
- ["we have to reset agent if it follows wrong raycast and crash, or we want to add reward if it follows correct raycast."](https://forum.unity.com/threads/how-can-i-use-rayperceptioncomponent3d-effectively.926426/#post-6086127)
- ["I am trying to teach an agent to find a target but once it has "seen" the target, I want to give it a reward."](https://forum.unity.com/threads/rewarding-an-agent-when-it-sees-something.955029/)
- ["I was wondering, if there is an easy way to draw the Debug gizmos of the Ray Perception Sensor ingame for demonstration purposes?"](https://forum.unity.com/threads/way-to-visualize-ray-perception-sensor.978642/)
- ["I'd like to get a value of distance between the agent and obstacles with using Ray Perception Sensor."](https://forum.unity.com/threads/how-to-get-value-of-distance-between-agent-obstacles-with-using-rayperceptionsensor3d.1043338/)
- ["I use three Ray Perception Sensor Components for measuring distances from the agent to some objects, and I'd like to get all values (HasHit, HitTaggedObject, HitTagIndex and HitFraction) from all components."](https://forum.unity.com/threads/how-to-get-values-from-multiple-ray-perception-sensor-3ds.1045960/)


### Types of change(s)
- [x] New feature
- [x] Code refactor

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)


### Other comments
