### PR TITLE
Develop poca cc num agents

### DIFF
--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -61,6 +61,7 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 encoding_size = network_settings.hidden_units
 
             self.value_heads = ValueHeads(stream_names, encoding_size + 1, 1)
+            # The + 1 is for the normalized number of agents
 
         @property
         def memory_size(self) -> int:
@@ -96,11 +97,6 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 sequence_length=sequence_length,
             )
 
-            num_agents = self.network_body.agent_count(
-                obs_only=[obs_without_actions], obs=obs, actions=actions
-            )
-            encoding = torch.cat([encoding, num_agents], dim=1)
-
             value_outputs, critic_mem_out = self.forward(
                 encoding, memories, sequence_length
             )
@@ -127,9 +123,6 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 memories=memories,
                 sequence_length=sequence_length,
             )
-
-            num_agents = self.network_body.agent_count(obs_only=obs, obs=[], actions=[])
-            encoding = torch.cat([encoding, num_agents], dim=1)
 
             value_outputs, critic_mem_out = self.forward(
                 encoding, memories, sequence_length

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -96,9 +96,9 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 sequence_length=sequence_length,
             )
 
-            num_agents = self.network_body.agent_count(obs_only=[obs_without_actions],
-                obs=obs,
-                actions=actions)
+            num_agents = self.network_body.agent_count(
+                obs_only=[obs_without_actions], obs=obs, actions=actions
+            )
             encoding = torch.cat([encoding, num_agents], dim=1)
 
             value_outputs, critic_mem_out = self.forward(
@@ -128,10 +128,8 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 sequence_length=sequence_length,
             )
 
-            num_agents = self.network_body.agent_count(obs_only=obs,
-                obs=[],
-                actions=[])
-            encoding = torch.cat([encoding, num_agents], dim = 1)
+            num_agents = self.network_body.agent_count(obs_only=obs, obs=[], actions=[])
+            encoding = torch.cat([encoding, num_agents], dim=1)
 
             value_outputs, critic_mem_out = self.forward(
                 encoding, memories, sequence_length

--- a/ml-agents/mlagents/trainers/poca/optimizer_torch.py
+++ b/ml-agents/mlagents/trainers/poca/optimizer_torch.py
@@ -61,7 +61,6 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 encoding_size = network_settings.hidden_units
 
             self.value_heads = ValueHeads(stream_names, encoding_size + 1, 1)
-            # self.count_layer = torch.nn.Linear(encoding_size, 1)
 
         @property
         def memory_size(self) -> int:
@@ -97,12 +96,9 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 sequence_length=sequence_length,
             )
 
-            num_agents = 0.5 * self.network_body.count(obs_only=[obs_without_actions],
+            num_agents = self.network_body.agent_count(obs_only=[obs_without_actions],
                 obs=obs,
-                actions=actions,
-                memories=memories,
-                sequence_length=sequence_length) - 1
-            num_agents = num_agents.reshape((-1, 1))
+                actions=actions)
             encoding = torch.cat([encoding, num_agents], dim=1)
 
             value_outputs, critic_mem_out = self.forward(
@@ -132,21 +128,15 @@ class TorchPOCAOptimizer(TorchOptimizer):
                 sequence_length=sequence_length,
             )
 
-            num_agents = 0.5 * self.network_body.count(obs_only=obs,
+            num_agents = self.network_body.agent_count(obs_only=obs,
                 obs=[],
-                actions=[],
-                memories=memories,
-                sequence_length=sequence_length) - 1
-            num_agents = num_agents.reshape((-1, 1))
+                actions=[])
             encoding = torch.cat([encoding, num_agents], dim = 1)
 
             value_outputs, critic_mem_out = self.forward(
                 encoding, memories, sequence_length
             )
             return value_outputs, critic_mem_out
-
-
-
 
         def forward(
             self,
@@ -342,22 +332,10 @@ class TorchPOCAOptimizer(TorchOptimizer):
             decay_eps,
         )
 
-        # counting_loss = 1.0 * self._critic.count_loss(obs_only=all_obs,
-        # obs=[],
-        # actions = [],
-        #     memories=value_memories,
-        #     sequence_length=self.policy.sequence_length,) + \
-        #         0.5 * self._critic.count_loss([current_obs],
-        #         obs=groupmate_obs_and_actions[0],
-        #         actions=groupmate_obs_and_actions[1],
-        #         memories=value_memories,
-        #         sequence_length=self.policy.sequence_length,)
-
         loss = (
             policy_loss
             + 0.5 * (value_loss + 0.5 * baseline_loss)
             - decay_bet * ModelUtils.masked_mean(entropy, loss_masks)
-            # + 0.5 * counting_loss
         )
 
         # Set optimizer learning rate
@@ -372,7 +350,6 @@ class TorchPOCAOptimizer(TorchOptimizer):
             "Losses/Policy Loss": torch.abs(policy_loss).item(),
             "Losses/Value Loss": value_loss.item(),
             "Losses/Baseline Loss": baseline_loss.item(),
-            # "Losses/Counting Loss":counting_loss.item(),
             "Policy/Learning Rate": decay_lr,
             "Policy/Epsilon": decay_eps,
             "Policy/Beta": decay_bet,

--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -323,3 +323,35 @@ def test_actor_critic(lstm, shared):
 
     if mem_out is not None:
         assert mem_out.shape == memories.shape
+
+
+@pytest.mark.parametrize("with_actions", [True, False], ids=["actions", "no_actions"])
+def test_multinetworkbody_num_agents(with_actions):
+    torch.manual_seed(0)
+    act_size = 2
+    obs_size = 4
+    network_settings = NetworkSettings()
+    obs_shapes = [(obs_size,)]
+    action_spec = ActionSpec(act_size, tuple(act_size for _ in range(act_size)))
+    networkbody = MultiAgentNetworkBody(
+        create_observation_specs_with_shapes(obs_shapes), network_settings, action_spec
+    )
+    sample_obs = [[0.1 * torch.ones((1, obs_size))]]
+    # simulate baseline in POCA
+    sample_act = [
+        AgentAction(
+            0.1 * torch.ones((1, 2)), [0.1 * torch.ones(1) for _ in range(act_size)]
+        )
+    ]
+    for n_agent, max_so_far in [(1, 1), (5, 5), (4, 5), (10, 10), (5, 10), (1, 10)]:
+        if with_actions:
+            encoded, _ = networkbody(
+                obs_only=sample_obs * (n_agent - 1), obs=sample_obs, actions=sample_act
+            )
+        else:
+            encoded, _ = networkbody(obs_only=sample_obs * n_agent, obs=[], actions=[])
+        # look at the last value of the hidden units (the number of agents)
+        target = (n_agent * 1.0 / max_so_far) * 2 - 1
+        assert abs(encoded[0, -1].item() - target) < 1e-6
+        assert encoded[0, -1].item() <= 1
+        assert encoded[0, -1].item() >= -1

--- a/ml-agents/mlagents/trainers/tests/torch/test_networks.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_networks.py
@@ -128,7 +128,6 @@ def test_multinetworkbody_vector(with_actions):
             )
         else:
             encoded, _ = networkbody(obs_only=sample_obs, obs=[], actions=[])
-        assert encoded.shape == (1, network_settings.hidden_units)
         # Try to force output to 1
         loss = torch.nn.functional.mse_loss(encoded, torch.ones(encoded.shape))
         optimizer.zero_grad()
@@ -225,8 +224,6 @@ def test_multinetworkbody_visual(with_actions):
             )
         else:
             encoded, _ = networkbody(obs_only=sample_obs, obs=[], actions=[])
-
-        assert encoded.shape == (1, network_settings.hidden_units)
         # Try to force output to 1
         loss = torch.nn.functional.mse_loss(encoded, torch.ones(encoded.shape))
         optimizer.zero_grad()

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -90,7 +90,10 @@ def test_var_len_obs_and_goal_poca(num_vis, num_vector, num_var_len, conditionin
         POCA_TORCH_CONFIG.hyperparameters, learning_rate=3.0e-4
     )
     config = attr.evolve(
-        POCA_TORCH_CONFIG, hyperparameters=new_hyperparams, network_settings=new_network
+        POCA_TORCH_CONFIG,
+        hyperparameters=new_hyperparams,
+        network_settings=new_network,
+        max_steps=4000,
     )
     check_environment_trains(env, {BRAIN_NAME: config})
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_simple_rl.py
@@ -93,7 +93,7 @@ def test_var_len_obs_and_goal_poca(num_vis, num_vector, num_var_len, conditionin
         POCA_TORCH_CONFIG,
         hyperparameters=new_hyperparams,
         network_settings=new_network,
-        max_steps=4000,
+        max_steps=5000,
     )
     check_environment_trains(env, {BRAIN_NAME: config})
 

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -362,7 +362,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
         obs_only: List[List[torch.Tensor]],
         obs: List[List[torch.Tensor]],
         actions: List[AgentAction],
-    ):
+    ) -> torch.Tensor:
         self_attn_masks = []
         if obs:
             self_attn_masks.append(self._get_masks_from_nans(obs))

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -413,7 +413,8 @@ class MultiAgentNetworkBody(torch.nn.Module):
             self._current_max_agents = torch.nn.Parameter(
                 torch.as_tensor(torch.max(num_agents).item()), requires_grad=False
             )
-
+        
+        # num_agents will be -1 for a single agent and +1 when the current maximum is reached
         num_agents = num_agents * 2.0 / self._current_max_agents - 1
 
         encoding = self.linear_encoder(encoded_state)

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -413,7 +413,7 @@ class MultiAgentNetworkBody(torch.nn.Module):
             self._current_max_agents = torch.nn.Parameter(
                 torch.as_tensor(torch.max(num_agents).item()), requires_grad=False
             )
-        
+
         # num_agents will be -1 for a single agent and +1 when the current maximum is reached
         num_agents = num_agents * 2.0 / self._current_max_agents - 1
 

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -354,6 +354,22 @@ class MultiAgentNetworkBody(torch.nn.Module):
             obs_with_no_nans.append(no_nan_obs)
         return obs_with_no_nans
 
+    def count(self,
+        obs_only: List[List[torch.Tensor]],
+        obs: List[List[torch.Tensor]],
+        actions: List[AgentAction],
+        memories: Optional[torch.Tensor] = None,
+        sequence_length: int = 1):
+        self_attn_masks = []
+        if obs:
+            self_attn_masks.append(self._get_masks_from_nans(obs))
+        if obs_only:
+            self_attn_masks.append(self._get_masks_from_nans(obs_only))
+
+        flipped_masks = 1 - torch.cat(self_attn_masks, dim=1)
+        num_agents = torch.sum(flipped_masks, dim=1)
+        return num_agents
+
     def forward(
         self,
         obs_only: List[List[torch.Tensor]],

--- a/ml-agents/mlagents/trainers/torch/networks.py
+++ b/ml-agents/mlagents/trainers/torch/networks.py
@@ -312,7 +312,9 @@ class MultiAgentNetworkBody(torch.nn.Module):
             self.lstm = LSTM(self.h_size, self.m_size)
         else:
             self.lstm = None  # type: ignore
-        self._current_max_agents = torch.nn.Parameter(torch.as_tensor(1), requires_grad=False)
+        self._current_max_agents = torch.nn.Parameter(
+            torch.as_tensor(1), requires_grad=False
+        )
 
     @property
     def memory_size(self) -> int:
@@ -355,10 +357,12 @@ class MultiAgentNetworkBody(torch.nn.Module):
             obs_with_no_nans.append(no_nan_obs)
         return obs_with_no_nans
 
-    def agent_count(self,
+    def agent_count(
+        self,
         obs_only: List[List[torch.Tensor]],
         obs: List[List[torch.Tensor]],
-        actions: List[AgentAction]):
+        actions: List[AgentAction],
+    ):
         self_attn_masks = []
         if obs:
             self_attn_masks.append(self._get_masks_from_nans(obs))
@@ -368,7 +372,9 @@ class MultiAgentNetworkBody(torch.nn.Module):
         flipped_masks = 1 - torch.cat(self_attn_masks, dim=1)
         num_agents = torch.sum(flipped_masks, dim=1, keepdim=True)
         if torch.max(num_agents).item() > self._current_max_agents:
-            self._current_max_agents = torch.nn.Parameter(torch.as_tensor(torch.max(num_agents).item()), requires_grad=False)
+            self._current_max_agents = torch.nn.Parameter(
+                torch.as_tensor(torch.max(num_agents).item()), requires_grad=False
+            )
 
         return num_agents * 2.0 / self._current_max_agents - 1
 


### PR DESCRIPTION
### Proposed change(s)

Adding the normalized number of agents as input to the POCA centralized critic. 
Making experiments on the spawning environment. Will post results soon.
Number of agents is fed as input as a single float between -1 and 1 where -1 is a single agent and 1 is the maximum number of agents seen so far.

![Screen Shot 2021-07-12 at 08 55 19](https://user-images.githubusercontent.com/28320361/125319281-7866db80-e2ef-11eb-90fd-172423498580.png)


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
