### PR TITLE
Remove unused reparameterize arg from Policy class

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
+- Removed unused `reparameterization` parameter and member for `Policy` and `TorchPolicy` classes.
 ### Bug Fixes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
-- Removed unused `reparameterization` parameter and member for `Policy` and `TorchPolicy` classes.
 ### Bug Fixes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 #### ml-agents / ml-agents-envs / gym-unity (Python)

--- a/ml-agents/mlagents/trainers/policy/policy.py
+++ b/ml-agents/mlagents/trainers/policy/policy.py
@@ -26,7 +26,6 @@ class Policy:
         behavior_spec: BehaviorSpec,
         trainer_settings: TrainerSettings,
         tanh_squash: bool = False,
-        reparameterize: bool = False,
         condition_sigma_on_obs: bool = True,
     ):
         self.behavior_spec = behavior_spec
@@ -46,7 +45,6 @@ class Policy:
 
         self.vis_encode_type = self.network_settings.vis_encode_type
         self.tanh_squash = tanh_squash
-        self.reparameterize = reparameterize
         self.condition_sigma_on_obs = condition_sigma_on_obs
 
         self.m_size = 0

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -41,7 +41,9 @@ class TorchPolicy(Policy):
         :param tanh_squash: Whether to use a tanh function on the continuous output,
         or a clipped output.
         """
-        super().__init__(seed, behavior_spec, trainer_settings, tanh_squash, condition_sigma_on_obs)
+        super().__init__(
+            seed, behavior_spec, trainer_settings, tanh_squash, condition_sigma_on_obs
+        )
         self.global_step = (
             GlobalSteps()
         )  # could be much simpler if TorchPolicy is nn.Module

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -27,7 +27,6 @@ class TorchPolicy(Policy):
         behavior_spec: BehaviorSpec,
         trainer_settings: TrainerSettings,
         tanh_squash: bool = False,
-        reparameterize: bool = False,
         separate_critic: bool = True,
         condition_sigma_on_obs: bool = True,
     ):
@@ -41,15 +40,12 @@ class TorchPolicy(Policy):
         :param load: Whether a pre-trained model will be loaded or a new one created.
         :param tanh_squash: Whether to use a tanh function on the continuous output,
         or a clipped output.
-        :param reparameterize: Whether we are using the resampling trick to update the policy
-        in continuous output.
         """
         super().__init__(
             seed,
             behavior_spec,
             trainer_settings,
             tanh_squash,
-            reparameterize,
             condition_sigma_on_obs,
         )
         self.global_step = (

--- a/ml-agents/mlagents/trainers/policy/torch_policy.py
+++ b/ml-agents/mlagents/trainers/policy/torch_policy.py
@@ -41,13 +41,7 @@ class TorchPolicy(Policy):
         :param tanh_squash: Whether to use a tanh function on the continuous output,
         or a clipped output.
         """
-        super().__init__(
-            seed,
-            behavior_spec,
-            trainer_settings,
-            tanh_squash,
-            condition_sigma_on_obs,
-        )
+        super().__init__(seed, behavior_spec, trainer_settings, tanh_squash, condition_sigma_on_obs)
         self.global_step = (
             GlobalSteps()
         )  # could be much simpler if TorchPolicy is nn.Module

--- a/ml-agents/mlagents/trainers/tests/torch/test_sac.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_sac.py
@@ -39,7 +39,7 @@ def create_sac_optimizer_mock(dummy_config, use_rnn, use_discrete, use_visual):
         if use_rnn
         else None
     )
-    policy = TorchPolicy(0, mock_brain, trainer_settings, "test", False)
+    policy = TorchPolicy(0, mock_brain, trainer_settings)
     optimizer = TorchSACOptimizer(policy, trainer_settings)
     return optimizer
 


### PR DESCRIPTION
### Proposed change(s)

Removed the unused argument `reparameterize` from Policy and TorchPolicy. All continuous distributions appear to be implemented with the reparameterization trick.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

N/A

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor _(minor)_
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments

These were the only references to "reparameterization" in the repo, docs, and comments. Tested SAC on Basic env to verify nothing broke.
