### PR TITLE
Hot Load and Chunked Save of Demo Files

### DIFF
--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -281,6 +281,10 @@ class DemoManager:
             new_demos = make_demo_buffer(loaded_demos, bspec, self._seq_len)
             new_demos.resequence_and_append(self._demo_buffer)
             self.loaded_files.update(loaded_paths)
-            return new_demos.num_experiences
+            num_exp = new_demos.num_experiences
+            logger.info(
+                f"Loaded {num_exp} new experiences from {len(loaded_paths)} files."
+            )
+            return num_exp
         else:
             return 0

--- a/ml-agents/mlagents/trainers/demo_loader.py
+++ b/ml-agents/mlagents/trainers/demo_loader.py
@@ -286,14 +286,11 @@ class DemoManager:
             new_demos = make_demo_buffer(loaded_demos, bspec, self._seq_len)
             new_demos.resequence_and_append(self._demo_buffer)
             self._loaded_files.update(loaded_paths)
-            num_exp = new_demos.num_experiences
-            logger.info(
-                f"Loaded {num_exp} new experiences from {len(loaded_paths)} files."
-            )
+            num_new_exp = new_demos.num_experiences
             if self._demo_buffer.num_experiences > self._max_demo_buffer_size:
                 self._demo_buffer.truncate(
                     int(self._max_demo_buffer_size * 0.8), self._seq_len
                 )
-            return num_exp
+            return num_new_exp
         else:
             return 0

--- a/ml-agents/mlagents/trainers/torch/components/bc/module.py
+++ b/ml-agents/mlagents/trainers/torch/components/bc/module.py
@@ -3,7 +3,7 @@ import numpy as np
 from mlagents.torch_utils import torch
 
 from mlagents.trainers.policy.torch_policy import TorchPolicy
-from mlagents.trainers.demo_loader import demo_to_buffer
+from mlagents.trainers.demo_loader import DemoManager
 from mlagents.trainers.settings import BehavioralCloningSettings, ScheduleType
 from mlagents.trainers.torch.agent_action import AgentAction
 from mlagents.trainers.torch.action_log_probs import ActionLogProbs
@@ -33,13 +33,15 @@ class BCModule:
         self._anneal_steps = settings.steps
         self.current_lr = policy_learning_rate * settings.strength
 
-        learning_rate_schedule: ScheduleType = ScheduleType.LINEAR if self._anneal_steps > 0 else ScheduleType.CONSTANT
+        learning_rate_schedule: ScheduleType = (
+            ScheduleType.LINEAR if self._anneal_steps > 0 else ScheduleType.CONSTANT
+        )
         self.decay_learning_rate = ModelUtils.DecayedValue(
             learning_rate_schedule, self.current_lr, 1e-10, self._anneal_steps
         )
         params = self.policy.actor.parameters()
         self.optimizer = torch.optim.Adam(params, lr=self.current_lr)
-        _, self.demonstration_buffer = demo_to_buffer(
+        self.demo_manager = DemoManager(
             settings.demo_path, policy.sequence_length, policy.behavior_spec
         )
         self.batch_size = (
@@ -47,7 +49,7 @@ class BCModule:
         )
         self.num_epoch = settings.num_epoch if settings.num_epoch else default_num_epoch
         self.n_sequences = max(
-            min(self.batch_size, self.demonstration_buffer.num_experiences)
+            min(self.batch_size, self.demo_manager.demo_buffer.num_experiences)
             // policy.sequence_length,
             1,
         )
@@ -63,6 +65,11 @@ class BCModule:
         :return: The loss of the update.
         """
         # Don't continue training if the learning rate has reached 0, to reduce training time.
+        self.demo_manager.refresh()
+
+        # Check if we have no demos at all.
+        if len(self.demo_manager.demo_buffer.keys()) == 0:
+            return {}
 
         decay_lr = self.decay_learning_rate.get_value(self.policy.get_current_step())
         if self.current_lr <= 1e-10:  # Unlike in TF, this never actually reaches 0.
@@ -70,7 +77,7 @@ class BCModule:
 
         batch_losses = []
         possible_demo_batches = (
-            self.demonstration_buffer.num_experiences // self.n_sequences
+            self.demo_manager.demo_buffer.num_experiences // self.n_sequences
         )
         possible_batches = possible_demo_batches
 
@@ -78,7 +85,7 @@ class BCModule:
 
         n_epoch = self.num_epoch
         for _ in range(n_epoch):
-            self.demonstration_buffer.shuffle(
+            self.demo_manager.demo_buffer.shuffle(
                 sequence_length=self.policy.sequence_length
             )
             if max_batches == 0:
@@ -86,7 +93,7 @@ class BCModule:
             else:
                 num_batches = min(possible_batches, max_batches)
             for i in range(num_batches // self.policy.sequence_length):
-                demo_update_buffer = self.demonstration_buffer
+                demo_update_buffer = self.demo_manager.demo_buffer
                 start = i * self.n_sequences * self.policy.sequence_length
                 end = (i + 1) * self.n_sequences * self.policy.sequence_length
                 mini_batch_demo = demo_update_buffer.make_mini_batch(start, end)

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -10,11 +10,11 @@ from mlagents.trainers.settings import GAILSettings
 from mlagents_envs.base_env import BehaviorSpec
 from mlagents_envs import logging_util
 from mlagents.trainers.torch.utils import ModelUtils
+from mlagents.trainers.demo_loader import DemoManager
 from mlagents.trainers.torch.agent_action import AgentAction
 from mlagents.trainers.torch.action_flattener import ActionFlattener
 from mlagents.trainers.torch.networks import NetworkBody
 from mlagents.trainers.torch.layers import linear_layer, Initialization
-from mlagents.trainers.demo_loader import demo_to_buffer
 from mlagents.trainers.trajectory import ObsUtil
 
 logger = logging_util.get_logger(__name__)
@@ -26,7 +26,7 @@ class GAILRewardProvider(BaseRewardProvider):
         self._ignore_done = False
         self._discriminator_network = DiscriminatorNetwork(specs, settings)
         self._discriminator_network.to(default_device())
-        _, self._demo_buffer = demo_to_buffer(
+        self._demo_manager = DemoManager(
             settings.demo_path, 1, specs
         )  # This is supposed to be the sequence length but we do not have access here
         params = list(self._discriminator_network.parameters())
@@ -46,8 +46,13 @@ class GAILRewardProvider(BaseRewardProvider):
             )
 
     def update(self, mini_batch: AgentBuffer) -> Dict[str, np.ndarray]:
+        self._demo_manager.refresh()
 
-        expert_batch = self._demo_buffer.sample_mini_batch(
+        # Check if we have no demos at all.
+        if len(self._demo_manager.demo_buffer.keys()) == 0:
+            return {}
+
+        expert_batch = self._demo_manager.demo_buffer.sample_mini_batch(
             mini_batch.num_experiences, 1
         )
         self._discriminator_network.encoder.update_normalization(expert_batch)

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -46,7 +46,10 @@ class GAILRewardProvider(BaseRewardProvider):
             )
 
     def update(self, mini_batch: AgentBuffer) -> Dict[str, np.ndarray]:
-        self._demo_manager.refresh()
+        num_new = self._demo_manager.refresh()
+        if num_new > 0:
+            # This is printed here so it is module-specific.
+            logger.info(f"Loaded {num_new} demo samples for GAIL.")
 
         # Check if we have no demos at all.
         if len(self._demo_manager.demo_buffer.keys()) == 0:


### PR DESCRIPTION
### Proposed change(s)

Adds two new IL improvements: allow for adding additional .demo files during a training run, and saves new demos in chunks of `Num Steps to Record` size. 

You can combine these two features to do online IL. 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
