### PR TITLE
[WIP] Modifying SAC to make \alpha converge faster

### DIFF
--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -199,13 +199,9 @@ class TorchSACOptimizer(TorchOptimizer):
             1e-10,
             self.trainer_settings.max_steps,
         )
-        self.policy_optimizer = torch.optim.Adam(
-            policy_params, lr=hyperparameters.learning_rate
-        )
-        self.value_optimizer = torch.optim.Adam(
-            value_params, lr=hyperparameters.learning_rate
-        )
-        self.entropy_optimizer = torch.optim.Adam(
+        self.policy_optimizer = torch.optim.Adam(policy_params)
+        self.value_optimizer = torch.optim.Adam(value_params)
+        self.entropy_optimizer = torch.optim.SGD(
             self._log_ent_coef.parameters(), lr=hyperparameters.learning_rate
         )
         self._move_to_device(default_device())
@@ -601,7 +597,6 @@ class TorchSACOptimizer(TorchOptimizer):
         total_value_loss.backward()
         self.value_optimizer.step()
 
-        ModelUtils.update_learning_rate(self.entropy_optimizer, decay_lr)
         self.entropy_optimizer.zero_grad()
         entropy_loss.backward()
         self.entropy_optimizer.step()


### PR DESCRIPTION
### Proposed change(s)

In gray what is on main and in blue with the proposed changes. The entropy converges slightly faster as expected. This leads to a higher cumulative reward at the beginning of training but it seems the final reward is not as high (probably the entropy is not high enough to leave a local minima)

![Screen Shot 2021-05-24 at 10 34 30](https://user-images.githubusercontent.com/28320361/119386077-e726a180-bc7b-11eb-99d0-8829af90a71c.png)
![Screen Shot 2021-05-24 at 10 33 55](https://user-images.githubusercontent.com/28320361/119386087-e857ce80-bc7b-11eb-8f55-33c2561c749d.png)
![Screen Shot 2021-05-24 at 10 33 49](https://user-images.githubusercontent.com/28320361/119386091-ea219200-bc7b-11eb-8c27-d89fa8a3d845.png)

We could set a slower learning rate for the entropy coefficient update to mitigate this issue (it is currently the same as the trainer's like in the original SAC paper)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
