### PR TITLE
Editing the GridSensor documentation for 2D use case

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - Added a fully connected visual encoder for environments with very small image inputs. (#5351)
 ### Bug Fixes
 - RigidBodySensorComponent now displays a warning if it's used in a way that won't generate useful observations. (#5387)
+- Update the documentation with a note saying that `GridSensor` does not work in 2D environments. (#5396)
 
 
 ## [2.0.0-exp.1] - 2021-04-22

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -570,6 +570,9 @@ See the doc on
 [extending grid Sensors](https://github.com/Unity-Technologies/ml-agents/blob/release_17/com.unity.ml-agents.extensions/Documentation~/CustomGridSensors.md)
 for more details on custom grid sensors.
 
+__Note__: The `GridSensor` only works in 3D environments and will not behave
+properly in 2D environments.
+
 #### Grid Observation Summary & Best Practices
 
 - Attach `GridSensorComponent` to use.
@@ -577,6 +580,7 @@ for more details on custom grid sensors.
   can be best captured in 2D representations.
 - Use as small grid size and as few tags as necessary to solve the problem in order to improve
   learning stability and agent performance.
+- Do not use `GridSensor` in a 2D game.
 
 ### Variable Length Observations
 


### PR DESCRIPTION
### Proposed change(s)

Grid Sensor does not work in 2D environments because we do a projection on the x,z plane.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
