### PR TITLE
Version bump main

### DIFF
--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents.extensions",
   "displayName": "ML Agents Extensions",
-  "version": "0.3.1-preview",
+  "version": "0.4.0-preview-preview",
   "unity": "2019.4",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {

--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents.extensions",
   "displayName": "ML Agents Extensions",
-  "version": "0.4.0-preview-preview",
+  "version": "0.4.0-preview",
   "unity": "2019.4",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Major Changes
+### Minor Changes
+### Bug Fixes
+
 
 ## [2.0.0-exp.1] - 2021-04-22
 ### Major Changes

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.26.0.dev0"
+__version__ = "0.27.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.26.0.dev0"
+__version__ = "0.27.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.26.0.dev0"
+__version__ = "0.27.0.dev0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
 __release_tag__ = None


### PR DESCRIPTION
### Proposed change(s)

Ran the following command to update the versions on main branch : 

```
python utils/validate_versions.py --python-version=0.27.0.dev0 --csharp-version=2.0.0 --csharp-extensions-version=0.4.0
```

__Note that the main com.unity.mlagents package was already at 2.0.0-exp.1 on the main branch__

Also readded the [Unreleased] section in the CHANGELOG.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
