### PR TITLE
Warn if no joints on Root Body

### DIFF
--- a/com.unity.ml-agents.extensions/Editor/RigidBodySensorComponentEditor.cs
+++ b/com.unity.ml-agents.extensions/Editor/RigidBodySensorComponentEditor.cs
@@ -16,6 +16,16 @@ namespace Unity.MLAgents.Extensions.Editor
             so.Update();
 
             var rbSensorComp = so.targetObject as RigidBodySensorComponent;
+            if (rbSensorComp.IsTrivial())
+            {
+                EditorGUILayout.HelpBox(
+                    "The Root Body has no Joints, and the Virtual Root is null or the same as the " +
+                    "Root Body's GameObject. This will not generate any useful observations; they will always " +
+                    "be the identity values. Consider removing this component since it won't help the Agent.",
+                    MessageType.Warning
+                );
+            }
+
             bool requireExtractorUpdate;
 
             EditorGUI.BeginDisabledGroup(!EditorUtilities.CanUpdateModelProperties());

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
@@ -94,6 +94,11 @@ namespace Unity.MLAgents.Extensions.Sensors
 
         internal bool IsTrivial()
         {
+            if (ReferenceEquals(RootBody, null))
+            {
+                // It *is* trivial, but this will happen when the sensor is being set up, so don't warn then.
+                return false;
+            }
             var joints = RootBody.GetComponentsInChildren<Joint>();
             if (joints.Length == 0)
             {

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodySensorComponent.cs
@@ -91,6 +91,19 @@ namespace Unity.MLAgents.Extensions.Sensors
         {
             GetPoseExtractor().SetPoseEnabled(index, enabled);
         }
+
+        internal bool IsTrivial()
+        {
+            var joints = RootBody.GetComponentsInChildren<Joint>();
+            if (joints.Length == 0)
+            {
+                if (ReferenceEquals(VirtualRoot, null) || ReferenceEquals(VirtualRoot, RootBody.gameObject))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
 }

--- a/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/RigidBodySensorTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Runtime/Sensors/RigidBodySensorTests.cs
@@ -31,6 +31,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
             var gameObj = new GameObject();
 
             var sensorComponent = gameObj.AddComponent<RigidBodySensorComponent>();
+            Assert.IsFalse(sensorComponent.IsTrivial());
             var sensor = sensorComponent.CreateSensors()[0];
             SensorTestHelper.CompareObservation(sensor, new float[0]);
         }
@@ -48,6 +49,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 UseLocalSpaceTranslations = true,
                 UseLocalSpaceRotations = true
             };
+            Assert.IsTrue(sensorComponent.IsTrivial());
 
             var sensor = sensorComponent.CreateSensors()[0];
             sensor.Update();
@@ -93,6 +95,7 @@ namespace Unity.MLAgents.Extensions.Tests.Sensors
                 UseLocalSpaceLinearVelocity = true
             };
             sensorComponent.VirtualRoot = virtualRoot;
+            Assert.IsFalse(sensorComponent.IsTrivial());
 
             var sensor = sensorComponent.CreateSensors()[0];
             sensor.Update();

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Added a fully connected visual encoder for environments with very small image inputs. (#5351)
 ### Bug Fixes
+- RigidBodySensorComponent now displays a warning if it's used in a way that won't generate useful observations. (#5387)
 
 
 ## [2.0.0-exp.1] - 2021-04-22


### PR DESCRIPTION
### Proposed change(s)
If there are no joints on a Rigid Body, the Rigid Body Sensor won't generate any useful observations, just identity values (unless there's a Virtual Root set, and that's different from the RB's GameObject). This adds a warning to the inspector in that case.

![image](https://user-images.githubusercontent.com/6877802/119411287-0256d880-bc9f-11eb-9de5-c93ed928f8ab.png)


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [x] Bug fix

### Checklist
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
