### PR TITLE
[ci] Shorten SAC Hallway runs

### DIFF
--- a/config/sac/Hallway.yaml
+++ b/config/sac/Hallway.yaml
@@ -25,6 +25,6 @@ behaviors:
         gamma: 0.99
         strength: 1.0
     keep_checkpoints: 5
-    max_steps: 10000000
+    max_steps: 4000000
     time_horizon: 64
     summary_freq: 10000


### PR DESCRIPTION
### Proposed change(s)

Shorten the SAC-Hallway run from 10M to 4M. This should get runs completing within 16 hours. 

Seems like the CI runs train by around 3M steps, so it should be safe. 

![image](https://user-images.githubusercontent.com/5085265/117880221-dd616f00-b275-11eb-903f-6958fb59867d.png)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
