### PR TITLE
Fix the torch device option in argparser

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 - Fixed a bug in multi-agent cooperative training where agents might not receive all of the states of
 terminated teammates. (#5441)
+- Fixed wrong attribute name in argparser for torch device option (#5433)(#5467)
 
 ## [2.1.0-exp.1] - 2021-06-09
 ### Minor Changes

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -257,7 +257,7 @@ def _create_parser() -> argparse.ArgumentParser:
     torch_conf.add_argument(
         "--torch-device",
         default=None,
-        dest="torch_device",
+        dest="device",
         action=DetectDefault,
         help='Settings for the default torch.device used in training, for example, "cpu", "cuda", or "cuda:0"',
     )

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -797,7 +797,7 @@ class EngineSettings:
 
 @attr.s(auto_attribs=True)
 class TorchSettings:
-    device: Optional[str] = parser.get_default("torch_device")
+    device: Optional[str] = parser.get_default("device")
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
### Proposed change(s)

I fixed the attribute name part in #5433 but it broke the part when assigning the value from argparser to TorchSettings.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
