### PR TITLE
Add more verbose messages when using --initialize-from and --resume

### DIFF
--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -67,10 +67,12 @@ class TorchModelSaver(BaseModelSaver):
         # This argument is mainly for initialization of the ghost trainer's fixed policy.
         reset_steps = not self.load
         if self.initialize_path is not None:
+            logger.info(f"Initializing from {self.initialize_path}")
             self._load_model(
                 self.initialize_path, policy, reset_global_steps=reset_steps
             )
         elif self.load:
+            logger.info(f"Resuming from {self.model_path}")
             self._load_model(self.model_path, policy, reset_global_steps=reset_steps)
 
     def _load_model(

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -67,12 +67,12 @@ class TorchModelSaver(BaseModelSaver):
         # This argument is mainly for initialization of the ghost trainer's fixed policy.
         reset_steps = not self.load
         if self.initialize_path is not None:
-            logger.info(f"Initializing from {self.initialize_path}")
+            logger.info(f"Initializing from {self.initialize_path}.")
             self._load_model(
                 self.initialize_path, policy, reset_global_steps=reset_steps
             )
         elif self.load:
-            logger.info(f"Resuming from {self.model_path}")
+            logger.info(f"Resuming from {self.model_path}.")
             self._load_model(self.model_path, policy, reset_global_steps=reset_steps)
 
     def _load_model(

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -235,7 +235,7 @@ class TensorboardWriter(StatsWriter):
         for file_name in os.listdir(directory_name):
             if file_name.startswith("events.out"):
                 logger.warning(
-                    f"Deleting TensorBoard data {file_name} that was left over from a"
+                    f"Deleting TensorBoard data {file_name} that was left over from a "
                     "previous run."
                 )
                 full_fname = os.path.join(directory_name, file_name)


### PR DESCRIPTION
### Proposed change(s)

Add more verbose messages when using initialize-from and resume.

Also fix typo in tensorboard overwrite log. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
