### PR TITLE
Docs: Suggest cloning ml-agents with --depth 1

### DIFF
--- a/docs/Installation-Anaconda-Windows.md
+++ b/docs/Installation-Anaconda-Windows.md
@@ -123,7 +123,7 @@ commands in an Anaconda Prompt _(if you open a new prompt, be sure to activate
 the ml-agents Conda environment by typing `activate ml-agents`)_:
 
 ```sh
-git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch release_17 --depth 1 https://github.com/Unity-Technologies/ml-agents.git
 ```
 
 The `--branch release_17` option will switch to the tag of the latest stable

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -64,7 +64,7 @@ of our tutorials / guides assume you have access to our example environments).
 the repository if you would like to explore more examples.
 
 ```sh
-git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch release_17 --depth 1 https://github.com/Unity-Technologies/ml-agents.git
 ```
 
 The `--branch release_17` option will switch to the tag of the latest stable

--- a/docs/Training-on-Amazon-Web-Service.md
+++ b/docs/Training-on-Amazon-Web-Service.md
@@ -69,7 +69,7 @@ After launching your EC2 instance using the ami and ssh into it:
 2. Clone the ML-Agents repo and install the required Python packages
 
    ```sh
-   git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+   git clone --branch release_17 --depth 1 https://github.com/Unity-Technologies/ml-agents.git
    cd ml-agents/ml-agents/
    pip3 install -e .
    ```


### PR DESCRIPTION
Suggest do a shallow clone of the ml-agents repository, using the `--depth 1` [parameter](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt). This only clones the latest commit of the specified branch, which results in a smaller and faster clone.

On the current release_17 branch this saves quite a lot in both download and file size:

| Comparison | Full clone | Shallow clone |
|------------|-----------:|--------------:|
| Download   |   1.92 GiB |      94.6 MiB |
| Objects    |      77402 |          2233 |
| Size       |    2.08 GB |        244 MB |

### Types of change(s)
- [x] Documentation update

### Checklist
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)

