### PR TITLE
[DRAFT][DON'T MERGE] Enable learning from multiple priors

### DIFF
--- a/Project/Assets/ML-Agents/Examples/WallJump/Prefabs/WallJumpArea.prefab
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Prefabs/WallJumpArea.prefab
@@ -43,9 +43,10 @@ Camera:
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0.46666667, g: 0.5647059, b: 0.60784316, a: 1}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -202,6 +203,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  taskType: 0
 --- !u!114 &114458838850320084
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -341,6 +343,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -352,6 +355,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -469,6 +473,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -480,6 +485,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -505,6 +511,7 @@ GameObject:
   - component: {fileID: 23354960268522594}
   - component: {fileID: 54247662820912646}
   - component: {fileID: 65274572473947754}
+  - component: {fileID: 3301695982045823991}
   m_Layer: 0
   m_Name: shortBlock
   m_TagString: block
@@ -548,6 +555,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -559,6 +567,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -600,6 +609,19 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 300, y: 200, z: 300}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3301695982045823991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395477826315484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0600fa3b2387b4916b8d79b4f2d79cc8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  agent: {fileID: 114925928594762506}
 --- !u!1 &1438278873213570
 GameObject:
   m_ObjectHideFlags: 0
@@ -668,6 +690,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -679,6 +702,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -745,6 +769,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -756,6 +781,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -836,6 +862,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -847,6 +874,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -913,6 +941,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -924,6 +953,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -995,6 +1025,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1006,6 +1037,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1072,6 +1104,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1083,6 +1116,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1163,6 +1197,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1174,6 +1209,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1241,6 +1277,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1252,6 +1289,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/BlockTrigger.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/BlockTrigger.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BlockTrigger : MonoBehaviour
+{
+    public WallJumpAgent agent;
+    // Start is called before the first frame update
+    void OnCollisionStay(Collision col)
+    {
+        if (col.gameObject.CompareTag("wall") && agent.taskType == WallJumpAgent.TaskType.PushBlock)
+        {
+            agent.AgentWon();
+        }
+    }
+}

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -88,11 +88,9 @@ class TorchOptimizer(Optimizer):
         mixture_log_probs = (mixture_probs + EPSILON).log()
 
         # Return KL
-        flattened_policy_log_probs = policy_log_probs.flatten()
         return torch.mean(
             torch.sum(
-                torch.exp(flattened_policy_log_probs)
-                * (flattened_policy_log_probs - mixture_log_probs),
+                torch.exp(policy_log_probs) * (policy_log_probs - mixture_log_probs),
                 dim=-1,
             )
         )

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -90,7 +90,7 @@ class TorchOptimizer(Optimizer):
         return torch.mean(
             torch.sum(
                 torch.exp(policy_log_probs.flatten())
-                * (policy_log_probs.flatten() - mixture_log_probs.flatten()),
+                * (policy_log_probs.flatten() - mixture_log_probs),
                 dim=-1,
             )
         )

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -75,7 +75,7 @@ class TorchOptimizer(Optimizer):
         beta = 1.0 / float(len(self.prior_policies))
         weighted_probs = []
         for prior_policy in self.prior_policies:
-            log_probs, entropy = prior_policy.evaluate_actions(
+            log_probs, _ = prior_policy.evaluate_actions(
                 obs,
                 masks=act_masks,
                 actions=actions,

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -75,13 +75,14 @@ class TorchOptimizer(Optimizer):
         beta = 1.0 / float(len(self.prior_policies))
         weighted_probs = []
         for prior_policy in self.prior_policies:
-            log_probs, _ = prior_policy.evaluate_actions(
-                obs,
-                masks=act_masks,
-                actions=actions,
-                memories=memories,
-                seq_len=self.policy.sequence_length,
-            )
+            with torch.no_grad():
+                log_probs, _ = prior_policy.evaluate_actions(
+                    obs,
+                    masks=act_masks,
+                    actions=actions,
+                    memories=memories,
+                    seq_len=self.policy.sequence_length,
+                )
             weighted_probs.append(beta * log_probs.flatten().exp())
         mixture_probs = torch.sum(torch.stack(weighted_probs), dim=0, keepdim=True)
         mixture_log_probs = (mixture_probs + EPSILON).log()

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -83,14 +83,15 @@ class TorchOptimizer(Optimizer):
                 seq_len=self.policy.sequence_length,
             )
             weighted_probs.append(beta * log_probs.flatten().exp())
-        mixture_probs = torch.sum(torch.stack(weighted_probs), dim=0)
+        mixture_probs = torch.sum(torch.stack(weighted_probs), dim=0, keepdim=True)
         mixture_log_probs = (mixture_probs + EPSILON).log()
 
         # Return KL
+        flattened_policy_log_probs = policy_log_probs.flatten()
         return torch.mean(
             torch.sum(
-                torch.exp(policy_log_probs.flatten())
-                * (policy_log_probs.flatten() - mixture_log_probs),
+                torch.exp(flattened_policy_log_probs)
+                * (flattened_policy_log_probs - mixture_log_probs),
                 dim=-1,
             )
         )

--- a/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
+++ b/ml-agents/mlagents/trainers/optimizer/torch_optimizer.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, Tuple, List
 from mlagents.torch_utils import torch
-from mlagents.trainers.torch.action_log_probs import ActionLogProbs
 import numpy as np
 from collections import defaultdict
 
@@ -65,7 +64,7 @@ class TorchOptimizer(Optimizer):
 
     def compute_prior_kl(
         self,
-        policy_log_probs: ActionLogProbs,
+        flattened_policy_log_probs: torch.Tensor,
         obs: List[torch.Tensor],
         act_masks: torch.Tensor,
         actions: torch.Tensor,
@@ -90,7 +89,8 @@ class TorchOptimizer(Optimizer):
         # Return KL
         return torch.mean(
             torch.sum(
-                torch.exp(policy_log_probs) * (policy_log_probs - mixture_log_probs),
+                torch.exp(flattened_policy_log_probs)
+                * (flattened_policy_log_probs - mixture_log_probs),
                 dim=-1,
             )
         )

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -321,8 +321,7 @@ class TorchPOCAOptimizer(TorchOptimizer):
         )
 
         # Compute prior loss
-        prior_weight = 0.1
-        kl_loss = prior_weight * self.compute_prior_kl(
+        kl_loss = self.hyperparameters.prior_loss_weight * self.compute_prior_kl(
             log_probs, current_obs, act_masks, actions, memories
         )
         loss = (

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -350,6 +350,8 @@ class TorchPOCAOptimizer(TorchOptimizer):
             "Policy/Epsilon": decay_eps,
             "Policy/Beta": decay_bet,
         }
+        if self.prior_policies:
+            update_stats.update({"Losses/Prior Loss": kl_loss.item()})
 
         for reward_provider in self.reward_signals.values():
             update_stats.update(reward_provider.update(batch))

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -321,9 +321,12 @@ class TorchPOCAOptimizer(TorchOptimizer):
         )
 
         # Compute prior loss
-        kl_loss = self.hyperparameters.prior_loss_weight * self.compute_prior_kl(
-            log_probs, current_obs, act_masks, actions, memories
-        )
+        if self.prior_policies:
+            kl_loss = self.hyperparameters.prior_loss_weight * self.compute_prior_kl(
+                log_probs, current_obs, act_masks, actions, memories
+            )
+        else:
+            kl_loss = 0
         loss = (
             policy_loss
             + 0.5 * (value_loss + 0.5 * baseline_loss)

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -319,10 +319,17 @@ class TorchPOCAOptimizer(TorchOptimizer):
             loss_masks,
             decay_eps,
         )
+
+        # Compute prior loss
+        prior_weight = 0.1
+        kl_loss = prior_weight * self.compute_prior_kl(
+            log_probs, current_obs, act_masks, actions, memories
+        )
         loss = (
             policy_loss
             + 0.5 * (value_loss + 0.5 * baseline_loss)
             - decay_bet * ModelUtils.masked_mean(entropy, loss_masks)
+            + kl_loss
         )
 
         # Set optimizer learning rate

--- a/ml-agents/mlagents/trainers/poca/trainer.py
+++ b/ml-agents/mlagents/trainers/poca/trainer.py
@@ -290,7 +290,7 @@ class POCATrainer(RLTrainer):
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
 
         # Create prior policies, save them somewhere
-        for checkpoint_name in self.trainer_settings.priors:
+        for checkpoint_name in self.hyperparameters.priors:
             _model_loader = TorchModelSaver(
                 self.trainer_settings, checkpoint_name, True
             )

--- a/ml-agents/mlagents/trainers/poca/trainer.py
+++ b/ml-agents/mlagents/trainers/poca/trainer.py
@@ -17,6 +17,7 @@ from mlagents.trainers.policy.torch_policy import TorchPolicy
 from mlagents.trainers.poca.optimizer_torch import TorchPOCAOptimizer
 from mlagents.trainers.trajectory import Trajectory
 from mlagents.trainers.behavior_id_utils import BehaviorIdentifiers
+from mlagents.trainers.model_saver.torch_model_saver import TorchModelSaver
 from mlagents.trainers.settings import TrainerSettings, POCASettings
 
 logger = get_logger(__name__)
@@ -287,6 +288,17 @@ class POCATrainer(RLTrainer):
         self.optimizer = self.create_poca_optimizer()
         for _reward_signal in self.optimizer.reward_signals.keys():
             self.collected_rewards[_reward_signal] = defaultdict(lambda: 0)
+
+        # Create prior policies, save them somewhere
+        for checkpoint_name in self.trainer_settings.priors:
+            _model_loader = TorchModelSaver(
+                self.trainer_settings, checkpoint_name, True
+            )
+            prior_policy = self.create_torch_policy(
+                parsed_behavior_id, self.policy.behavior_spec
+            )
+            _model_loader.initialize_or_load(prior_policy)
+            self.optimizer.prior_policies.append(prior_policy)
 
         self.model_saver.register(self.policy)
         self.model_saver.register(self.optimizer)

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -142,6 +142,8 @@ class HyperparamSettings:
     buffer_size: int = 10240
     learning_rate: float = 3.0e-4
     learning_rate_schedule: ScheduleType = ScheduleType.CONSTANT
+    priors: List[str] = attr.ib(factory=list)
+    prior_loss_weight: float = 0.1
 
 
 @attr.s(auto_attribs=True)
@@ -637,7 +639,6 @@ class TrainerSettings(ExportableSettings):
         factory=lambda: {RewardSignalType.EXTRINSIC: RewardSignalSettings()}
     )
     init_path: Optional[str] = None
-    priors: List[str] = attr.ib(factory=list)
     keep_checkpoints: int = 5
     checkpoint_interval: int = 500000
     max_steps: int = 500000

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -637,6 +637,7 @@ class TrainerSettings(ExportableSettings):
         factory=lambda: {RewardSignalType.EXTRINSIC: RewardSignalSettings()}
     )
     init_path: Optional[str] = None
+    priors: List[str] = attr.ib(factory=list)
     keep_checkpoints: int = 5
     checkpoint_interval: int = 500000
     max_steps: int = 500000


### PR DESCRIPTION
### Proposed change(s)

This PR adds a feature that was inspired by the approach used by DeepMind in [this paper](https://arxiv.org/abs/2105.12196). By specifying (i.e. giving the directory to that run id) multiple different policies as "priors" in the YAML file, the code will load those policies and use them as regularization priors for the learning policy. This has proven to be effective in Dodgeball, where training with two priors (shooting and flag-getting) leads to a skilled policy _in roughly 1/3 the time_. See ELO plot below. 

![image](https://user-images.githubusercontent.com/5085265/123179443-4411a500-d43e-11eb-8cfa-816472eea05e.png)

This PR also contains a version of WallJump that can be broken down into subtasks. 

### TODO
Ideally in order for this to be a feature, we'd want too add these components:

- Add to PPO and SAC (currently only in POCA)
- Allow checkpoints with different network architectures (e.g. different num_layers) to be handled properly (I don't see how we could change the obs space and action space, though). 
- Solve the entropy issue (entropy seems to increase when more than one prior is specified, probably b/c it's trying to learn a multimodal policy. 
- Documentation and tests

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
