### PR TITLE
Extend StatsWriter to allow handling of individual stat updates

### DIFF
--- a/docs/Training-Plugins.md
+++ b/docs/Training-Plugins.md
@@ -51,7 +51,8 @@ each summary period. By default, we log this information to the console and writ
 #### Interface
 The `StatsWriter.write_stats()` method must be implemented in any derived classes. It takes a "category" parameter,
 which typically is the behavior name of the Agents being trained, and a dictionary of `StatSummary` values with
-string keys.
+string keys. Additionally, `StatsWriter.on_add_stat()` may be extended to register a callback handler for each stat
+emission.
 
 #### Registration
 The `StatsWriter` registration function takes a `RunOptions` argument and returns a list of `StatsWriter`s. An

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -344,7 +344,9 @@ class StatsReporter:
                 key
             ] = StatsAggregationMethod.MOST_RECENT
             for writer in StatsReporter.writers:
-                writer.on_add_stat(self.category, key, value, StatsAggregationMethod.MOST_RECENT)
+                writer.on_add_stat(
+                    self.category, key, value, StatsAggregationMethod.MOST_RECENT
+                )
 
     def write_stats(self, step: int) -> None:
         """

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -94,9 +94,10 @@ class StatsWriter(abc.ABC):
         Callback method for handling an individual stat value as reported to the StatsReporter add_stat
         or set_stat methods.
 
+        :param category: Category of the statistics. Usually this is the behavior name.
         :param key: The type of statistic, e.g. Environment/Reward.
-        :param value: the value of the statistic.
-        :param aggregation: the aggregation method for the statistic, default StatsAggregationMethod.AVERAGE.
+        :param value: The value of the statistic.
+        :param aggregation: The aggregation method for the statistic, default StatsAggregationMethod.AVERAGE.
         """
         pass
 

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -85,6 +85,7 @@ class StatsWriter(abc.ABC):
 
     def on_add_stat(
         self,
+        category: str,
         key: str,
         value: float,
         aggregation: StatsAggregationMethod = StatsAggregationMethod.AVERAGE,
@@ -327,7 +328,7 @@ class StatsReporter:
             StatsReporter.stats_dict[self.category][key].append(value)
             StatsReporter.stats_aggregation[self.category][key] = aggregation
             for writer in StatsReporter.writers:
-                writer.on_add_stat(key, value, aggregation)
+                writer.on_add_stat(self.category, key, value, aggregation)
 
     def set_stat(self, key: str, value: float) -> None:
         """
@@ -343,7 +344,7 @@ class StatsReporter:
                 key
             ] = StatsAggregationMethod.MOST_RECENT
             for writer in StatsReporter.writers:
-                writer.on_add_stat(key, value, StatsAggregationMethod.MOST_RECENT)
+                writer.on_add_stat(self.category, key, value, StatsAggregationMethod.MOST_RECENT)
 
     def write_stats(self, step: int) -> None:
         """

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -83,14 +83,15 @@ class StatsWriter(abc.ABC):
     and writes it out by some method.
     """
 
-    def add_stat(
+    def on_add_stat(
         self,
         key: str,
         value: float,
         aggregation: StatsAggregationMethod = StatsAggregationMethod.AVERAGE,
     ) -> None:
         """
-        Handle an individual value stat reported to the StatsReporter.
+        Callback method for handling an individual stat value as reported to the StatsReporter add_stat
+        or set_stat methods.
 
         :param key: The type of statistic, e.g. Environment/Reward.
         :param value: the value of the statistic.
@@ -326,7 +327,7 @@ class StatsReporter:
             StatsReporter.stats_dict[self.category][key].append(value)
             StatsReporter.stats_aggregation[self.category][key] = aggregation
             for writer in StatsReporter.writers:
-                writer.add_stat(key, value, aggregation)
+                writer.on_add_stat(key, value, aggregation)
 
     def set_stat(self, key: str, value: float) -> None:
         """
@@ -342,7 +343,7 @@ class StatsReporter:
                 key
             ] = StatsAggregationMethod.MOST_RECENT
             for writer in StatsReporter.writers:
-                writer.add_stat(key, value, StatsAggregationMethod.MOST_RECENT)
+                writer.on_add_stat(key, value, StatsAggregationMethod.MOST_RECENT)
 
     def write_stats(self, step: int) -> None:
         """

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -83,7 +83,6 @@ class StatsWriter(abc.ABC):
     and writes it out by some method.
     """
 
-    @abc.abstractmethod
     def add_stat(
         self,
         key: str,
@@ -98,7 +97,6 @@ class StatsWriter(abc.ABC):
         :param aggregation: the aggregation method for the statistic, default StatsAggregationMethod.AVERAGE.
         """
         pass
-
 
     @abc.abstractmethod
     def write_stats(

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -32,6 +32,15 @@ def test_stat_reporter_add_summary_write():
         statsreporter1.add_stat("key1", float(i))
         statsreporter2.add_stat("key2", float(i))
 
+    statsreportercalls = [
+        mock.call(f"key{j}", float(i), StatsAggregationMethod.AVERAGE)
+        for i in range(10)
+        for j in [1, 2]
+    ]
+
+    mock_writer1.on_add_stat.assert_has_calls(statsreportercalls)
+    mock_writer2.on_add_stat.assert_has_calls(statsreportercalls)
+
     statssummary1 = statsreporter1.get_stats_summaries("key1")
     statssummary2 = statsreporter2.get_stats_summaries("key2")
 

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -33,7 +33,7 @@ def test_stat_reporter_add_summary_write():
         statsreporter2.add_stat("key2", float(i))
 
     statsreportercalls = [
-        mock.call(f"key{j}", float(i), StatsAggregationMethod.AVERAGE)
+        mock.call(f"category{j}", f"key{j}", float(i), StatsAggregationMethod.AVERAGE)
         for i in range(10)
         for j in [1, 2]
     ]


### PR DESCRIPTION
### Proposed change(s)

Expose add_stat to the StatsWriter interface so users can handle individual stat events if they choose.
 
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)


### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
