### PR TITLE
Remove MaxStep from Soccer agents

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Soccer/Prefabs/SoccerFieldTwos.prefab
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Prefabs/SoccerFieldTwos.prefab
@@ -2016,7 +2016,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 0
   position: 2
   agentRb: {fileID: 0}
@@ -2268,7 +2268,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 1
   position: 2
   agentRb: {fileID: 0}
@@ -4047,7 +4047,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 0
   position: 2
   agentRb: {fileID: 0}
@@ -4546,7 +4546,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 1
   position: 2
   agentRb: {fileID: 0}

--- a/Project/Assets/ML-Agents/Examples/Soccer/Prefabs/StrikersVsGoalieField.prefab
+++ b/Project/Assets/ML-Agents/Examples/Soccer/Prefabs/StrikersVsGoalieField.prefab
@@ -2016,7 +2016,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 0
   position: 1
   agentRb: {fileID: 0}
@@ -2266,7 +2266,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 1
   position: 0
   agentRb: {fileID: 0}
@@ -3979,7 +3979,7 @@ MonoBehaviour:
   agentParameters:
     maxStep: 0
   hasUpgradedFromAgentParameters: 1
-  MaxStep: 3000
+  MaxStep: 0
   team: 1
   position: 0
   agentRb: {fileID: 0}


### PR DESCRIPTION
### Proposed change(s)
Soccer Agents had a maxStep of 3000, but the SoccerEnvController would also reset the Agents when a goal was scored or after MaxEnvironmentSteps.

This sets the MaxStep of all Soccer prefab agents to 0.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://forum.unity.com/threads/some-advice-and-suggestions-python-status-maxstep-vs-maxenvironmentsteps-and-ray-sensor-useage.1097416/


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
