### PR TITLE
Add stacking option to VectorSensorComponent

### DIFF
--- a/com.unity.ml-agents/Editor/VectorSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/VectorSensorComponentEditor.cs
@@ -21,6 +21,7 @@ namespace Unity.MLAgents.Editor
                 EditorGUILayout.PropertyField(so.FindProperty("m_SensorName"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_ObservationSize"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_ObservationType"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_ObservationStacks"), true);
             }
             EditorGUI.EndDisabledGroup();
 

--- a/com.unity.ml-agents/Runtime/Sensors/VectorSensorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/VectorSensorComponent.cs
@@ -46,6 +46,21 @@ namespace Unity.MLAgents.Sensors
             set { m_ObservationType = value; }
         }
 
+        [HideInInspector, SerializeField]
+        [Range(1, 50)]
+        [Tooltip("Number of camera frames that will be stacked before being fed to the neural network.")]
+        int m_ObservationStacks = 1;
+
+        /// <summary>
+        /// Whether to stack previous observations. Using 1 means no previous observations.
+        /// Note that changing this after the sensor is created has no effect.
+        /// </summary>
+        public int ObservationStacks
+        {
+            get { return m_ObservationStacks; }
+            set { m_ObservationStacks = value; }
+        }
+
         /// <summary>
         /// Creates a VectorSensor.
         /// </summary>
@@ -53,6 +68,10 @@ namespace Unity.MLAgents.Sensors
         public override ISensor[] CreateSensors()
         {
             m_Sensor = new VectorSensor(m_ObservationSize, m_SensorName, m_ObservationType);
+            if (ObservationStacks != 1)
+            {
+                return new ISensor[] { new StackingSensor(m_Sensor, ObservationStacks) };
+            }
             return new ISensor[] { m_Sensor };
         }
 


### PR DESCRIPTION
### Proposed change(s)

Currently only the vector observation in CollectObservations have stacking option in behavior parameters. Vector obs from VectorSensorComponent can't be stacked.

Add stacking to VectorSensorComponent. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
