### PR TITLE
pre-commit - fix depencency on pydoc-markdown

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,10 +19,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
-    - name: Install dependencies
-      run: |
-          python -m pip install --upgrade pip
-          pip install pydoc-markdown==3.10.1
     - uses: pre-commit/action@v2.0.0
 
   markdown-link-check:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,7 @@ repos:
         entry: utils/validate_release_links.py
     -   id: generate-markdown-docs
         name: generate markdown docs
-        language: script
-        entry: utils/generate_markdown_docs.py --package_dirs ml-agents-envs
+        language: python
+        entry: ./utils/generate_markdown_docs.py --package_dirs ml-agents-envs
         pass_filenames: false
+        additional_dependencies: [pyyaml, pydoc-markdown==3.10.1]

--- a/utils/generate_markdown_docs.py
+++ b/utils/generate_markdown_docs.py
@@ -69,8 +69,7 @@ if __name__ == "__main__":
     parser.add_argument("--package_dirs", nargs="+")
     args = parser.parse_args()
 
-    ok = False
-    return_code = 0
+    ok = True
     for package_dir in args.package_dirs:
         config_path = os.path.join(os.getcwd(), package_dir, "pydoc-config.yaml")
         print(config_path)
@@ -96,8 +95,6 @@ if __name__ == "__main__":
                     subprocess.check_call(subprocess_args, stdout=output_file)
                 remove_trailing_whitespace(output_file_name)
                 new_hash = hash_file(output_file_name)
-                ok = old_hash == new_hash
+                ok &= old_hash == new_hash
 
-        return_code = 0 if ok else 1
-
-    sys.exit(return_code)
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
### Proposed change(s)
Change the pre-commit hook type to `python` so that it can specify it's pip dependency (so that you don't need to manually install it). I can potentially change the other scripts too, but none of them have external dependencies.

Also, the return code logic was potentially broken for multiple package directories or modules, as it would only use the most recent one.

See also: https://github.com/Unity-Technologies/ml-agents/pull/5325/

### Types of change(s)

- [x] CI
