### PR TITLE
Exclude test_visual_encoder_trains from GPU test

### DIFF
--- a/ml-agents/mlagents/trainers/tests/torch/test_encoders.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_encoders.py
@@ -103,6 +103,7 @@ def test_visual_encoder(vis_class, image_size):
         (FullyConnectedVisualEncoder, 36),
     ],
 )
+@pytest.mark.check_environment_trains
 def test_visual_encoder_trains(vis_class, size):
     torch.manual_seed(0)
     image_size = (size, size, 1)


### PR DESCRIPTION
### Proposed change(s)

`test_visual_encoder_trains` is failing in GPUs tests due to stochasticity (see tests on merging into main from [#5351](https://yamato.cds.internal.unity3d.com/jobs/497-ml-agents/tree/main/.yamato%252Fpytest-gpu.yml%2523pytest_gpu/6768703/job) and [#5358](https://yamato.cds.internal.unity3d.com/jobs/497-ml-agents/tree/main/.yamato%252Fpytest-gpu.yml%2523pytest_gpu/6802691/job)).

Exclude it from the GPU test.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
