### PR TITLE
avoid empty set iteration, avoid Debug.AssertFormat

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -61,6 +61,7 @@ determine whether `Agent.RequestDecision()` and `Agent.RequestAction()` are call
 - Fixed a bug where sensors and actuators could get sorted inconsistently on different systems to different Culture
 settings. Unfortunately, this may require retraining models if it changes the resulting order of the sensors
 or actuators on your system. (#5194)
+- Removed additional memory allocations that were occurring due to assert messages and iterating of DemonstrationRecorders. (#5246)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed an issue which was causing increased variance when using LSTMs. Also fixed an issue with LSTM when used with POCA and `sequence_length` < `time_horizon`. (#5206)
 - Fixed a bug where the SAC replay buffer would not be saved out at the end of a run, even if `save_replay_buffer` was enabled. (#5205)

--- a/com.unity.ml-agents/Runtime/Actuators/ActuatorManager.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/ActuatorManager.cs
@@ -174,10 +174,13 @@ namespace Unity.MLAgents.Actuators
             }
             else
             {
-                Debug.AssertFormat(sourceActionBuffer.Length == destination.Length,
-                    "sourceActionBuffer: {0} is a different size than destination: {1}.",
-                    sourceActionBuffer.Length,
-                    destination.Length);
+                if (sourceActionBuffer.Length != destination.Length)
+                {
+                    Debug.AssertFormat(sourceActionBuffer.Length == destination.Length,
+                        "sourceActionBuffer: {0} is a different size than destination: {1}.",
+                        sourceActionBuffer.Length,
+                        destination.Length);
+                }
 
                 Array.Copy(sourceActionBuffer.Array,
                     sourceActionBuffer.Offset,

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -574,9 +574,12 @@ namespace Unity.MLAgents
             m_Brain?.RequestDecision(m_Info, sensors);
 
             // We also have to write any to any DemonstationStores so that they get the "done" flag.
-            foreach (var demoWriter in DemonstrationWriters)
+            if (DemonstrationWriters.Count != 0)
             {
-                demoWriter.Record(m_Info, sensors);
+                foreach (var demoWriter in DemonstrationWriters)
+                {
+                    demoWriter.Record(m_Info, sensors);
+                }
             }
 
             ResetSensors();
@@ -1082,9 +1085,12 @@ namespace Unity.MLAgents
             }
 
             // If we have any DemonstrationWriters, write the AgentInfo and sensors to them.
-            foreach (var demoWriter in DemonstrationWriters)
+            if (DemonstrationWriters.Count != 0)
             {
-                demoWriter.Record(m_Info, sensors);
+                foreach (var demoWriter in DemonstrationWriters)
+                {
+                    demoWriter.Record(m_Info, sensors);
+                }
             }
         }
 

--- a/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/SensorShapeValidator.cs
@@ -25,23 +25,29 @@ namespace Unity.MLAgents.Sensors
             else
             {
                 // Check for compatibility with the other Agents' Sensors
-                // TODO make sure this only checks once per agent
-                Debug.AssertFormat(
-                    m_SensorShapes.Count == sensors.Count,
-                    "Number of Sensors must match. {0} != {1}",
-                    m_SensorShapes.Count,
-                    sensors.Count
-                );
+                if (m_SensorShapes.Count != sensors.Count)
+                {
+                    Debug.AssertFormat(
+                        m_SensorShapes.Count == sensors.Count,
+                        "Number of Sensors must match. {0} != {1}",
+                        m_SensorShapes.Count,
+                        sensors.Count
+                    );
+                }
                 for (var i = 0; i < Mathf.Min(m_SensorShapes.Count, sensors.Count); i++)
                 {
                     var cachedSpec = m_SensorShapes[i];
                     var sensorSpec = sensors[i].GetObservationSpec();
-                    Debug.AssertFormat(
-                        cachedSpec.Shape == sensorSpec.Shape,
-                        "Sensor shapes must match. {0} != {1}",
-                        cachedSpec.Shape,
-                        sensorSpec.Shape
-                    );
+                    if (cachedSpec.Shape != sensorSpec.Shape)
+                    {
+                        Debug.AssertFormat(
+                            cachedSpec.Shape == sensorSpec.Shape,
+                            "Sensor shapes must match. {0} != {1}",
+                            cachedSpec.Shape,
+                            sensorSpec.Shape
+                        );
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Proposed change(s)
Remove some extra sources of garbage-collected memory during runtime:
* Don't iterate of the set of DemonstrationRecorders if it's empty (this still allocates an iterator).
* Wrap calls to Debug.AssertFormat in their own condition (this still allocates the `object[]` for the parameters).

#### Before
![image](https://user-images.githubusercontent.com/6877802/114439135-82a4fc80-9b7d-11eb-99db-9342a6a2c644.png)
![image](https://user-images.githubusercontent.com/6877802/114439152-86d11a00-9b7d-11eb-80b9-2f6009e4f001.png)

#### After

![image](https://user-images.githubusercontent.com/6877802/114439354-bbdd6c80-9b7d-11eb-9415-46ffdf5388da.png)


### Types of change(s)
- [x] Bug fix

### Checklist
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)

### Other comments
