### PR TITLE
lock PRs after 30 days

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -20,4 +20,3 @@ jobs:
             any recent activity after it was closed. Please open a new issue for
             related bugs.
           issue-lock-reason: 'resolved'
-          process-only: 'issues'


### PR DESCRIPTION
### Proposed change(s)
Lock PRs for comments after they've been closed for 30 days. Expect a lot of bot emails.
