### PR TITLE
pin CI image version

### DIFF
--- a/.yamato/com.unity.ml-agents-optional-dep-tests.yml
+++ b/.yamato/com.unity.ml-agents-optional-dep-tests.yml
@@ -15,7 +15,7 @@ OptionalDependencyTests_{{ optional_dep.name }}:
     name : Test Optional Package Dependencies {{ optional_dep.name }}
     agent:
         type: Unity::VM
-        image: package-ci/ubuntu:stable
+        image: package-ci/ubuntu:v1.3.1-719011
         flavor: b1.medium
     commands:
         - |

--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -2,7 +2,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.small
   commands:
     - |

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -27,7 +27,7 @@ test_platforms:
       flavor: b1.small
     - name: linux
       type: Unity::VM
-      image: package-ci/ubuntu:stable
+      image: package-ci/ubuntu:v1.3.1-719011
       flavor: b1.medium
 
 packages:

--- a/.yamato/compressed-sensor-test.yml
+++ b/.yamato/compressed-sensor-test.yml
@@ -5,7 +5,7 @@ test_compressed_obs_{{ editor.version }}:
   name: Test Compressed Sensor Observation {{ editor.version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/coverage_tests.metafile
+++ b/.yamato/coverage_tests.metafile
@@ -5,7 +5,7 @@ coverage_test_editors:
 coverage_test_platforms:
     - name: linux
       type: Unity::VM
-      image: package-ci/ubuntu:stable
+      image: package-ci/ubuntu:v1.3.1-719011
       flavor: b1.medium
 
 coverage_test_packages:

--- a/.yamato/gym-interface-test.yml
+++ b/.yamato/gym-interface-test.yml
@@ -5,7 +5,7 @@ test_gym_interface_{{ editor.version }}:
   name: Test Linux Gym Interface {{ editor.version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/protobuf-generation-test.yml
+++ b/.yamato/protobuf-generation-test.yml
@@ -2,7 +2,7 @@ test_linux_protobuf_generation:
   name: Protobuf Generation Tests
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.large
   variables:
     GRPC_VERSION: "1.14.1"

--- a/.yamato/pytest-gpu.yml
+++ b/.yamato/pytest-gpu.yml
@@ -2,7 +2,7 @@ pytest_gpu:
   name: Pytest GPU
   agent:
     type: Unity::VM::GPU
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.large
   commands:
     - |

--- a/.yamato/python-ll-api-test.yml
+++ b/.yamato/python-ll-api-test.yml
@@ -5,7 +5,7 @@ test_linux_ll_api_{{ editor.version }}:
   name: Test Linux LL-API {{ editor.version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -5,7 +5,7 @@ test_linux_standalone_{{ editor.version }}:
   name: Test Linux Standalone {{ editor.version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.large
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/standalone-build-webgl-test.yml
+++ b/.yamato/standalone-build-webgl-test.yml
@@ -3,7 +3,7 @@ test_webgl_standalone_{{ editor_version }}:
   name: Test WebGL Standalone {{ editor_version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.large
   variables:
     UNITY_VERSION: {{ editor_version }}

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -5,7 +5,7 @@ test_linux_training_int_{{ editor.version }}:
   name: Test Linux Fast Training {{ editor.version }}
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v1.3.1-719011
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}


### PR DESCRIPTION
### Proposed change(s)
Update all ubuntu imagse to `package-ci/ubuntu:v1.3.1-719011`
We should revert this when the `stable` image is, well, stable.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://unity.slack.com/archives/C26EP4SUQ/p1618313475307600


### Types of change(s)
- [x] CI
