### PR TITLE
[🐛🔨 ] Fix sac target for continuous actions

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -385,9 +385,9 @@ class TorchSACOptimizer(TorchOptimizer):
             all_mean_q1 = mean_q1
         if self._action_spec.continuous_size > 0:
             cont_log_probs = log_probs.continuous_tensor
-            batch_policy_loss += torch.mean(
-                _cont_ent_coef * cont_log_probs - all_mean_q1.unsqueeze(1), dim=1
-            )
+            batch_policy_loss += _cont_ent_coef * torch.sum(
+                cont_log_probs, dim=1
+            ) - all_mean_q1.unsqueeze(1)
         policy_loss = ModelUtils.masked_mean(batch_policy_loss, loss_masks)
 
         return policy_loss

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -385,9 +385,9 @@ class TorchSACOptimizer(TorchOptimizer):
             all_mean_q1 = mean_q1
         if self._action_spec.continuous_size > 0:
             cont_log_probs = log_probs.continuous_tensor
-            batch_policy_loss += _cont_ent_coef * torch.sum(
-                cont_log_probs, dim=1
-            ) - all_mean_q1.unsqueeze(1)
+            batch_policy_loss += (
+                _cont_ent_coef * torch.sum(cont_log_probs, dim=1) - all_mean_q1
+            )
         policy_loss = ModelUtils.masked_mean(batch_policy_loss, loss_masks)
 
         return policy_loss

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -426,8 +426,8 @@ class TorchSACOptimizer(TorchOptimizer):
         if self._action_spec.continuous_size > 0:
             with torch.no_grad():
                 cont_log_probs = log_probs.continuous_tensor
-                target_current_diff = torch.sum(
-                    cont_log_probs + self.target_entropy.continuous, dim=1
+                target_current_diff = (
+                    torch.sum(cont_log_probs, dim=1) + self.target_entropy.continuous
                 )
             # We update all the _cont_ent_coef as one block
             entropy_loss += -1 * ModelUtils.masked_mean(

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -256,7 +256,7 @@ def test_2d_sac(action_sizes):
         SAC_TORCH_CONFIG.hyperparameters, buffer_init_steps=2000
     )
     config = attr.evolve(
-        SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=6000
+        SAC_TORCH_CONFIG, hyperparameters=new_hyperparams, max_steps=3000
     )
     check_environment_trains(env, {BRAIN_NAME: config}, success_threshold=0.8)
 


### PR DESCRIPTION

### Proposed change(s)

Fixing the target entropy calculation for SAC in continuous and hybrid action cases. 
Removing implicit broadcasting, changing the target entropy from -dim(A) ^ 2 to -dim(A)


![Screen Shot 2021-05-18 at 09 33 08](https://user-images.githubusercontent.com/28320361/118690844-518f9b80-b7bd-11eb-84bf-00ea344dcd83.png)



### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
[Experiment doc ](https://docs.google.com/document/d/12-9Zh7BO-y1xZyHrOaLHhREhMIJVSFGZd_pu1ZEhGZU/edit)


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
