### PR TITLE
check for missing AbstractBoard, display warning

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3Drawer.cs
+++ b/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3Drawer.cs
@@ -105,6 +105,10 @@ namespace Unity.MLAgentsExamples
             if (!m_Board)
             {
                 m_Board = GetComponent<Match3Board>();
+                if (m_Board == null)
+                {
+                    return;
+                }
             }
 
             var currentSize = m_Board.GetCurrentBoardSize();

--- a/com.unity.ml-agents/Editor/Match3ActuatorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/Match3ActuatorComponentEditor.cs
@@ -11,6 +11,14 @@ namespace Unity.MLAgents.Editor
             var so = serializedObject;
             so.Update();
 
+            var component = (Match3ActuatorComponent)target;
+            var board = component.GetComponent<AbstractBoard>();
+            if (board == null)
+            {
+                EditorGUILayout.HelpBox("You must provide an implementation of an AbstractBoard.", MessageType.Warning);
+                return;
+            }
+
             // Drawing the RenderTextureComponent
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.ml-agents/Editor/Match3SensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/Match3SensorComponentEditor.cs
@@ -11,6 +11,14 @@ namespace Unity.MLAgents.Editor
             var so = serializedObject;
             so.Update();
 
+            var component = (Match3SensorComponent)target;
+            var board = component.GetComponent<AbstractBoard>();
+            if (board == null)
+            {
+                EditorGUILayout.HelpBox("You must provide an implementation of an AbstractBoard.", MessageType.Warning);
+                return;
+            }
+
             // Drawing the RenderTextureComponent
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.ml-agents/Runtime/Integrations/Match3/Match3ActuatorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Integrations/Match3/Match3ActuatorComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using Unity.MLAgents.Actuators;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -52,6 +53,11 @@ namespace Unity.MLAgents.Integrations.Match3
         public override IActuator[] CreateActuators()
         {
             var board = GetComponent<AbstractBoard>();
+            if (!board)
+            {
+                return Array.Empty<IActuator>();
+            }
+
             var seed = m_RandomSeed == -1 ? gameObject.GetInstanceID() : m_RandomSeed + 1;
             return new IActuator[] { new Match3Actuator(board, m_ForceHeuristic, seed, m_ActuatorName) };
         }

--- a/com.unity.ml-agents/Runtime/Integrations/Match3/Match3SensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Integrations/Match3/Match3SensorComponent.cs
@@ -45,6 +45,10 @@ namespace Unity.MLAgents.Integrations.Match3
             Dispose();
 
             var board = GetComponent<AbstractBoard>();
+            if (!board)
+            {
+                return Array.Empty<ISensor>();
+            }
             var cellSensor = Match3Sensor.CellTypeSensor(board, m_ObservationType, m_SensorName + " (cells)");
             // This can be null if numSpecialTypes is 0
             var specialSensor = Match3Sensor.SpecialTypeSensor(board, m_ObservationType, m_SensorName + " (special)");

--- a/com.unity.ml-agents/Tests/Editor/Integrations/Match3/Match3ActuatorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Integrations/Match3/Match3ActuatorTests.cs
@@ -194,5 +194,14 @@ namespace Unity.MLAgents.Tests.Integrations.Match3
             // And they should add up to all the potential moves
             Assert.AreEqual(validIndices.Count + masks.HashSets[0].Count, board.NumMoves());
         }
+
+        [Test]
+        public void TestNoBoardReturnsEmptyActuators()
+        {
+            var gameObj = new GameObject("board");
+            var actuatorComponent = gameObj.AddComponent<Match3ActuatorComponent>();
+            var actuators = actuatorComponent.CreateActuators();
+            Assert.AreEqual(0, actuators.Length);
+        }
     }
 }

--- a/com.unity.ml-agents/Tests/Editor/Integrations/Match3/Match3SensorTests.cs
+++ b/com.unity.ml-agents/Tests/Editor/Integrations/Match3/Match3SensorTests.cs
@@ -395,5 +395,14 @@ namespace Unity.MLAgents.Tests.Integrations.Match3
 
             return bytesOut.ToArray();
         }
+
+        [Test]
+        public void TestNoBoardReturnsEmptySensors()
+        {
+            var gameObj = new GameObject("board");
+            var sensorComponent = gameObj.AddComponent<Match3SensorComponent>();
+            var sensors = sensorComponent.CreateSensors();
+            Assert.AreEqual(0, sensors.Length);
+        }
     }
 }


### PR DESCRIPTION
### Proposed change(s)
If the AbstractBoard is missing, sensor creation will fail. I think it makes sense to just return empty arrays for the sensors and actuators in this case.

Also added a warning to the respective editor components.

I tried, but we can't add `[RequireComponent(typeof(AbstractBoard))]`, since AbstractBoard is, well, abstract.

### Types of change(s)
- [x] Bug fix

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
