### PR TITLE
[Release 18] Update versions and links

### DIFF
--- a/DevProject/Packages/packages-lock.json
+++ b/DevProject/Packages/packages-lock.json
@@ -65,7 +65,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ml-agents": "2.0.0-exp.1",
+        "com.unity.ml-agents": "2.1.0-exp.1",
         "com.unity.modules.physics": "1.0.0"
       }
     },

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -63,7 +63,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ml-agents": "2.0.0-exp.1",
+        "com.unity.ml-agents": "2.1.0-exp.1",
         "com.unity.modules.physics": "1.0.0"
       }
     },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Unity ML-Agents Toolkit
 
-[![docs badge](https://img.shields.io/badge/docs-reference-blue.svg)](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/)
+[![docs badge](https://img.shields.io/badge/docs-reference-blue.svg)](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/)
 
 [![license badge](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 
@@ -47,7 +47,7 @@ descriptions of all these features.
 ## Releases & Documentation
 
 **Our latest, stable release is `Release 17`. Click
-[here](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/Readme.md)
+[here](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/Readme.md)
 to get started with the latest release of ML-Agents.**
 
 The table below lists all our releases, including our `main` branch which is

--- a/colab/Colab_UnityEnvironment_1_Run.ipynb
+++ b/colab/Colab_UnityEnvironment_1_Run.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Open a UnityEnvironment\n",
-    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/images/image-banner.png?raw=true\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/images/image-banner.png?raw=true\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {

--- a/colab/Colab_UnityEnvironment_1_Run.ipynb
+++ b/colab/Colab_UnityEnvironment_1_Run.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Open a UnityEnvironment\n",
-    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_1/docs/images/image-banner.png?raw=true\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/images/image-banner.png?raw=true\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {
@@ -146,7 +146,7 @@
     "  import mlagents\n",
     "  print(\"ml-agents already installed\")\n",
     "except ImportError:\n",
-    "  !pip install -q mlagents==0.25.1\n",
+    "  !python -m pip install -q mlagents==0.27.0\n",
     "  print(\"Installed ml-agents\")"
    ],
    "execution_count": null,

--- a/colab/Colab_UnityEnvironment_2_Train.ipynb
+++ b/colab/Colab_UnityEnvironment_2_Train.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Q-Learning with GridWorld\n",
-    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/images/gridworld.png?raw=true\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/images/gridworld.png?raw=true\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {
@@ -176,7 +176,7 @@
     "id": "pZhVRfdoyPmv"
    },
    "source": [
-    "The [GridWorld](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Learning-Environment-Examples.md#gridworld) Environment is a simple Unity visual environment. The Agent is a blue square in a 3x3 grid that is trying to reach a green __`+`__ while avoiding a red __`x`__.\n",
+    "The [GridWorld](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Examples.md#gridworld) Environment is a simple Unity visual environment. The Agent is a blue square in a 3x3 grid that is trying to reach a green __`+`__ while avoiding a red __`x`__.\n",
     "\n",
     "The observation is an image obtained by a camera on top of the grid.\n",
     "\n",

--- a/colab/Colab_UnityEnvironment_2_Train.ipynb
+++ b/colab/Colab_UnityEnvironment_2_Train.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Q-Learning with GridWorld\n",
-    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_2/docs/images/gridworld.png?raw=true\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/images/gridworld.png?raw=true\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {
@@ -146,7 +146,7 @@
     "  import mlagents\n",
     "  print(\"ml-agents already installed\")\n",
     "except ImportError:\n",
-    "  !pip install -q mlagents==0.25.1\n",
+    "  !python -m pip install -q mlagents==0.27.0\n",
     "  print(\"Installed ml-agents\")"
    ],
    "execution_count": null,
@@ -176,7 +176,7 @@
     "id": "pZhVRfdoyPmv"
    },
    "source": [
-    "The [GridWorld](https://github.com/Unity-Technologies/ml-agents/blob/release_2/docs/Learning-Environment-Examples.md#gridworld) Environment is a simple Unity visual environment. The Agent is a blue square in a 3x3 grid that is trying to reach a green __`+`__ while avoiding a red __`x`__.\n",
+    "The [GridWorld](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Learning-Environment-Examples.md#gridworld) Environment is a simple Unity visual environment. The Agent is a blue square in a 3x3 grid that is trying to reach a green __`+`__ while avoiding a red __`x`__.\n",
     "\n",
     "The observation is an image obtained by a camera on top of the grid.\n",
     "\n",

--- a/colab/Colab_UnityEnvironment_3_SideChannel.ipynb
+++ b/colab/Colab_UnityEnvironment_3_SideChannel.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Use SideChannels\n",
-    "<img src=\"https://raw.githubusercontent.com/Unity-Technologies/ml-agents/release_1/docs/images/3dball_big.png\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://raw.githubusercontent.com/Unity-Technologies/ml-agents/release_18/docs/images/3dball_big.png\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {
@@ -146,7 +146,7 @@
     "  import mlagents\n",
     "  print(\"ml-agents already installed\")\n",
     "except ImportError:\n",
-    "  !pip install -q mlagents==0.25.1\n",
+    "  !python -m pip install -q mlagents==0.27.0\n",
     "  print(\"Installed ml-agents\")"
    ],
    "execution_count": null,
@@ -161,7 +161,7 @@
     "## Side Channel\n",
     "\n",
     "SideChannels are objects that can be passed to the constructor of a UnityEnvironment or the `make()` method of a registry entry to send non Reinforcement Learning related data.\n",
-    "More information available [here](https://github.com/Unity-Technologies/ml-agents/blob/release_1/docs/Python-API.md#communicating-additional-information-with-the-environment)\n",
+    "More information available [here](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#communicating-additional-information-with-the-environment)\n",
     "\n",
     "\n",
     "\n"
@@ -174,7 +174,7 @@
    },
    "source": [
     "### Engine Configuration SideChannel\n",
-    "The [Engine Configuration Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_1/docs/Python-API.md#engineconfigurationchannel) is used to configure how the Unity Engine should run.\n",
+    "The [Engine Configuration Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#engineconfigurationchannel) is used to configure how the Unity Engine should run.\n",
     "We will use the GridWorld environment to demonstrate how to use the EngineConfigurationChannel."
    ]
   },
@@ -226,7 +226,7 @@
    },
    "source": [
     "### Environment Parameters Channel\n",
-    "The [Environment Parameters Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_1/docs/Python-API.md#environmentparameters) is used to modify environment parameters during the simulation.\n",
+    "The [Environment Parameters Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#environmentparameters) is used to modify environment parameters during the simulation.\n",
     "We will use the GridWorld environment to demonstrate how to use the EngineConfigurationChannel."
    ]
   },
@@ -296,7 +296,7 @@
    },
    "source": [
     "### Creating your own Side Channels\n",
-    "You can send various kinds of data between a Unity Environment and Python but you will need to [create your own implementation of a Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_1/docs/Custom-SideChannels.md#custom-side-channels) for advanced use cases.\n"
+    "You can send various kinds of data between a Unity Environment and Python but you will need to [create your own implementation of a Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Custom-SideChannels.md#custom-side-channels) for advanced use cases.\n"
    ]
   }
  ]

--- a/colab/Colab_UnityEnvironment_3_SideChannel.ipynb
+++ b/colab/Colab_UnityEnvironment_3_SideChannel.ipynb
@@ -32,7 +32,7 @@
    },
    "source": [
     "# ML-Agents Use SideChannels\n",
-    "<img src=\"https://raw.githubusercontent.com/Unity-Technologies/ml-agents/release_18/docs/images/3dball_big.png\" align=\"middle\" width=\"435\"/>"
+    "<img src=\"https://raw.githubusercontent.com/Unity-Technologies/ml-agents/release_18_docs/docs/images/3dball_big.png\" align=\"middle\" width=\"435\"/>"
    ]
   },
   {
@@ -161,7 +161,7 @@
     "## Side Channel\n",
     "\n",
     "SideChannels are objects that can be passed to the constructor of a UnityEnvironment or the `make()` method of a registry entry to send non Reinforcement Learning related data.\n",
-    "More information available [here](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#communicating-additional-information-with-the-environment)\n",
+    "More information available [here](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Python-API.md#communicating-additional-information-with-the-environment)\n",
     "\n",
     "\n",
     "\n"
@@ -174,7 +174,7 @@
    },
    "source": [
     "### Engine Configuration SideChannel\n",
-    "The [Engine Configuration Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#engineconfigurationchannel) is used to configure how the Unity Engine should run.\n",
+    "The [Engine Configuration Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Python-API.md#engineconfigurationchannel) is used to configure how the Unity Engine should run.\n",
     "We will use the GridWorld environment to demonstrate how to use the EngineConfigurationChannel."
    ]
   },
@@ -226,7 +226,7 @@
    },
    "source": [
     "### Environment Parameters Channel\n",
-    "The [Environment Parameters Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Python-API.md#environmentparameters) is used to modify environment parameters during the simulation.\n",
+    "The [Environment Parameters Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Python-API.md#environmentparameters) is used to modify environment parameters during the simulation.\n",
     "We will use the GridWorld environment to demonstrate how to use the EngineConfigurationChannel."
    ]
   },
@@ -296,7 +296,7 @@
    },
    "source": [
     "### Creating your own Side Channels\n",
-    "You can send various kinds of data between a Unity Environment and Python but you will need to [create your own implementation of a Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18/docs/Custom-SideChannels.md#custom-side-channels) for advanced use cases.\n"
+    "You can send various kinds of data between a Unity Environment and Python but you will need to [create your own implementation of a Side Channel](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Custom-SideChannels.md#custom-side-channels) for advanced use cases.\n"
    ]
   }
  ]

--- a/com.unity.ml-agents.extensions/Documentation~/com.unity.ml-agents.extensions.md
+++ b/com.unity.ml-agents.extensions/Documentation~/com.unity.ml-agents.extensions.md
@@ -28,24 +28,24 @@ The ML-Agents Extensions package is not currently available in the Package Manag
 recommended ways to install the package:
 
 ### Local Installation
-[Clone the repository](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/Installation.md#clone-the-ml-agents-toolkit-repository-optional) and follow the
-[Local Installation for Development](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/Installation.md#advanced-local-installation-for-development-1)
+[Clone the repository](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/Installation.md#clone-the-ml-agents-toolkit-repository-optional) and follow the
+[Local Installation for Development](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/Installation.md#advanced-local-installation-for-development-1)
 directions (substituting `com.unity.ml-agents.extensions` for the package name).
 
 ### Github via Package Manager
 In Unity 2019.4 or later, open the Package Manager, hit the "+" button, and select "Add package from git URL".
 
-![Package Manager git URL](https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/images/unity_package_manager_git_url.png)
+![Package Manager git URL](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/images/unity_package_manager_git_url.png)
 
 In the dialog that appears, enter
  ```
-git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_17
+git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_18
 ```
 
 You can also edit your project's `manifest.json` directly and add the following line to the `dependencies`
 section:
 ```
-"com.unity.ml-agents.extensions": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_17",
+"com.unity.ml-agents.extensions": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents.extensions#release_18",
 ```
 See [Git dependencies](https://docs.unity3d.com/Manual/upm-git.html#subfolder) for more information. Note that this
 may take several minutes to resolve the packages the first time that you add it.
@@ -67,4 +67,4 @@ If using the `InputActuatorComponent`
     - No way to customize the action space of the `InputActuatorComponent`
 
 ## Need Help?
-The main [README](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/README.md) contains links for contacting the team or getting support.
+The main [README](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/README.md) contains links for contacting the team or getting support.

--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.unity.ml-agents.extensions",
   "displayName": "ML Agents Extensions",
-  "version": "0.4.0-preview",
+  "version": "0.5.0-preview",
   "unity": "2019.4",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {
-    "com.unity.ml-agents": "2.0.0-exp.1",
+    "com.unity.ml-agents": "2.1.0-exp.1",
     "com.unity.modules.physics": "1.0.0"
   }
 }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -6,17 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### Major Changes
-#### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-### Minor Changes
-#### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-### Bug Fixes
-#### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-#### ml-agents / ml-agents-envs / gym-unity (Python)
-
 
 ## [2.1.0-exp.1] - 2021-06-09
 ### Minor Changes

--- a/com.unity.ml-agents/Documentation~/com.unity.ml-agents.md
+++ b/com.unity.ml-agents/Documentation~/com.unity.ml-agents.md
@@ -61,25 +61,25 @@ With the changes to Unity Package Manager in 2021, experimental packages will no
 
 In Unity 2019.4 or later, open the Package Manager, hit the "+" button, and select "Add package from git URL".
 
-![Package Manager git URL](https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/images/unity_package_manager_git_url.png)
+![Package Manager git URL](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/images/unity_package_manager_git_url.png)
 
 In the dialog that appears, enter
  ```
-git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents#release_17
+git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents#release_18
 ```
 
 You can also edit your project's `manifest.json` directly and add the following line to the `dependencies`
 section:
 ```
-"com.unity.ml-agents": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents#release_17",
+"com.unity.ml-agents": "git+https://github.com/Unity-Technologies/ml-agents.git?path=com.unity.ml-agents#release_18",
 ```
 See [Git dependencies](https://docs.unity3d.com/Manual/upm-git.html#subfolder) for more information. Note that this
 may take several minutes to resolve the packages the first time that you add it.
 
 #### Local Installation for Development
 
-[Clone the repository](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/Installation.md#clone-the-ml-agents-toolkit-repository-optional) and follow the
-[Local Installation for Development](https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/Installation.md#advanced-local-installation-for-development-1)
+[Clone the repository](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/Installation.md#clone-the-ml-agents-toolkit-repository-optional) and follow the
+[Local Installation for Development](https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/Installation.md#advanced-local-installation-for-development-1)
 directions.
 
 ## Requirements
@@ -152,10 +152,10 @@ Please refer to "Information that is passively collected by Unity" in the
 [unity ML-Agents Toolkit]: https://github.com/Unity-Technologies/ml-agents
 [unity inference engine]: https://docs.unity3d.com/Packages/com.unity.barracuda@latest/index.html
 [package manager documentation]: https://docs.unity3d.com/Manual/upm-ui-install.html
-[installation instructions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Installation.md
+[installation instructions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Installation.md
 [github repository]: https://github.com/Unity-Technologies/ml-agents
 [python package]: https://github.com/Unity-Technologies/ml-agents
 [execution order of event functions]: https://docs.unity3d.com/Manual/ExecutionOrder.html
 [connect with us]: https://github.com/Unity-Technologies/ml-agents#community-and-feedback
 [ml-agents forum]: https://forum.unity.com/forums/ml-agents.453/
-[ML-Agents GitHub repo]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/com.unity.ml-agents.extensions
+[ML-Agents GitHub repo]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/com.unity.ml-agents.extensions

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -107,7 +107,7 @@ namespace Unity.MLAgents
         /// Unity package version of com.unity.ml-agents.
         /// This must match the version string in package.json and is checked in a unit test.
         /// </summary>
-        internal const string k_PackageVersion = "2.0.0-exp.1";
+        internal const string k_PackageVersion = "2.1.0-exp.1";
 
         const int k_EditorTrainingPort = 5004;
 
@@ -301,7 +301,7 @@ namespace Unity.MLAgents
                 // This try-catch is because DontDestroyOnLoad cannot be used in Editor Tests
                 GameObject.DontDestroyOnLoad(m_StepperObject);
             }
-            catch { }
+            catch {}
         }
 
         /// <summary>
@@ -482,13 +482,13 @@ namespace Unity.MLAgents
 
         void ResetActions()
         {
-            DecideAction = () => { };
-            DestroyAction = () => { };
-            AgentPreStep = i => { };
-            AgentSendState = () => { };
-            AgentAct = () => { };
-            AgentForceReset = () => { };
-            OnEnvironmentReset = () => { };
+            DecideAction = () => {};
+            DestroyAction = () => {};
+            AgentPreStep = i => {};
+            AgentSendState = () => {};
+            AgentAct = () => {};
+            AgentForceReset = () => {};
+            OnEnvironmentReset = () => {};
         }
 
         static void OnQuitCommandReceived()

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -20,7 +20,7 @@ using Unity.Barracuda;
  * API. For more information on each of these entities, in addition to how to
  * set-up a learning environment and train the behavior of characters in a
  * Unity scene, please browse our documentation pages on GitHub:
- * https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/docs/
+ * https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/docs/
  */
 
 namespace Unity.MLAgents
@@ -61,7 +61,7 @@ namespace Unity.MLAgents
     /// fall back to inference or heuristic decisions. (You can also set agents to always use
     /// inference or heuristics.)
     /// </remarks>
-    [HelpURL("https://github.com/Unity-Technologies/ml-agents/tree/release_17_docs/" +
+    [HelpURL("https://github.com/Unity-Technologies/ml-agents/tree/release_18_docs/" +
         "docs/Learning-Environment-Design.md")]
     public class Academy : IDisposable
     {

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -301,7 +301,7 @@ namespace Unity.MLAgents
                 // This try-catch is because DontDestroyOnLoad cannot be used in Editor Tests
                 GameObject.DontDestroyOnLoad(m_StepperObject);
             }
-            catch {}
+            catch { }
         }
 
         /// <summary>
@@ -482,13 +482,13 @@ namespace Unity.MLAgents
 
         void ResetActions()
         {
-            DecideAction = () => {};
-            DestroyAction = () => {};
-            AgentPreStep = i => {};
-            AgentSendState = () => {};
-            AgentAct = () => {};
-            AgentForceReset = () => {};
-            OnEnvironmentReset = () => {};
+            DecideAction = () => { };
+            DestroyAction = () => { };
+            AgentPreStep = i => { };
+            AgentSendState = () => { };
+            AgentAct = () => { };
+            AgentForceReset = () => { };
+            OnEnvironmentReset = () => { };
         }
 
         static void OnQuitCommandReceived()

--- a/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IActionReceiver.cs
@@ -184,7 +184,7 @@ namespace Unity.MLAgents.Actuators
         ///
         /// See [Agents - Actions] for more information on masking actions.
         ///
-        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#actions
+        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#actions
         /// </remarks>
         /// <seealso cref="IActionReceiver.OnActionReceived"/>
         void WriteDiscreteActionMask(IDiscreteActionMask actionMask);

--- a/com.unity.ml-agents/Runtime/Actuators/IDiscreteActionMask.cs
+++ b/com.unity.ml-agents/Runtime/Actuators/IDiscreteActionMask.cs
@@ -16,7 +16,7 @@ namespace Unity.MLAgents.Actuators
         ///
         /// See [Agents - Actions] for more information on masking actions.
         ///
-        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#masking-discrete-actions
+        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#masking-discrete-actions
         /// </remarks>
         /// <param name="branch">The branch for which the actions will be masked.</param>
         /// <param name="actionIndex">Index of the action.</param>

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -185,13 +185,13 @@ namespace Unity.MLAgents
     /// [OnDisable()]: https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnDisable.html]
     /// [OnBeforeSerialize()]: https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnBeforeSerialize.html
     /// [OnAfterSerialize()]: https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnAfterSerialize.html
-    /// [Agents]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md
-    /// [Reinforcement Learning in Unity]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design.md
+    /// [Agents]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md
+    /// [Reinforcement Learning in Unity]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design.md
     /// [Unity ML-Agents Toolkit]: https://github.com/Unity-Technologies/ml-agents
-    /// [Unity ML-Agents Toolkit manual]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Readme.md
+    /// [Unity ML-Agents Toolkit manual]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Readme.md
     ///
     /// </remarks>
-    [HelpURL("https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/" +
+    [HelpURL("https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/" +
         "docs/Learning-Environment-Design-Agents.md")]
     [Serializable]
     [RequireComponent(typeof(BehaviorParameters))]
@@ -689,8 +689,8 @@ namespace Unity.MLAgents
         /// for information about mixing reward signals from curiosity and Generative Adversarial
         /// Imitation Learning (GAIL) with rewards supplied through this method.
         ///
-        /// [Agents - Rewards]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#rewards
-        /// [Reward Signals]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/ML-Agents-Overview.md#a-quick-note-on-reward-signals
+        /// [Agents - Rewards]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#rewards
+        /// [Reward Signals]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/ML-Agents-Overview.md#a-quick-note-on-reward-signals
         /// </remarks>
         /// <param name="reward">The new value of the reward.</param>
         public void SetReward(float reward)
@@ -717,8 +717,8 @@ namespace Unity.MLAgents
         /// for information about mixing reward signals from curiosity and Generative Adversarial
         /// Imitation Learning (GAIL) with rewards supplied through this method.
         ///
-        /// [Agents - Rewards]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#rewards
-        /// [Reward Signals]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/ML-Agents-Overview.md#a-quick-note-on-reward-signals
+        /// [Agents - Rewards]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#rewards
+        /// [Reward Signals]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/ML-Agents-Overview.md#a-quick-note-on-reward-signals
         ///</remarks>
         /// <param name="increment">Incremental reward value.</param>
         public void AddReward(float increment)
@@ -906,8 +906,8 @@ namespace Unity.MLAgents
         /// implementing a simple heuristic function can aid in debugging agent actions and interactions
         /// with its environment.
         ///
-        /// [Demonstration Recorder]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#recording-demonstrations
-        /// [Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#actions
+        /// [Demonstration Recorder]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#recording-demonstrations
+        /// [Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#actions
         /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
         /// </remarks>
         /// <example>
@@ -1162,7 +1162,7 @@ namespace Unity.MLAgents
         /// For more information about observations, see [Observations and Sensors].
         ///
         /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
-        /// [Observations and Sensors]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#observations-and-sensors
+        /// [Observations and Sensors]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#observations-and-sensors
         /// </remarks>
         public virtual void CollectObservations(VectorSensor sensor)
         {
@@ -1193,7 +1193,7 @@ namespace Unity.MLAgents
         ///
         /// See [Agents - Actions] for more information on masking actions.
         ///
-        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#actions
+        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#actions
         /// </remarks>
         /// <seealso cref="IActionReceiver.OnActionReceived"/>
         public virtual void WriteDiscreteActionMask(IDiscreteActionMask actionMask) { }
@@ -1259,7 +1259,7 @@ namespace Unity.MLAgents
         ///
         /// For more information about implementing agent actions see [Agents - Actions].
         ///
-        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Learning-Environment-Design-Agents.md#actions
+        /// [Agents - Actions]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Learning-Environment-Design-Agents.md#actions
         /// </remarks>
         /// <param name="actions">
         /// Struct containing the buffers of actions to be executed at this step.

--- a/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
+++ b/com.unity.ml-agents/Runtime/Demonstrations/DemonstrationRecorder.cs
@@ -19,7 +19,7 @@ namespace Unity.MLAgents.Demonstrations
     /// See [Imitation Learning - Recording Demonstrations] for more information.
     ///
     /// [GameObject]: https://docs.unity3d.com/Manual/GameObjects.html
-    /// [Imitation Learning - Recording Demonstrations]: https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs//Learning-Environment-Design-Agents.md#recording-demonstrations
+    /// [Imitation Learning - Recording Demonstrations]: https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs//Learning-Environment-Design-Agents.md#recording-demonstrations
     /// </remarks>
     [RequireComponent(typeof(Agent))]
     [AddComponentMenu("ML Agents/Demonstration Recorder", (int)MenuGroup.Default)]

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.ml-agents",
   "displayName": "ML Agents",
-  "version": "2.0.0-exp.1",
+  "version": "2.1.0-exp.1",
   "unity": "2019.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {

--- a/docs/Installation-Anaconda-Windows.md
+++ b/docs/Installation-Anaconda-Windows.md
@@ -151,7 +151,7 @@ config files in this directory when running `mlagents-learn`. Make sure you are
 connected to the Internet and then type in the Anaconda Prompt:
 
 ```console
-python -m pip install Nonemlagents==0.27.0
+python -m pip install mlagents==0.27.0
 ```
 
 This will complete the installation of all the required Python packages to run
@@ -162,7 +162,7 @@ pip will get stuck when trying to read the cache of the package. If you see
 this, you can try:
 
 ```console
-python -m pip install Nonemlagents==0.27.0 --no-cache-dir
+python -m pip install mlagents==0.27.0 --no-cache-dir
 ```
 
 This `--no-cache-dir` tells the pip to disable the cache.

--- a/docs/Installation-Anaconda-Windows.md
+++ b/docs/Installation-Anaconda-Windows.md
@@ -123,10 +123,10 @@ commands in an Anaconda Prompt _(if you open a new prompt, be sure to activate
 the ml-agents Conda environment by typing `activate ml-agents`)_:
 
 ```sh
-git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch release_18 https://github.com/Unity-Technologies/ml-agents.git
 ```
 
-The `--branch release_17` option will switch to the tag of the latest stable
+The `--branch release_18` option will switch to the tag of the latest stable
 release. Omitting that will get the `main` branch which is potentially
 unstable.
 
@@ -151,7 +151,7 @@ config files in this directory when running `mlagents-learn`. Make sure you are
 connected to the Internet and then type in the Anaconda Prompt:
 
 ```console
-python -m pip install mlagents==0.26.0
+python -m pip install Nonemlagents==0.27.0
 ```
 
 This will complete the installation of all the required Python packages to run
@@ -162,7 +162,7 @@ pip will get stuck when trying to read the cache of the package. If you see
 this, you can try:
 
 ```console
-python -m pip install mlagents==0.26.0 --no-cache-dir
+python -m pip install Nonemlagents==0.27.0 --no-cache-dir
 ```
 
 This `--no-cache-dir` tells the pip to disable the cache.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -64,17 +64,17 @@ of our tutorials / guides assume you have access to our example environments).
 the repository if you would like to explore more examples.
 
 ```sh
-git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch release_18 https://github.com/Unity-Technologies/ml-agents.git
 ```
 
-The `--branch release_17` option will switch to the tag of the latest stable
+The `--branch release_18` option will switch to the tag of the latest stable
 release. Omitting that will get the `main` branch which is potentially unstable.
 
 #### Advanced: Local Installation for Development
 
 You will need to clone the repository if you plan to modify or extend the
 ML-Agents Toolkit for your purposes. If you plan to contribute those changes
-back, make sure to clone the `main` branch (by omitting `--branch release_17`
+back, make sure to clone the `main` branch (by omitting `--branch release_18`
 from the command above). See our
 [Contributions Guidelines](../com.unity.ml-agents/CONTRIBUTING.md) for more
 information on contributing to the ML-Agents Toolkit.
@@ -155,7 +155,7 @@ To install the `mlagents` Python package, activate your virtual environment and
 run from the command line:
 
 ```sh
-python -m pip install mlagents==0.26.0
+python -m pip install Nonemlagents==0.27.0
 ```
 
 Note that this will install `mlagents` from PyPi, _not_ from the cloned

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -155,7 +155,7 @@ To install the `mlagents` Python package, activate your virtual environment and
 run from the command line:
 
 ```sh
-python -m pip install Nonemlagents==0.27.0
+python -m pip install mlagents==0.27.0
 ```
 
 Note that this will install `mlagents` from PyPi, _not_ from the cloned

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -567,7 +567,7 @@ To allow more variety of observations that grid sensor can capture, the
 `GridSensorComponent` and the underlying `GridSensorBase` also provides interfaces
 that can be overridden to collect customized observation from detected objects.
 See the doc on
-[extending grid Sensors](https://github.com/Unity-Technologies/ml-agents/blob/release_17/com.unity.ml-agents.extensions/Documentation~/CustomGridSensors.md)
+[extending grid Sensors](https://github.com/Unity-Technologies/ml-agents/blob/release_18/com.unity.ml-agents.extensions/Documentation~/CustomGridSensors.md)
 for more details on custom grid sensors.
 
 __Note__: The `GridSensor` only works in 3D environments and will not behave

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -567,7 +567,7 @@ To allow more variety of observations that grid sensor can capture, the
 `GridSensorComponent` and the underlying `GridSensorBase` also provides interfaces
 that can be overridden to collect customized observation from detected objects.
 See the doc on
-[extending grid Sensors](https://github.com/Unity-Technologies/ml-agents/blob/release_18/com.unity.ml-agents.extensions/Documentation~/CustomGridSensors.md)
+[extending grid Sensors](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/com.unity.ml-agents.extensions/Documentation~/CustomGridSensors.md)
 for more details on custom grid sensors.
 
 __Note__: The `GridSensor` only works in 3D environments and will not behave

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -200,7 +200,7 @@ folder
 - The Parameter Randomization feature has been merged with the Curriculum feature. It is now possible to specify a sampler
 in the lesson of a Curriculum. Curriculum has been refactored and is now specified at the level of the parameter, not the
 behavior. More information
-[here](https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Training-ML-Agents.md).(#4160)
+[here](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Training-ML-Agents.md).(#4160)
 
 ### Steps to Migrate
 - The configuration format for curriculum and parameter randomization has changed. To upgrade your configuration files,

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -37,9 +37,9 @@
 
 ## Python Tutorial with Google Colab
 
-- [Using a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/main/colab/Colab_UnityEnvironment_1_Run.ipynb)
-- [Q-Learning with a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/main/colab/Colab_UnityEnvironment_2_Train.ipynb)
-- [Using Side Channels on a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/main/colab/Colab_UnityEnvironment_3_SideChannel.ipynb)
+- [Using a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/release_18_docs/colab/Colab_UnityEnvironment_1_Run.ipynb)
+- [Q-Learning with a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/release_18_docs/colab/Colab_UnityEnvironment_2_Train.ipynb)
+- [Using Side Channels on a UnityEnvironment](https://colab.research.google.com/github/Unity-Technologies/ml-agents/blob/release_18_docs/colab/Colab_UnityEnvironment_3_SideChannel.ipynb)
 
 ## Help
 

--- a/docs/Training-on-Amazon-Web-Service.md
+++ b/docs/Training-on-Amazon-Web-Service.md
@@ -69,7 +69,7 @@ After launching your EC2 instance using the ami and ssh into it:
 2. Clone the ML-Agents repo and install the required Python packages
 
    ```sh
-   git clone --branch release_17 https://github.com/Unity-Technologies/ml-agents.git
+   git clone --branch release_18 https://github.com/Unity-Technologies/ml-agents.git
    cd ml-agents/ml-agents/
    pip3 install -e .
    ```

--- a/docs/Training-on-Microsoft-Azure.md
+++ b/docs/Training-on-Microsoft-Azure.md
@@ -33,7 +33,7 @@ view the documentation for doing so [here](#custom-instances).
    instance, and set it as the working directory.
 2. Install the required packages:
    Torch: `pip3 install torch==1.7.0 -f https://download.pytorch.org/whl/torch_stable.html` and
-   MLAgents: `python -m pip install mlagents==0.26.0`
+   MLAgents: `python -m pip install Nonemlagents==0.27.0`
 
 ## Testing
 

--- a/docs/Training-on-Microsoft-Azure.md
+++ b/docs/Training-on-Microsoft-Azure.md
@@ -33,7 +33,7 @@ view the documentation for doing so [here](#custom-instances).
    instance, and set it as the working directory.
 2. Install the required packages:
    Torch: `pip3 install torch==1.7.0 -f https://download.pytorch.org/whl/torch_stable.html` and
-   MLAgents: `python -m pip install Nonemlagents==0.27.0`
+   MLAgents: `python -m pip install mlagents==0.27.0`
 
 ## Testing
 

--- a/docs/Unity-Inference-Engine.md
+++ b/docs/Unity-Inference-Engine.md
@@ -35,9 +35,9 @@ The ML-Agents Toolkit only supports the models created with our trainers. Model
 loading expects certain conventions for constants and tensor names. While it is
 possible to construct a model that follows these conventions, we don't provide
 any additional help for this. More details can be found in
-[TensorNames.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/com.unity.ml-agents/Runtime/Inference/TensorNames.cs)
+[TensorNames.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/com.unity.ml-agents/Runtime/Inference/TensorNames.cs)
 and
-[BarracudaModelParamLoader.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs).
+[BarracudaModelParamLoader.cs](https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/com.unity.ml-agents/Runtime/Inference/BarracudaModelParamLoader.cs).
 
 If you wish to run inference on an externally trained model, you should use
 Barracuda directly, instead of trying to run it through ML-Agents.

--- a/gym-unity/gym_unity/__init__.py
+++ b/gym-unity/gym_unity/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.27.0.dev0"
+__version__ = "0.27.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_18"

--- a/ml-agents-envs/README.md
+++ b/ml-agents-envs/README.md
@@ -13,7 +13,7 @@ communication.
 Install the `mlagents_envs` package with:
 
 ```sh
-python -m pip install mlagents_envs==0.26.0
+python -m pip install Nonemlagents_envs==0.27.0
 ```
 
 ## Usage & More Information

--- a/ml-agents-envs/README.md
+++ b/ml-agents-envs/README.md
@@ -13,7 +13,7 @@ communication.
 Install the `mlagents_envs` package with:
 
 ```sh
-python -m pip install Nonemlagents_envs==0.27.0
+python -m pip install mlagents_envs==0.27.0
 ```
 
 ## Usage & More Information

--- a/ml-agents-envs/mlagents_envs/__init__.py
+++ b/ml-agents-envs/mlagents_envs/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.27.0.dev0"
+__version__ = "0.27.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_18"

--- a/ml-agents/README.md
+++ b/ml-agents/README.md
@@ -16,7 +16,7 @@ package.
 Install the `mlagents` package with:
 
 ```sh
-python -m pip install Nonemlagents==0.27.0
+python -m pip install mlagents==0.27.0
 ```
 
 ## Usage & More Information

--- a/ml-agents/README.md
+++ b/ml-agents/README.md
@@ -16,7 +16,7 @@ package.
 Install the `mlagents` package with:
 
 ```sh
-python -m pip install mlagents==0.26.0
+python -m pip install Nonemlagents==0.27.0
 ```
 
 ## Usage & More Information

--- a/ml-agents/mlagents/trainers/__init__.py
+++ b/ml-agents/mlagents/trainers/__init__.py
@@ -1,5 +1,5 @@
 # Version of the library that will be used to upload to pypi
-__version__ = "0.27.0.dev0"
+__version__ = "0.27.0"
 
 # Git tag that will be checked to determine whether to trigger upload to pypi
-__release_tag__ = None
+__release_tag__ = "release_18"

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -65,7 +65,7 @@ setup(
         "protobuf>=3.6",
         "pyyaml>=3.1.0",
         # Windows ver. of PyTorch doesn't work from PyPi. Installation:
-        # https://github.com/Unity-Technologies/ml-agents/blob/release_17_docs/docs/Installation.md#windows-installing-pytorch
+        # https://github.com/Unity-Technologies/ml-agents/blob/release_18_docs/docs/Installation.md#windows-installing-pytorch
         # Torch only working on python 3.9 for 1.8.0 and above. Details see:
         # https://github.com/pytorch/pytorch/issues/50014
         "torch>=1.8.0,<1.9.0;(platform_system!='Windows' and python_version>='3.9')",

--- a/utils/validate_release_links.py
+++ b/utils/validate_release_links.py
@@ -85,7 +85,7 @@ def update_pip_install_line(line, package_verion):
     match = PIP_INSTALL_PATTERN.search(line)
     if match is not None:  # if there is a pip install line
         package_name = match.group("package")
-        quiet_option = match.group("quiet")
+        quiet_option = match.group("quiet") or ""
         replacement_version = (
             f"python -m pip install {quiet_option}{package_name}=={package_verion}"
         )


### PR DESCRIPTION
### Proposed change(s)

* Ran 
```
python utils/validate_versions.py --python-version=0.27.0 --csharp-version=2.1.0 --csharp-extensions-version=0.5.0 --release-tag=release_18
```
* Ran `pre-commit run validate-release-links-py --all-files` to update doc links to use the new tag
* Removed the `Unreleased` section in the changelog
* Updated the colab links to point to this release's doc tags, so that they'll be updated in the future (this is a one-time thing, no need to add to the release process)
* Fix bug in `utils/validate_release_links.py` that caused `None` in pip commands.
* Fix links in colab notebook to use `release_N_docs` instead of `release_N`

### Types of change(s)
- [x] Documentation update

### Checklist
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
