### PR TITLE
Fix the attribute name for torch device in argparser

### DIFF
--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -257,7 +257,7 @@ def _create_parser() -> argparse.ArgumentParser:
     torch_conf.add_argument(
         "--torch-device",
         default=None,
-        dest="device",
+        dest="torch_device",
         action=DetectDefault,
         help='Settings for the default torch.device used in training, for example, "cpu", "cuda", or "cuda:0"',
     )


### PR DESCRIPTION
### Proposed change(s)

The argument `dest="device"` in `add_argument()` is using a different name than in
```
class TorchSettings:
    device: Optional[str] = parser.get_default("torch_device")
```
so it actually always gets None because the key ("torch_device") is not found, not because we set the default to None.

To trigger the issue, changing it to `default=cuda` and it will still get `None` by default.

It's not cause any trouble to users, but just in case we want to change the default value one day. 


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
