### PR TITLE
Fix errors when creating new RayCast sensor

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -63,6 +63,7 @@ This results in much less memory being allocated during inference with `CameraSe
 settings. Unfortunately, this may require retraining models if it changes the resulting order of the sensors
 or actuators on your system. (#5194)
 - Removed additional memory allocations that were occurring due to assert messages and iterating of DemonstrationRecorders. (#5246)
+- Fixed a bug where agent trying to access unintialized fields when creating a new RayPerceptionSensorComponent on an agent. (#5261)
 
 ## [1.9.1-preview] - 2021-04-13
 ### Major Changes

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Sensors
         /// <returns></returns>
         public int OutputSize()
         {
-            return (DetectableTags?.Count ?? 0 + 2) * Angles?.Count ?? 0;
+            return ((DetectableTags?.Count ?? 0) + 2) * (Angles?.Count ?? 0);
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensor.cs
@@ -78,7 +78,7 @@ namespace Unity.MLAgents.Sensors
         /// <returns></returns>
         public int OutputSize()
         {
-            return (DetectableTags.Count + 2) * Angles.Count;
+            return (DetectableTags?.Count ?? 0 + 2) * Angles?.Count ?? 0;
         }
 
         /// <summary>

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/RayPerceptionSensorTests.cs
@@ -420,6 +420,19 @@ namespace Unity.MLAgents.Tests
                 Assert.AreEqual(-1, castOutput.RayOutputs[0].HitTagIndex);
             }
         }
+
+        [Test]
+        public void TestCreateDefault()
+        {
+            SetupScene();
+            var obj = new GameObject("agent");
+            var perception = obj.AddComponent<RayPerceptionSensorComponent3D>();
+
+            Assert.DoesNotThrow(() =>
+            {
+                perception.CreateSensors();
+            });
+        }
 #endif
     }
 }


### PR DESCRIPTION
### Proposed change(s)

If you create an agent, and then add a RayPerceptionSensorComponent, the editor will keep throwing error: `NullReferenceException: Object reference not set to an instance of an object`

The Agent is trying to get OutputSize while RayPerceptionSensor.DetectableTags/Angles are still null.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
