### PR TITLE
[MLA-1952] Add optional seed for gym action spaces

### DIFF
--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.barracuda": {
-      "version": "1.4.0-preview",
+      "version": "1.3.3-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -53,7 +53,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.barracuda": "1.4.0-preview",
+        "com.unity.barracuda": "1.3.3-preview",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.barracuda": {
-      "version": "1.3.3-preview",
+      "version": "1.4.0-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -53,7 +53,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.barracuda": "1.3.3-preview",
+        "com.unity.barracuda": "1.4.0-preview",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 ## [Unreleased]
 ### Major Changes
 ### Minor Changes
+#### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
+#### ml-agents / ml-agents-envs / gym-unity (Python)
+The `UnityToGymWrapper` initializer now accepts an optional `action_space_seed` seed. If this is specified, it will
+be used to set the random seed on the resulting action space. (#5303)
 ### Bug Fixes
 
 

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -1,6 +1,6 @@
 import itertools
 import numpy as np
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import gym
 from gym import error, spaces
@@ -35,6 +35,7 @@ class UnityToGymWrapper(gym.Env):
         uint8_visual: bool = False,
         flatten_branched: bool = False,
         allow_multiple_obs: bool = False,
+        action_space_seed: Optional[int] = None,
     ):
         """
         Environment initialization
@@ -46,6 +47,7 @@ class UnityToGymWrapper(gym.Env):
             containing the visual observations and the last element containing the array of vector observations.
             If False, returns a single np.ndarray containing either only a single visual observation or the array of
             vector observations.
+        :param action_space_seed: If non-None, will be used to set the random seed on created gym.Space instances.
         """
         self._env = unity_env
 
@@ -129,6 +131,9 @@ class UnityToGymWrapper(gym.Env):
                 "The gym wrapper does not provide explicit support for both discrete "
                 "and continuous actions."
             )
+
+        if action_space_seed is not None:
+            self._action_space.seed(action_space_seed)
 
         # Set observations space
         list_spaces: List[gym.Space] = []
@@ -305,7 +310,7 @@ class UnityToGymWrapper(gym.Env):
         return -float("inf"), float("inf")
 
     @property
-    def action_space(self):
+    def action_space(self) -> gym.Space:
         return self._action_space
 
     @property

--- a/gym-unity/gym_unity/tests/test_gym.py
+++ b/gym-unity/gym_unity/tests/test_gym.py
@@ -22,7 +22,6 @@ def test_gym_wrapper():
         mock_env, mock_spec, mock_decision_step, mock_terminal_step
     )
     env = UnityToGymWrapper(mock_env)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.reset(), np.ndarray)
     actions = env.action_space.sample()
     assert actions.shape[0] == 2
@@ -78,6 +77,21 @@ def test_action_space():
     assert env.action_space.n == 5
 
 
+def test_action_space_seed():
+    mock_env = mock.MagicMock()
+    mock_spec = create_mock_group_spec()
+    mock_decision_step, mock_terminal_step = create_mock_vector_steps(mock_spec)
+    setup_mock_unityenvironment(
+        mock_env, mock_spec, mock_decision_step, mock_terminal_step
+    )
+    actions = []
+    for _ in range(0, 2):
+        env = UnityToGymWrapper(mock_env, action_space_seed=1337)
+        env.reset()
+        actions.append(env.action_space.sample())
+    assert (actions[0] == actions[1]).all()
+
+
 @pytest.mark.parametrize("use_uint8", [True, False], ids=["float", "uint8"])
 def test_gym_wrapper_visual(use_uint8):
     mock_env = mock.MagicMock()
@@ -93,7 +107,6 @@ def test_gym_wrapper_visual(use_uint8):
 
     env = UnityToGymWrapper(mock_env, uint8_visual=use_uint8)
     assert isinstance(env.observation_space, spaces.Box)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.reset(), np.ndarray)
     actions = env.action_space.sample()
     assert actions.shape[0] == 2
@@ -121,7 +134,6 @@ def test_gym_wrapper_single_visual_and_vector(use_uint8):
     )
 
     env = UnityToGymWrapper(mock_env, uint8_visual=use_uint8, allow_multiple_obs=True)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.observation_space, spaces.Tuple)
     assert len(env.observation_space) == 2
     reset_obs = env.reset()
@@ -143,7 +155,6 @@ def test_gym_wrapper_single_visual_and_vector(use_uint8):
 
     # check behavior for allow_multiple_obs = False
     env = UnityToGymWrapper(mock_env, uint8_visual=use_uint8, allow_multiple_obs=False)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.observation_space, spaces.Box)
     reset_obs = env.reset()
     assert isinstance(reset_obs, np.ndarray)
@@ -170,7 +181,6 @@ def test_gym_wrapper_multi_visual_and_vector(use_uint8):
     )
 
     env = UnityToGymWrapper(mock_env, uint8_visual=use_uint8, allow_multiple_obs=True)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.observation_space, spaces.Tuple)
     assert len(env.observation_space) == 3
     reset_obs = env.reset()
@@ -188,7 +198,6 @@ def test_gym_wrapper_multi_visual_and_vector(use_uint8):
 
     # check behavior for allow_multiple_obs = False
     env = UnityToGymWrapper(mock_env, uint8_visual=use_uint8, allow_multiple_obs=False)
-    assert isinstance(env, UnityToGymWrapper)
     assert isinstance(env.observation_space, spaces.Box)
     reset_obs = env.reset()
     assert isinstance(reset_obs, np.ndarray)


### PR DESCRIPTION
### Proposed change(s)
Add an optional `action_space_seed` argument to UnityToGymWrapper initializer - if this is set, it will be passed to gym.Space.seed() after the action space is created.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Resolves https://github.com/Unity-Technologies/ml-agents/issues/5297

### Types of change(s)
- [x] Bug fix

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
