### PR TITLE
[Cherry pick] Bring back root reference in grid sensor

### DIFF
--- a/Project/Assets/ML-Agents/Examples/PushBlock/Prefabs/PushBlockCollabAreaGrid.prefab
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Prefabs/PushBlockCollabAreaGrid.prefab
@@ -2261,6 +2261,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8188317207052398481}
     m_Modifications:
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_RootReference
+      value: 
+      objectReference: {fileID: 8190299122290044757}
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_AgentGameObject
+      value: 
+      objectReference: {fileID: 8190299122290044757}
     - target: {fileID: 2598450485826216109, guid: ac01d0f42c5e1463e943632a60d99967,
         type: 3}
       propertyPath: m_Model
@@ -2336,7 +2346,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 6067781793364901444}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 8190299122290044757}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d94a85eca2e074578943301959c555ba, type: 3}
@@ -2348,6 +2358,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6067781793364901444}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8190299122290044757 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2710286047221272849, guid: ac01d0f42c5e1463e943632a60d99967,
+    type: 3}
+  m_PrefabInstance: {fileID: 6067781793364901444}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6565363751102736699
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2355,6 +2371,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8188317207052398481}
     m_Modifications:
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_RootReference
+      value: 
+      objectReference: {fileID: 9115291448867436586}
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_AgentGameObject
+      value: 
+      objectReference: {fileID: 9115291448867436586}
     - target: {fileID: 2598450485826216109, guid: ac01d0f42c5e1463e943632a60d99967,
         type: 3}
       propertyPath: m_Model
@@ -2435,7 +2461,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 6565363751102736699}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 9115291448867436586}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d94a85eca2e074578943301959c555ba, type: 3}
@@ -2447,6 +2473,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6565363751102736699}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &9115291448867436586 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2710286047221272849, guid: ac01d0f42c5e1463e943632a60d99967,
+    type: 3}
+  m_PrefabInstance: {fileID: 6565363751102736699}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6716844123244810954
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2454,6 +2486,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8188317207052398481}
     m_Modifications:
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_RootReference
+      value: 
+      objectReference: {fileID: 8695281997955662811}
+    - target: {fileID: 1548337883655231979, guid: ac01d0f42c5e1463e943632a60d99967,
+        type: 3}
+      propertyPath: m_AgentGameObject
+      value: 
+      objectReference: {fileID: 8695281997955662811}
     - target: {fileID: 2598450485826216109, guid: ac01d0f42c5e1463e943632a60d99967,
         type: 3}
       propertyPath: m_Model
@@ -2534,7 +2576,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 6716844123244810954}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 8695281997955662811}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d94a85eca2e074578943301959c555ba, type: 3}
@@ -2543,6 +2585,12 @@ MonoBehaviour:
 --- !u!4 &8692073903331065053 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2708762399863795223, guid: ac01d0f42c5e1463e943632a60d99967,
+    type: 3}
+  m_PrefabInstance: {fileID: 6716844123244810954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8695281997955662811 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2710286047221272849, guid: ac01d0f42c5e1463e943632a60d99967,
     type: 3}
   m_PrefabInstance: {fileID: 6716844123244810954}
   m_PrefabAsset: {fileID: 0}

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scenes/PushBlockCollab.unity
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scenes/PushBlockCollab.unity
@@ -816,6 +816,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4704531522807670703, guid: f5bbed44a6ea747a687fbbb738eb1730,
+        type: 3}
+      propertyPath: m_ShowGizmos
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8188317207052398481, guid: f5bbed44a6ea747a687fbbb738eb1730,
         type: 3}
       propertyPath: m_RootOrder

--- a/com.unity.ml-agents/Editor/GridSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/GridSensorComponentEditor.cs
@@ -37,6 +37,7 @@ namespace Unity.MLAgents.Editor
                 gridSize.vector3IntValue = new Vector3Int(newGridSize.x, 1, newGridSize.z);
             }
             EditorGUI.EndDisabledGroup();
+            EditorGUILayout.PropertyField(so.FindProperty(nameof(GridSensorComponent.m_AgentGameObject)), true);
             EditorGUILayout.PropertyField(so.FindProperty(nameof(GridSensorComponent.m_RotateWithAgent)), true);
 
             EditorGUI.BeginDisabledGroup(!EditorUtilities.CanUpdateModelProperties());

--- a/com.unity.ml-agents/Runtime/Sensors/BoxOverlapChecker.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/BoxOverlapChecker.cs
@@ -9,7 +9,8 @@ namespace Unity.MLAgents.Sensors
         Vector3Int m_GridSize;
         bool m_RotateWithAgent;
         LayerMask m_ColliderMask;
-        GameObject m_RootReference;
+        GameObject m_CenterObject;
+        GameObject m_AgentGameObject;
         string[] m_DetectableTags;
         int m_InitialColliderBufferSize;
         int m_MaxColliderBufferSize;
@@ -32,7 +33,8 @@ namespace Unity.MLAgents.Sensors
             Vector3Int gridSize,
             bool rotateWithAgent,
             LayerMask colliderMask,
-            GameObject rootReference,
+            GameObject centerObject,
+            GameObject agentGameObject,
             string[] detectableTags,
             int initialColliderBufferSize,
             int maxColliderBufferSize)
@@ -41,7 +43,8 @@ namespace Unity.MLAgents.Sensors
             m_GridSize = gridSize;
             m_RotateWithAgent = rotateWithAgent;
             m_ColliderMask = colliderMask;
-            m_RootReference = rootReference;
+            m_CenterObject = centerObject;
+            m_AgentGameObject = agentGameObject;
             m_DetectableTags = detectableTags;
             m_InitialColliderBufferSize = initialColliderBufferSize;
             m_MaxColliderBufferSize = maxColliderBufferSize;
@@ -95,17 +98,17 @@ namespace Unity.MLAgents.Sensors
         {
             if (m_RotateWithAgent)
             {
-                return m_RootReference.transform.TransformPoint(m_CellLocalPositions[cellIndex]);
+                return m_CenterObject.transform.TransformPoint(m_CellLocalPositions[cellIndex]);
             }
             else
             {
-                return m_CellLocalPositions[cellIndex] + m_RootReference.transform.position;
+                return m_CellLocalPositions[cellIndex] + m_CenterObject.transform.position;
             }
         }
 
         internal Quaternion GetGridRotation()
         {
-            return m_RotateWithAgent ? m_RootReference.transform.rotation : Quaternion.identity;
+            return m_RotateWithAgent ? m_CenterObject.transform.rotation : Quaternion.identity;
         }
 
         /// <summary>
@@ -191,13 +194,13 @@ namespace Unity.MLAgents.Sensors
                 var currentColliderGo = foundColliders[i].gameObject;
 
                 // Continue if the current collider go is the root reference
-                if (ReferenceEquals(currentColliderGo, m_RootReference))
+                if (ReferenceEquals(currentColliderGo, m_AgentGameObject))
                 {
                     continue;
                 }
 
                 var closestColliderPoint = foundColliders[i].ClosestPointOnBounds(cellCenter);
-                var currentDistanceSquared = (closestColliderPoint - m_RootReference.transform.position).sqrMagnitude;
+                var currentDistanceSquared = (closestColliderPoint - m_CenterObject.transform.position).sqrMagnitude;
 
                 if (currentDistanceSquared >= minDistanceSquared)
                 {
@@ -235,7 +238,7 @@ namespace Unity.MLAgents.Sensors
             for (int i = 0; i < numFound; i++)
             {
                 var currentColliderGo = foundColliders[i].gameObject;
-                if (!ReferenceEquals(currentColliderGo, m_RootReference))
+                if (!ReferenceEquals(currentColliderGo, m_AgentGameObject))
                 {
                     detectedAction.Invoke(currentColliderGo, cellIndex);
                 }

--- a/com.unity.ml-agents/Runtime/Sensors/GridSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/GridSensorComponent.cs
@@ -73,6 +73,18 @@ namespace Unity.MLAgents.Sensors
         }
 
         [HideInInspector, SerializeField]
+        internal GameObject m_AgentGameObject;
+        /// <summary>
+        /// The reference of the root of the agent. This is used to disambiguate objects with
+        /// the same tag as the agent. Defaults to current GameObject.
+        /// </summary>
+        public GameObject AgentGameObject
+        {
+            get { return (m_AgentGameObject == null ? gameObject : m_AgentGameObject); }
+            set { m_AgentGameObject = value; }
+        }
+
+        [HideInInspector, SerializeField]
         internal string[] m_DetectableTags;
         /// <summary>
         /// List of tags that are detected.
@@ -191,6 +203,7 @@ namespace Unity.MLAgents.Sensors
                 m_RotateWithAgent,
                 m_ColliderMask,
                 gameObject,
+                AgentGameObject,
                 m_DetectableTags,
                 m_InitialColliderBufferSize,
                 m_MaxColliderBufferSize

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/BoxOverlapCheckerTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/BoxOverlapCheckerTests.cs
@@ -14,7 +14,8 @@ namespace Unity.MLAgents.Tests
             Vector3Int gridSize,
             bool rotateWithAgent,
             LayerMask colliderMask,
-            GameObject rootReference,
+            GameObject centerObject,
+            GameObject agentGameObject,
             string[] detectableTags,
             int initialColliderBufferSize,
             int maxColliderBufferSize
@@ -23,7 +24,8 @@ namespace Unity.MLAgents.Tests
                 gridSize,
                 rotateWithAgent,
                 colliderMask,
-                rootReference,
+                centerObject,
+                agentGameObject,
                 detectableTags,
                 initialColliderBufferSize,
                 maxColliderBufferSize)
@@ -53,7 +55,8 @@ namespace Unity.MLAgents.Tests
             int gridSizeX = 10,
             int gridSizeZ = 10,
             bool rotateWithAgent = true,
-            GameObject rootReference = null,
+            GameObject centerObject = null,
+            GameObject agentGameObject = null,
             string[] detectableTags = null,
             int initialColliderBufferSize = 4,
             int maxColliderBufferSize = 500)
@@ -63,7 +66,8 @@ namespace Unity.MLAgents.Tests
                 new Vector3Int(gridSizeX, 1, gridSizeZ),
                 rotateWithAgent,
                 LayerMask.GetMask("Default"),
-                rootReference,
+                centerObject,
+                agentGameObject,
                 detectableTags,
                 initialColliderBufferSize,
                 maxColliderBufferSize);
@@ -77,7 +81,7 @@ namespace Unity.MLAgents.Tests
         {
             var testGo = new GameObject("test");
             testGo.transform.position = Vector3.zero;
-            var boxOverlapSquare = TestBoxOverlapChecker.CreateChecker(gridSizeX: 10, gridSizeZ: 10, rotateWithAgent: false, rootReference: testGo);
+            var boxOverlapSquare = TestBoxOverlapChecker.CreateChecker(gridSizeX: 10, gridSizeZ: 10, rotateWithAgent: false, agentGameObject: testGo);
 
             var localPos = boxOverlapSquare.CellLocalPositions;
             Assert.AreEqual(new Vector3(-4.5f, 0, -4.5f), localPos[0]);
@@ -88,7 +92,7 @@ namespace Unity.MLAgents.Tests
 
             var testGo2 = new GameObject("test");
             testGo2.transform.position = new Vector3(3.5f, 8f, 17f); // random, should have no effect on local positions
-            var boxOverlapRect = TestBoxOverlapChecker.CreateChecker(gridSizeX: 5, gridSizeZ: 15, rotateWithAgent: true, rootReference: testGo);
+            var boxOverlapRect = TestBoxOverlapChecker.CreateChecker(gridSizeX: 5, gridSizeZ: 15, rotateWithAgent: true, agentGameObject: testGo);
 
             localPos = boxOverlapRect.CellLocalPositions;
             Assert.AreEqual(new Vector3(-2f, 0, -7f), localPos[0]);
@@ -104,7 +108,7 @@ namespace Unity.MLAgents.Tests
             var testGo = new GameObject("test");
             var position = new Vector3(3.5f, 8f, 17f);
             testGo.transform.position = position;
-            var boxOverlap = TestBoxOverlapChecker.CreateChecker(gridSizeX: 10, gridSizeZ: 10, rotateWithAgent: false, rootReference: testGo);
+            var boxOverlap = TestBoxOverlapChecker.CreateChecker(gridSizeX: 10, gridSizeZ: 10, rotateWithAgent: false, agentGameObject: testGo, centerObject: testGo);
 
             Assert.AreEqual(new Vector3(-4.5f, 0, -4.5f) + position, boxOverlap.GetCellGlobalPosition(0));
             Assert.AreEqual(new Vector3(-4.5f, 0, 4.5f) + position, boxOverlap.GetCellGlobalPosition(9));
@@ -126,7 +130,7 @@ namespace Unity.MLAgents.Tests
             var testGo = new GameObject("test");
             var position = new Vector3(15f, 6f, 13f);
             testGo.transform.position = position;
-            var boxOverlap = TestBoxOverlapChecker.CreateChecker(gridSizeX: 5, gridSizeZ: 15, rotateWithAgent: true, rootReference: testGo);
+            var boxOverlap = TestBoxOverlapChecker.CreateChecker(gridSizeX: 5, gridSizeZ: 15, rotateWithAgent: true, agentGameObject: testGo, centerObject: testGo);
 
             Assert.AreEqual(new Vector3(-2f, 0, -7f) + position, boxOverlap.GetCellGlobalPosition(0));
             Assert.AreEqual(new Vector3(-2f, 0, 7f) + position, boxOverlap.GetCellGlobalPosition(14));
@@ -150,7 +154,7 @@ namespace Unity.MLAgents.Tests
             var testGo = new GameObject("test");
             testGo.transform.position = Vector3.zero;
             testObjects.Add(testGo);
-            var boxOverlap = TestBoxOverlapChecker.CreateChecker(rootReference: testGo, initialColliderBufferSize: 2, maxColliderBufferSize: 5);
+            var boxOverlap = TestBoxOverlapChecker.CreateChecker(agentGameObject: testGo, centerObject: testGo, initialColliderBufferSize: 2, maxColliderBufferSize: 5);
             boxOverlap.Update();
             Assert.AreEqual(2, boxOverlap.ColliderBuffer.Length);
 
@@ -193,7 +197,8 @@ namespace Unity.MLAgents.Tests
                 cellScaleZ: 10f,
                 gridSizeX: 2,
                 gridSizeZ: 2,
-                rootReference: testGo,
+                agentGameObject: testGo,
+                centerObject: testGo,
                 detectableTags: new [] { tag1 });
             var helper = new VerifyParseCollidersHelper();
             boxOverlap.GridOverlapDetectedClosest += helper.DetectedAction;
@@ -229,7 +234,8 @@ namespace Unity.MLAgents.Tests
                 cellScaleZ: 10f,
                 gridSizeX: 2,
                 gridSizeZ: 2,
-                rootReference: testGo,
+                agentGameObject: testGo,
+                centerObject: testGo,
                 detectableTags: new [] { tag1 });
             var helper = new VerifyParseCollidersHelper();
             boxOverlap.GridOverlapDetectedAll += helper.DetectedAction;

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -117,7 +117,6 @@ will not work in newer version. Some errors might show up when loading the old s
 You'll need to remove the old sensor and create a new GridSensor.
 * These parameters names have changed but still refer to the same concept in the sensor: `GridNumSide` -> `GridSize`,
 `RotateToAgent` -> `RotateWithAgent`, `ObserveMask` -> `ColliderMask`, `DetectableObjects` -> `DetectableTags`
-* `RootReference` is removed and the sensor component's GameObject will always be ignored for hit results.
 * `DepthType` (`ChanelBase`/`ChannelHot`) option and `ChannelDepth` are removed. Now the default is
 one-hot encoding for detected tag. If you were using original GridSensor without overriding any method,
 switching to new GridSensor will produce similar effect for training although the actual observations


### PR DESCRIPTION
### Proposed change(s)

Cherry pick #5300.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
