### PR TITLE
[WIP] [Fix] Fixing collect observation called on done

### DIFF
--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -562,14 +562,12 @@ namespace Unity.MLAgents
             m_Info.done = true;
             m_Info.maxStepReached = doneReason == DoneReason.MaxStepReached;
             m_Info.groupId = m_GroupId;
-            if (collectObservationsSensor != null)
+            UpdateSensors();
+            // Make sure the latest observations are being passed to training.
+            collectObservationsSensor.Reset();
+            using (m_CollectObservationsChecker.Start())
             {
-                // Make sure the latest observations are being passed to training.
-                collectObservationsSensor.Reset();
-                using (m_CollectObservationsChecker.Start())
-                {
-                    CollectObservations(collectObservationsSensor);
-                }
+                CollectObservations(collectObservationsSensor);
             }
             // Request the last decision with no callbacks
             // We request a decision so Python knows the Agent is done immediately

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -564,7 +564,6 @@ namespace Unity.MLAgents
             m_Info.groupId = m_GroupId;
             UpdateSensors();
             // Make sure the latest observations are being passed to training.
-            collectObservationsSensor.Reset();
             using (m_CollectObservationsChecker.Start())
             {
                 CollectObservations(collectObservationsSensor);

--- a/com.unity.ml-agents/Tests/Runtime/Sensor/StackingSensorTests.cs
+++ b/com.unity.ml-agents/Tests/Runtime/Sensor/StackingSensorTests.cs
@@ -59,10 +59,17 @@ namespace Unity.MLAgents.Tests
                 agent1.RequestDecision();
                 aca.EnvironmentStep();
             }
-
-            policy.OnRequestDecision = () => SensorTestHelper.CompareObservation(sensor, new[] { 18f, 19f, 21f });
+            SensorTestHelper.CompareObservation(sensor, new[] { 18f, 19f, 20f });
+            policy.OnRequestDecision = () => SensorTestHelper.CompareObservation(sensor, new[] { 19f, 20f, 21f });
             agent1.EndEpisode();
+            policy.OnRequestDecision = () => { };
             SensorTestHelper.CompareObservation(sensor, new[] { 0f, 0f, 0f });
+            for (int i = 0; i < 20; i++)
+            {
+                agent1.RequestDecision();
+                aca.EnvironmentStep();
+                SensorTestHelper.CompareObservation(sensor, new[] { Math.Max(0, i - 1f), i, i + 1 });
+            }
         }
 
         [Test]

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -612,7 +612,8 @@ The `BufferSensorComponent` Editor inspector has two arguments:
  the `BufferSensor` will be able to collect.
 
 To add an entity's observations to a `BufferSensorComponent`, you need
-to call `BufferSensorComponent.AppendObservation()`
+to call `BufferSensorComponent.AppendObservation()` in the
+Agent.CollectObservations() method
 with a float array of size `Observation Size` as argument.
 
 __Note__: Currently, the observations put into the `BufferSensor` are
@@ -621,7 +622,8 @@ between -1 and 1.
 
 #### Variable Length Observation Summary & Best Practices
  - Attach `BufferSensorComponent` to use.
- - Call `BufferSensorComponent.AppendObservation()` to add the observations
+ - Call `BufferSensorComponent.AppendObservation()` in the
+ Agent.CollectObservations() methodto add the observations
  of an entity to the `BufferSensor`.
  - Normalize the entities observations before feeding them into the `BufferSensor`.
 


### PR DESCRIPTION
### Proposed change(s)

@ervteng noticed that "If you put a GoalSensor/VectorSensorComponent on a dodgeball agent, and add to it in Collectobservations, it will throw a warning when the agent dies"
Investigation showed that the code 
```
            if (collectObservationsSensor != null)
            {
                // Make sure the latest observations are being passed to training.
                collectObservationsSensor.Reset();
                using (m_CollectObservationsChecker.Start())
                {
                    CollectObservations(collectObservationsSensor);
                }
            }
```
is problematic when using a VectorSensor because only the `collectObservationsSensor` will be reset **BUT** both the VectorSensor and `collectObservationsSensor` will have new observations (because CollectObservations is called).
The proposed solution is to replace the call to `collectObservationsSensor.Reset();` with `UpdateSensors` which is what we do in `SendInfoToBrain()` already. We also remove the check `if (collectObservationsSensor != null)` because there could be a Vector Sensor without a `collectObservationsSensor`.

I also modified the test of the stacking sensor to fit this new logic.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
[Slack message](https://unity.slack.com/archives/C01H5LE96RE/p1621449697012400)


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
