### PR TITLE
[bug-fix] Make resnet barracuda-compatible

### DIFF
--- a/ml-agents/mlagents/trainers/torch/encoders.py
+++ b/ml-agents/mlagents/trainers/torch/encoders.py
@@ -259,7 +259,7 @@ class ResNetVisualEncoder(nn.Module):
         layers.append(Swish())
         self.final_flat_size = n_channels[-1] * height * width
         self.dense = linear_layer(
-            n_channels[-1] * height * width,
+            self.final_flat_size,
             output_size,
             kernel_init=Initialization.KaimingHeNormal,
             kernel_gain=1.41,  # Use ReLU gain

--- a/ml-agents/mlagents/trainers/torch/encoders.py
+++ b/ml-agents/mlagents/trainers/torch/encoders.py
@@ -257,6 +257,7 @@ class ResNetVisualEncoder(nn.Module):
                 layers.append(ResNetBlock(channel))
             last_channel = channel
         layers.append(Swish())
+        self.final_flat_size = n_channels[-1] * height * width
         self.dense = linear_layer(
             n_channels[-1] * height * width,
             output_size,
@@ -268,7 +269,6 @@ class ResNetVisualEncoder(nn.Module):
     def forward(self, visual_obs: torch.Tensor) -> torch.Tensor:
         if not exporting_to_onnx.is_exporting():
             visual_obs = visual_obs.permute([0, 3, 1, 2])
-        batch_size = visual_obs.shape[0]
         hidden = self.sequential(visual_obs)
-        before_out = hidden.reshape(batch_size, -1)
+        before_out = hidden.reshape(-1, self.final_flat_size)
         return torch.relu(self.dense(before_out))


### PR DESCRIPTION
### Proposed change(s)

In the ResNet encoder, we were grabbing the batch size from the actual observations themselves and using that to reshape the final output of the conv layer. This was not compatible with current versions of the Barracuda importer. Now we just cache it first and use that value. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://forum.unity.com/threads/sac-training-very-unstable.1104580/#post-7131539


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
