### PR TITLE
Run package tests with warn-as-error

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -83,7 +83,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
         flavor: {{ platform.flavor}}
     commands:
         - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-        - upm-ci project test -u {{ editor.version }} --project-path {{ editor.testProject }} --package-filter {{ package.name }} {{ noDefaultPackagesOptions }} --extra-utr-arg "reruncount=2"
+        - upm-ci package test -u {{ editor.version }} --package-path {{ package.name }} {{ noDefaultPackagesOptions }} --warnings-as-errors --extra-utr-arg "reruncount=2"
     artifacts:
         logs:
             paths:


### PR DESCRIPTION
### Proposed change(s)
We're running `upm-ci project test` in the coverage job, so I think we can go back to just running the package tests in this job (assuming we didn't need this for the way we pack). Add `--warnings-as-errors` here to catch warnings that would appear in the package.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
