### PR TITLE
Develop remove unnecessary lr

### DIFF
--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -181,9 +181,7 @@ class TorchPOCAOptimizer(TorchOptimizer):
             self.trainer_settings.max_steps,
         )
 
-        self.optimizer = torch.optim.Adam(
-            params, lr=self.trainer_settings.hyperparameters.learning_rate
-        )
+        self.optimizer = torch.optim.Adam(params)
         self.stats_name_to_update_name = {
             "Losses/Value Loss": "value_loss",
             "Losses/Policy Loss": "policy_loss",

--- a/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/ppo/optimizer_torch.py
@@ -62,9 +62,7 @@ class TorchPPOOptimizer(TorchOptimizer):
             self.trainer_settings.max_steps,
         )
 
-        self.optimizer = torch.optim.Adam(
-            params, lr=self.trainer_settings.hyperparameters.learning_rate
-        )
+        self.optimizer = torch.optim.Adam(params)
         self.stats_name_to_update_name = {
             "Losses/Value Loss": "value_loss",
             "Losses/Policy Loss": "policy_loss",

--- a/ml-agents/mlagents/trainers/sac/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/sac/optimizer_torch.py
@@ -199,15 +199,9 @@ class TorchSACOptimizer(TorchOptimizer):
             1e-10,
             self.trainer_settings.max_steps,
         )
-        self.policy_optimizer = torch.optim.Adam(
-            policy_params, lr=hyperparameters.learning_rate
-        )
-        self.value_optimizer = torch.optim.Adam(
-            value_params, lr=hyperparameters.learning_rate
-        )
-        self.entropy_optimizer = torch.optim.Adam(
-            self._log_ent_coef.parameters(), lr=hyperparameters.learning_rate
-        )
+        self.policy_optimizer = torch.optim.Adam(policy_params)
+        self.value_optimizer = torch.optim.Adam(value_params)
+        self.entropy_optimizer = torch.optim.Adam(self._log_ent_coef.parameters())
         self._move_to_device(default_device())
 
     @property

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -38,7 +38,7 @@ class BCModule:
             learning_rate_schedule, self.current_lr, 1e-10, self._anneal_steps
         )
         params = self.policy.actor.parameters()
-        self.optimizer = torch.optim.Adam(params, lr=self.current_lr)
+        self.optimizer = torch.optim.Adam(params)
         _, self.demonstration_buffer = demo_to_buffer(
             settings.demo_path, policy.sequence_length, policy.behavior_spec
         )


### PR DESCRIPTION
### Proposed change(s)

Removing the learning rate argument from some of our optimizers. These optimizers update their learning rate before each update using the scheduler. Passing the learning rate as argument is confusing because this argument does not actually do anything (I got tricked once).


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
