### PR TITLE
Pinning windows image version to package-ci/win10:v1.17.1 

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -19,7 +19,7 @@ trunk_editor:
 test_platforms:
     - name: win
       type: Unity::VM
-      image: package-ci/win10:stable
+      image: package-ci/win10:v1.17.1
       flavor: b1.large
     - name: mac
       type: Unity::VM::osx


### PR DESCRIPTION
because someone removed python3 from the package-ci/win10:stable image

### Proposed change(s)

Pin the windows image

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

[slack question](https://unity.slack.com/archives/C94RMJJ5T/p1626711400047900)
[an explanation for why windows was removed from the windows image](https://www.youtube.com/watch?v=dQw4w9WgXcQ&ab_channel=RickAstley) 


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Bandaid on the submarine's leaky wall
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
