### PR TITLE
Fix GridSensorComponent bug

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/GridSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/GridSensorComponent.cs
@@ -184,7 +184,7 @@ namespace Unity.MLAgents.Sensors
         /// <inheritdoc/>
         public override ISensor[] CreateSensors()
         {
-            List<ISensor> m_Sensors = new List<ISensor>();
+            m_Sensors = new List<ISensor>();
             m_BoxOverlapChecker = new BoxOverlapChecker(
                 m_CellScale,
                 m_GridSize,

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/GridSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/GridSensorTests.cs
@@ -80,6 +80,19 @@ namespace Unity.MLAgents.Tests
         }
 
         [Test]
+        public void TestCreateSensor()
+        {
+            testGo.tag = k_Tag2;
+            string[] tags = { k_Tag1, k_Tag2 };
+            gridSensorComponent.SetComponentParameters(tags, useBaseGridSensor: true);
+
+            var gridSensor = (GridSensorBase)gridSensorComponent.CreateSensors()[0];
+            var componentSensor = (GridSensorBase[])typeof(GridSensorComponent).GetField("m_Sensor",
+                        BindingFlags.Instance | BindingFlags.NonPublic).GetValue(gridSensorComponent);
+            Assert.AreEqual(componentSensor.Count, 1);
+        }
+
+        [Test]
         public void PerceiveNotSelf()
         {
             testGo.tag = k_Tag2;

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/GridSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/GridSensorTests.cs
@@ -1,5 +1,7 @@
 #if MLA_UNITY_PHYSICS_MODULE
+using System.Collections.Generic;
 using System.Collections;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -84,10 +86,10 @@ namespace Unity.MLAgents.Tests
         {
             testGo.tag = k_Tag2;
             string[] tags = { k_Tag1, k_Tag2 };
-            gridSensorComponent.SetComponentParameters(tags, useBaseGridSensor: true);
+            gridSensorComponent.SetComponentParameters(tags, useGridSensorBase: true);
 
-            var gridSensor = (GridSensorBase)gridSensorComponent.CreateSensors()[0];
-            var componentSensor = (GridSensorBase[])typeof(GridSensorComponent).GetField("m_Sensor",
+            gridSensorComponent.CreateSensors();
+            var componentSensor = (List<ISensor>)typeof(GridSensorComponent).GetField("m_Sensors",
                         BindingFlags.Instance | BindingFlags.NonPublic).GetValue(gridSensorComponent);
             Assert.AreEqual(componentSensor.Count, 1);
         }


### PR DESCRIPTION
### Proposed change(s)

GridSensorComponent.CreateSensors  accidentally created m_Sensors as local variable and not actually storing the sensor.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
