### PR TITLE
Add rendering to Gym wrapper limitations

### DIFF
--- a/gym-unity/README.md
+++ b/gym-unity/README.md
@@ -67,7 +67,8 @@ The returned environment `env` will function as a gym.
   be accessed from the `info` provided by `env.step(action)`.
 - Stacked vector observations are not supported.
 - Environment registration for use with `gym.make()` is currently not supported.
-- Display rendering is not supported. Calling `env.render()` might not work as expected in display.
+- Calling env.render() will not render a new frame of the environment. It will
+  return the latest visual observation if using visual observations.
 
 ## Running OpenAI Baselines Algorithms
 

--- a/gym-unity/README.md
+++ b/gym-unity/README.md
@@ -67,6 +67,7 @@ The returned environment `env` will function as a gym.
   be accessed from the `info` provided by `env.step(action)`.
 - Stacked vector observations are not supported.
 - Environment registration for use with `gym.make()` is currently not supported.
+- Display rendering is not supported. Calling `env.render()` might not work as expected in display.
 
 ## Running OpenAI Baselines Algorithms
 

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -278,7 +278,8 @@ class UnityToGymWrapper(gym.Env):
         return result
 
     def render(self, mode="rgb_array"):
-        """Return the latest visual observations.
+        """
+        Return the latest visual observations.
         Note that it will not render a new frame of the environment.
         """
         return self.visual_obs

--- a/gym-unity/gym_unity/envs/__init__.py
+++ b/gym-unity/gym_unity/envs/__init__.py
@@ -278,6 +278,9 @@ class UnityToGymWrapper(gym.Env):
         return result
 
     def render(self, mode="rgb_array"):
+        """Return the latest visual observations.
+        Note that it will not render a new frame of the environment.
+        """
         return self.visual_obs
 
     def close(self) -> None:


### PR DESCRIPTION
### Proposed change(s)

Reported in #5380 . We didn't mention the limitation around rendering in the documents and it's not working as expected for users.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
