### PR TITLE
[MLA-1909] Match3 and Camera/RenderTexture sensor GC improvements

### DIFF
--- a/DevProject/Packages/packages-lock.json
+++ b/DevProject/Packages/packages-lock.json
@@ -57,9 +57,7 @@
       "dependencies": {
         "com.unity.barracuda": "1.3.2-preview",
         "com.unity.modules.imageconversion": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.physics2d": "1.0.0"
+        "com.unity.modules.jsonserialize": "1.0.0"
       }
     },
     "com.unity.ml-agents.extensions": {
@@ -67,7 +65,8 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ml-agents": "2.0.0-exp.1"
+        "com.unity.ml-agents": "2.0.0-exp.1",
+        "com.unity.modules.physics": "1.0.0"
       }
     },
     "com.unity.nuget.mono-cecil": {

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3Sensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3Sensor.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 
 namespace Unity.MLAgents.Extensions.Match3
 {
-
     /// <summary>
     /// Delegate that provides integer values at a given (x,y) coordinate.
     /// </summary>
@@ -167,7 +166,6 @@ namespace Unity.MLAgents.Extensions.Match3
 
 
             return offset;
-
         }
 
         /// <inheritdoc/>
@@ -243,6 +241,9 @@ namespace Unity.MLAgents.Extensions.Match3
             return BuiltInSensorType.Match3Sensor;
         }
 
+        /// <summary>
+        /// Clean up the owned Texture2D.
+        /// </summary>
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_ObservationTexture))
@@ -279,7 +280,7 @@ namespace Unity.MLAgents.Extensions.Match3
             int channelOffset,
             int currentHeight,
             int currentWidth
-            )
+        )
         {
             var i = 0;
             // There's an implicit flip converting to PNG from texture, so make sure we

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3Sensor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3Sensor.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using Unity.MLAgents.Sensors;
 using UnityEngine;
-using Debug = UnityEngine.Debug;
-using Object = UnityEngine.Object;
 
 namespace Unity.MLAgents.Extensions.Match3
 {
@@ -245,24 +243,11 @@ namespace Unity.MLAgents.Extensions.Match3
             return BuiltInSensorType.Match3Sensor;
         }
 
-        static void DestroyTexture(Texture2D texture)
-        {
-            if (Application.isEditor)
-            {
-                // Edit Mode tests complain if we use Destroy()
-                Object.DestroyImmediate(texture);
-            }
-            else
-            {
-                Object.Destroy(texture);
-            }
-        }
-
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_ObservationTexture))
             {
-                DestroyTexture(m_ObservationTexture);
+                Utilities.DestroyTexture(m_ObservationTexture);
                 m_ObservationTexture = null;
             }
         }

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using Unity.MLAgents.Sensors;
 using UnityEngine;
 
@@ -20,15 +21,36 @@ namespace Unity.MLAgents.Extensions.Match3
         /// </summary>
         public Match3ObservationType ObservationType = Match3ObservationType.Vector;
 
+        private ISensor[] m_Sensors;
+
         /// <inheritdoc/>
         public override ISensor[] CreateSensors()
         {
+            // Clean up any existing sensors
+            Dispose();
+
             var board = GetComponent<AbstractBoard>();
             var cellSensor = Match3Sensor.CellTypeSensor(board, ObservationType, SensorName + " (cells)");
             // This can be null if numSpecialTypes is 0
             var specialSensor = Match3Sensor.SpecialTypeSensor(board, ObservationType, SensorName + " (special)");
-            return specialSensor != null ? new ISensor[] { cellSensor, specialSensor } : new ISensor[] { cellSensor };
+            m_Sensors = specialSensor != null
+                ? new ISensor[] { cellSensor, specialSensor }
+                : new ISensor[] { cellSensor };
+            return m_Sensors;
         }
 
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            if (m_Sensors != null)
+            {
+                for (var i = 0; i < m_Sensors.Length; i++)
+                {
+                    ((Match3Sensor)m_Sensors[i]).Dispose();
+                }
+
+                m_Sensors = null;
+            }
+        }
     }
 }

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
@@ -8,7 +8,7 @@ namespace Unity.MLAgents.Extensions.Match3
     /// Sensor component for a Match3 game.
     /// </summary>
     [AddComponentMenu("ML Agents/Match 3 Sensor", (int)MenuGroup.Sensors)]
-    public class Match3SensorComponent : SensorComponent
+    public class Match3SensorComponent : SensorComponent, IDisposable
     {
         /// <summary>
         /// Name of the generated Match3Sensor object.
@@ -40,7 +40,7 @@ namespace Unity.MLAgents.Extensions.Match3
         }
 
         /// <inheritdoc/>
-        public override void Dispose()
+        public void Dispose()
         {
             if (m_Sensors != null)
             {

--- a/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Match3/Match3SensorComponent.cs
@@ -35,11 +35,13 @@ namespace Unity.MLAgents.Extensions.Match3
             var specialSensor = Match3Sensor.SpecialTypeSensor(board, ObservationType, SensorName + " (special)");
             m_Sensors = specialSensor != null
                 ? new ISensor[] { cellSensor, specialSensor }
-                : new ISensor[] { cellSensor };
+            : new ISensor[] { cellSensor };
             return m_Sensors;
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Clean up the sensors created by CreateSensors().
+        /// </summary>
         public void Dispose()
         {
             if (m_Sensors != null)

--- a/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Editor/Match3/Match3SensorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework;
 using Unity.MLAgents.Extensions.Match3;
 using UnityEngine;
@@ -244,6 +245,17 @@ namespace Unity.MLAgents.Extensions.Tests.Match3
                 };
                 SensorTestHelper.CompareObservation(specialSensor, expectedObs3D);
             }
+
+            // Test that Dispose() cleans up the component and its sensors
+            sensorComponent.Dispose();
+
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var componentSensors = (ISensor[])typeof(Match3SensorComponent).GetField("m_Sensors", flags).GetValue(sensorComponent);
+            Assert.IsNull(componentSensors);
+            var cellTexture = (Texture2D)typeof(Match3Sensor).GetField("m_ObservationTexture", flags).GetValue(cellSensor);
+            Assert.IsNull(cellTexture);
+            var specialTexture = (Texture2D)typeof(Match3Sensor).GetField("m_ObservationTexture", flags).GetValue(cellSensor);
+            Assert.IsNull(specialTexture);
         }
 
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -52,6 +52,11 @@ determine whether `Agent.RequestDecision()` and `Agent.RequestAction()` are call
 - `RaycastPerceptionSensor` now caches its raycast results; they can be accessed via `RayPerceptionSensor.RayPerceptionOutput`. (#5222)
 - `ActionBuffers` are now reset to zero before being passed to `Agent.Heuristic()` and
 `IHeuristicProvider.Heuristic()`. (#5227)
+- `Agent` will now call `IDisposable.Dispose()` on all `ISensor`s that implement the `IDisposable` interface. (#5233)
+- `CameraSensor`, `RenderTextureSensor`, and `Match3Sensor` will now reuse their `Texture2D`s, reducing the
+amount of memory that needs to be allocated during runtime. (#5233)
+- Optimzed `ObservationWriter.WriteTexture()` so that it doesn't call `Texture2D.GetPixels32()` for `RGB24` textures.
+This results in much less memory being allocated during inference with `CameraSensor` and `RenderTextureSensor`. (#5233)
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Some console output have been moved from `info` to `debug` and will not be printed by default. If you want all messages to be printed, you can run `mlagents-learn` with the `--debug` option or add the line `debug: true` at the top of the yaml config file. (#5211)

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -542,6 +542,8 @@ namespace Unity.MLAgents
                 Academy.Instance.AgentForceReset -= _AgentReset;
                 NotifyAgentDone(DoneReason.Disabled);
             }
+
+            CleanupSensors();
             m_Brain?.Dispose();
             OnAgentDisabled?.Invoke(this);
             m_Initialized = false;
@@ -1002,6 +1004,25 @@ namespace Unity.MLAgents
                     "Sensor names must be unique.");
             }
 #endif
+        }
+
+        void CleanupSensors()
+        {
+            // Get all attached sensor components
+            SensorComponent[] attachedSensorComponents;
+            if (m_PolicyFactory.UseChildSensors)
+            {
+                attachedSensorComponents = GetComponentsInChildren<SensorComponent>();
+            }
+            else
+            {
+                attachedSensorComponents = GetComponents<SensorComponent>();
+            }
+
+            for (var i = 0; i < attachedSensorComponents.Length; i++)
+            {
+                attachedSensorComponents[i].Dispose();
+            }
         }
 
         void InitializeActuators()

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1008,20 +1008,14 @@ namespace Unity.MLAgents
 
         void CleanupSensors()
         {
-            // Get all attached sensor components
-            SensorComponent[] attachedSensorComponents;
-            if (m_PolicyFactory.UseChildSensors)
+            // Dispose all attached sensor
+            for (var i = 0; i < sensors.Count; i++)
             {
-                attachedSensorComponents = GetComponentsInChildren<SensorComponent>();
-            }
-            else
-            {
-                attachedSensorComponents = GetComponents<SensorComponent>();
-            }
-
-            for (var i = 0; i < attachedSensorComponents.Length; i++)
-            {
-                attachedSensorComponents[i].Dispose();
+                var sensor = sensors[i];
+                if (sensor is IDisposable disposableSensor)
+                {
+                    disposableSensor.Dispose();
+                }
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -1,7 +1,6 @@
 using System;
 using UnityEngine;
 using UnityEngine.Rendering;
-using Object = UnityEngine.Object;
 
 namespace Unity.MLAgents.Sensors
 {
@@ -178,20 +177,6 @@ namespace Unity.MLAgents.Sensors
             return new[] { height, width, grayscale ? 1 : 3 };
         }
 
-        static void DestroyTexture(Texture2D texture)
-        {
-            if (Application.isEditor)
-            {
-                // Edit Mode tests complain if we use Destroy()
-                // TODO move to extension methods for UnityEngine.Object?
-                Object.DestroyImmediate(texture);
-            }
-            else
-            {
-                Object.Destroy(texture);
-            }
-        }
-
         /// <inheritdoc/>
         public BuiltInSensorType GetBuiltInSensorType()
         {
@@ -202,7 +187,7 @@ namespace Unity.MLAgents.Sensors
         {
             if (!ReferenceEquals(null, m_Texture))
             {
-                DestroyTexture(m_Texture);
+                Utilities.DestroyTexture(m_Texture);
                 m_Texture = null;
             }
         }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -170,6 +170,7 @@ namespace Unity.MLAgents.Sensors
             return BuiltInSensorType.CameraSensor;
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_Texture))

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -126,7 +126,6 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// Renders a Camera instance to a 2D texture at the corresponding resolution.
         /// </summary>
-        /// <returns>The 2D texture.</returns>
         /// <param name="obsCamera">Camera.</param>
         /// <param name="texture2D">Texture2D to render to.</param>
         /// <param name="width">Width of resulting 2D texture.</param>
@@ -170,7 +169,9 @@ namespace Unity.MLAgents.Sensors
             return BuiltInSensorType.CameraSensor;
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Clean up the owned Texture2D.
+        /// </summary>
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_Texture))

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensor.cs
@@ -164,19 +164,6 @@ namespace Unity.MLAgents.Sensors
             RenderTexture.ReleaseTemporary(tempRt);
         }
 
-        /// <summary>
-        /// Computes the observation shape for a camera sensor based on the height, width
-        /// and grayscale flag.
-        /// </summary>
-        /// <param name="width">Width of the image captures from the camera.</param>
-        /// <param name="height">Height of the image captures from the camera.</param>
-        /// <param name="grayscale">Whether or not to convert the image to grayscale.</param>
-        /// <returns>The observation shape.</returns>
-        internal static int[] GenerateShape(int width, int height, bool grayscale)
-        {
-            return new[] { height, width, grayscale ? 1 : 3 };
-        }
-
         /// <inheritdoc/>
         public BuiltInSensorType GetBuiltInSensorType()
         {

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -143,6 +143,9 @@ namespace Unity.MLAgents.Sensors
             }
         }
 
+        /// <summary>
+        /// Clean up the sensor created by CreateSensors().
+        /// </summary>
         public void Dispose()
         {
             if (!ReferenceEquals(m_Sensor, null))

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -140,5 +140,15 @@ namespace Unity.MLAgents.Sensors
                 m_Sensor.CompressionType = m_Compression;
             }
         }
+
+        public override void Dispose()
+        {
+            if (!ReferenceEquals(m_Sensor, null))
+            {
+                m_Sensor.Dispose();
+                m_Sensor = null;
+            }
+            base.Dispose();
+        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CameraSensorComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -7,7 +8,7 @@ namespace Unity.MLAgents.Sensors
     /// A SensorComponent that creates a <see cref="CameraSensor"/>.
     /// </summary>
     [AddComponentMenu("ML Agents/Camera Sensor", (int)MenuGroup.Sensors)]
-    public class CameraSensorComponent : SensorComponent
+    public class CameraSensorComponent : SensorComponent, IDisposable
     {
         [HideInInspector, SerializeField, FormerlySerializedAs("camera")]
         Camera m_Camera;
@@ -120,6 +121,7 @@ namespace Unity.MLAgents.Sensors
         /// <returns>The created <see cref="CameraSensor"/> object for this component.</returns>
         public override ISensor[] CreateSensors()
         {
+            Dispose();
             m_Sensor = new CameraSensor(m_Camera, m_Width, m_Height, Grayscale, m_SensorName, m_Compression, m_ObservationType);
 
             if (ObservationStacks != 1)
@@ -141,14 +143,13 @@ namespace Unity.MLAgents.Sensors
             }
         }
 
-        public override void Dispose()
+        public void Dispose()
         {
             if (!ReferenceEquals(m_Sensor, null))
             {
                 m_Sensor.Dispose();
                 m_Sensor = null;
             }
-            base.Dispose();
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -45,7 +45,6 @@ namespace Unity.MLAgents.Sensors
             m_ObservationSpec = ObservationSpec.Visual(height, width, grayscale ? 1 : 3);
             m_CompressionType = compressionType;
             m_Texture = new Texture2D(width, height, TextureFormat.RGB24, false);
-
         }
 
         /// <inheritdoc/>
@@ -104,7 +103,6 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// Converts a RenderTexture to a 2D texture.
         /// </summary>
-        /// <returns>The 2D texture.</returns>
         /// <param name="obsTexture">RenderTexture.</param>
         /// <param name="texture2D">Texture2D to render to.</param>
         public static void ObservationToTexture(RenderTexture obsTexture, Texture2D texture2D)
@@ -120,6 +118,9 @@ namespace Unity.MLAgents.Sensors
             RenderTexture.active = prevActiveRt;
         }
 
+        /// <summary>
+        /// Clean up the owned Texture2D.
+        /// </summary>
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_Texture))

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Unity.MLAgents.Sensors
 {
@@ -121,25 +120,11 @@ namespace Unity.MLAgents.Sensors
             RenderTexture.active = prevActiveRt;
         }
 
-        static void DestroyTexture(Texture2D texture)
-        {
-            if (Application.isEditor)
-            {
-                // Edit Mode tests complain if we use Destroy()
-                // TODO move to extension methods for UnityEngine.Object?
-                Object.DestroyImmediate(texture);
-            }
-            else
-            {
-                Object.Destroy(texture);
-            }
-        }
-
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_Texture))
             {
-                DestroyTexture(m_Texture);
+                Utilities.DestroyTexture(m_Texture);
                 m_Texture = null;
             }
         }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -1,17 +1,20 @@
+using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Unity.MLAgents.Sensors
 {
     /// <summary>
     /// Sensor class that wraps a [RenderTexture](https://docs.unity3d.com/ScriptReference/RenderTexture.html) instance.
     /// </summary>
-    public class RenderTextureSensor : ISensor, IBuiltInSensor
+    public class RenderTextureSensor : ISensor, IBuiltInSensor, IDisposable
     {
         RenderTexture m_RenderTexture;
         bool m_Grayscale;
         string m_Name;
         private ObservationSpec m_ObservationSpec;
         SensorCompressionType m_CompressionType;
+        Texture2D m_Texture;
 
         /// <summary>
         /// The compression type used by the sensor.
@@ -42,6 +45,8 @@ namespace Unity.MLAgents.Sensors
             m_Name = name;
             m_ObservationSpec = ObservationSpec.Visual(height, width, grayscale ? 1 : 3);
             m_CompressionType = compressionType;
+            m_Texture = new Texture2D(width, height, TextureFormat.RGB24, false);
+
         }
 
         /// <inheritdoc/>
@@ -61,10 +66,9 @@ namespace Unity.MLAgents.Sensors
         {
             using (TimerStack.Instance.Scoped("RenderTextureSensor.GetCompressedObservation"))
             {
-                var texture = ObservationToTexture(m_RenderTexture);
+                ObservationToTexture(m_RenderTexture, m_Texture);
                 // TODO support more types here, e.g. JPG
-                var compressed = texture.EncodeToPNG();
-                DestroyTexture(texture);
+                var compressed = m_Texture.EncodeToPNG();
                 return compressed;
             }
         }
@@ -74,9 +78,8 @@ namespace Unity.MLAgents.Sensors
         {
             using (TimerStack.Instance.Scoped("RenderTextureSensor.Write"))
             {
-                var texture = ObservationToTexture(m_RenderTexture);
-                var numWritten = writer.WriteTexture(texture, m_Grayscale);
-                DestroyTexture(texture);
+                ObservationToTexture(m_RenderTexture, m_Texture;
+                var numWritten = writer.WriteTexture(m_Texture, m_Grayscale);
                 return numWritten;
             }
         }
@@ -104,12 +107,11 @@ namespace Unity.MLAgents.Sensors
         /// </summary>
         /// <returns>The 2D texture.</returns>
         /// <param name="obsTexture">RenderTexture.</param>
-        /// <returns name="texture2D">Texture2D to render to.</returns>
-        public static Texture2D ObservationToTexture(RenderTexture obsTexture)
+        /// <param name="texture2D">Texture2D to render to.</param>
+        public static void ObservationToTexture(RenderTexture obsTexture, Texture2D texture2D)
         {
             var height = obsTexture.height;
             var width = obsTexture.width;
-            var texture2D = new Texture2D(width, height, TextureFormat.RGB24, false);
 
             var prevActiveRt = RenderTexture.active;
             RenderTexture.active = obsTexture;
@@ -117,7 +119,6 @@ namespace Unity.MLAgents.Sensors
             texture2D.ReadPixels(new Rect(0, 0, texture2D.width, texture2D.height), 0, 0);
             texture2D.Apply();
             RenderTexture.active = prevActiveRt;
-            return texture2D;
         }
 
         static void DestroyTexture(Texture2D texture)
@@ -131,6 +132,15 @@ namespace Unity.MLAgents.Sensors
             else
             {
                 Object.Destroy(texture);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!ReferenceEquals(null, m_Texture))
+            {
+                DestroyTexture(m_Texture);
+                m_Texture = null;
             }
         }
     }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensor.cs
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Sensors
         {
             using (TimerStack.Instance.Scoped("RenderTextureSensor.Write"))
             {
-                ObservationToTexture(m_RenderTexture, m_Texture;
+                ObservationToTexture(m_RenderTexture, m_Texture);
                 var numWritten = writer.WriteTexture(m_Texture, m_Grayscale);
                 return numWritten;
             }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -102,5 +102,15 @@ namespace Unity.MLAgents.Sensors
                 m_Sensor.CompressionType = m_Compression;
             }
         }
+
+        public override void Dispose()
+        {
+            if (!ReferenceEquals(null, m_Sensor))
+            {
+                m_Sensor.Dispose();
+                m_Sensor = null;
+            }
+            base.Dispose();
+        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -105,7 +105,9 @@ namespace Unity.MLAgents.Sensors
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Clean up the sensor created by CreateSensors().
+        /// </summary>
         public void Dispose()
         {
             if (!ReferenceEquals(null, m_Sensor))

--- a/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RenderTextureSensorComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -7,7 +8,7 @@ namespace Unity.MLAgents.Sensors
     /// Component that wraps a <see cref="RenderTextureSensor"/>.
     /// </summary>
     [AddComponentMenu("ML Agents/Render Texture Sensor", (int)MenuGroup.Sensors)]
-    public class RenderTextureSensorComponent : SensorComponent
+    public class RenderTextureSensorComponent : SensorComponent, IDisposable
     {
         RenderTextureSensor m_Sensor;
 
@@ -84,6 +85,7 @@ namespace Unity.MLAgents.Sensors
         /// <inheritdoc/>
         public override ISensor[] CreateSensors()
         {
+            Dispose();
             m_Sensor = new RenderTextureSensor(RenderTexture, Grayscale, SensorName, m_Compression);
             if (ObservationStacks != 1)
             {
@@ -103,14 +105,14 @@ namespace Unity.MLAgents.Sensors
             }
         }
 
-        public override void Dispose()
+        /// <inheritdoc/>
+        public void Dispose()
         {
             if (!ReferenceEquals(null, m_Sensor))
             {
                 m_Sensor.Dispose();
                 m_Sensor = null;
             }
-            base.Dispose();
         }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
@@ -7,16 +7,12 @@ namespace Unity.MLAgents.Sensors
     /// Editor components for creating Sensors. Generally an ISensor implementation should have a
     /// corresponding SensorComponent to create it.
     /// </summary>
-    public abstract class SensorComponent : MonoBehaviour, IDisposable
+    public abstract class SensorComponent : MonoBehaviour
     {
         /// <summary>
         /// Create the ISensors. This is called by the Agent when it is initialized.
         /// </summary>
         /// <returns>Created ISensor objects.</returns>
         public abstract ISensor[] CreateSensors();
-
-        public virtual void Dispose()
-        {
-        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorComponent.cs
@@ -7,12 +7,16 @@ namespace Unity.MLAgents.Sensors
     /// Editor components for creating Sensors. Generally an ISensor implementation should have a
     /// corresponding SensorComponent to create it.
     /// </summary>
-    public abstract class SensorComponent : MonoBehaviour
+    public abstract class SensorComponent : MonoBehaviour, IDisposable
     {
         /// <summary>
         /// Create the ISensors. This is called by the Agent when it is initialized.
         /// </summary>
         /// <returns>Created ISensor objects.</returns>
         public abstract ISensor[] CreateSensors();
+
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/com.unity.ml-agents/Runtime/Utilities.cs
+++ b/com.unity.ml-agents/Runtime/Utilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using UnityEngine;
 
 namespace Unity.MLAgents
 {
@@ -24,6 +25,23 @@ namespace Unity.MLAgents
                 result[actionIndex + 1] = runningSum;
             }
             return result;
+        }
+
+        /// <summary>
+        /// Safely destroy a texture. This has to be used differently in unit tests.
+        /// </summary>
+        /// <param name="texture"></param>
+        internal static void DestroyTexture(Texture2D texture)
+        {
+            if (Application.isEditor)
+            {
+                // Edit Mode tests complain if we use Destroy()
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+            else
+            {
+                UnityEngine.Object.Destroy(texture);
+            }
         }
 
         [Conditional("DEBUG")]

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorComponentTest.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/CameraSensorComponentTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.MLAgents.Sensors;
@@ -33,6 +34,14 @@ namespace Unity.MLAgents.Tests
                     var expectedShape = new InplaceArray<int>(height, width, grayscale ? 1 : 3);
                     Assert.AreEqual(expectedShape, sensor.GetObservationSpec().Shape);
                     Assert.AreEqual(typeof(CameraSensor), sensor.GetType());
+
+                    // Make sure cleaning up the component cleans up the sensor too
+                    cameraComponent.Dispose();
+                    var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+                    var cameraComponentSensor = (CameraSensor)typeof(CameraSensorComponent).GetField("m_Sensor", flags).GetValue(cameraComponent);
+                    Assert.IsNull(cameraComponentSensor);
+                    var cameraTexture = (Texture2D)typeof(CameraSensor).GetField("m_Texture", flags).GetValue(sensor);
+                    Assert.IsNull(cameraTexture);
                 }
             }
         }


### PR DESCRIPTION
### Proposed change(s)
* Reuse `Texture2D`s to avoid allocations
* Agent now calls `Dispose()` on any `ISensor`s that implement `IDisposable`.
* Special-case RGB24 texture->ObservationWriter (which is what Camera and RenderTexture Sensors user for inference) to avoid GetPixels32(), which allocates a copy of the pixel data.

#### Match3Sensor
Before
![image](https://user-images.githubusercontent.com/6877802/114249709-39239a00-9950-11eb-8795-d50f64fee8a8.png)
After
![image](https://user-images.githubusercontent.com/6877802/114249725-404aa800-9950-11eb-8c63-525cf62ceebe.png)

#### GridWorld (Camera + RenderTexture Sensors)
Before
![image](https://user-images.githubusercontent.com/6877802/114249756-55273b80-9950-11eb-94de-609ec97ed6c8.png)
After
![image](https://user-images.githubusercontent.com/6877802/114249777-66704800-9950-11eb-9c55-bd3bd19fe5c4.png)



### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://jira.unity3d.com/browse/MLA-1909
https://jira.unity3d.com/browse/MLA-1910
https://jira.unity3d.com/browse/MLA-208

### Types of change(s)

- [x] Bug fix
- [x] New feature
- [x] Code refactor

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)

### Other comments
