### PR TITLE
Fix NullReferenceException for Behavior Parameters without Agent

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 ### Major Changes
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
+- Fixed NullReferenceException when adding Behavior Parameters with no Agent. (#5382)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added a fully connected visual encoder for environments with very small image inputs. (#5351)
 ### Bug Fixes

--- a/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
+++ b/com.unity.ml-agents/Editor/BehaviorParametersEditor.cs
@@ -36,6 +36,16 @@ namespace Unity.MLAgents.Editor
             so.Update();
             bool needPolicyUpdate; // Whether the name, model, inference device, or BehaviorType changed.
 
+            var behaviorParameters = (BehaviorParameters)target;
+            var agent = behaviorParameters.gameObject.GetComponent<Agent>();
+            if (agent == null)
+            {
+                EditorGUILayout.HelpBox(
+                    "No Agent is associated with this Behavior Parameters. Attach an Agent to " +
+                    "this GameObject to configure your Agent with these behavior parameters.",
+                    MessageType.Warning);
+            }
+
             // Drawing the Behavior Parameters
             EditorGUI.indentLevel++;
             EditorGUI.BeginChangeCheck(); // global
@@ -106,6 +116,10 @@ namespace Unity.MLAgents.Editor
             // Grab the sensor components, since we need them to determine the observation sizes.
             // TODO make these methods of BehaviorParameters
             var agent = behaviorParameters.gameObject.GetComponent<Agent>();
+            if (agent == null)
+            {
+                return;
+            }
             agent.sensors = new List<ISensor>();
             agent.InitializeSensors();
             var sensors = agent.sensors.ToArray();


### PR DESCRIPTION
### Proposed change(s)

Fix the NullReferenceException reported in #5374.

Check agent existence in editor script. Also add warning box if no Agent is found.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
