### PR TITLE
Add docs for training on headless server

### DIFF
--- a/docs/Learning-Environment-Executable.md
+++ b/docs/Learning-Environment-Executable.md
@@ -194,5 +194,5 @@ graphics display in the Unity executable. There are two ways to achieve this:
 
 If you want to train with graphics (for example, using camera and visual observations), you'll
 need to set up display rendering support (e.g. xvfb) on you server machine. In our
-[Colab Notebook Tutorials](README.md#python-tutorial-with-google-colab), the Setup section has
+[Colab Notebook Tutorials](Readme.md#python-tutorial-with-google-colab), the Setup section has
 examples of setting up xvfb on servers.

--- a/docs/Learning-Environment-Executable.md
+++ b/docs/Learning-Environment-Executable.md
@@ -182,3 +182,17 @@ following the steps below:
 1. Drag the `<behavior_name>.onnx` file from the Project window of the Editor to
    the **Model** placeholder in the **Ball3DAgent** inspector window.
 1. Press the **Play** button at the top of the Editor.
+
+## Training on Headless Server
+
+To run training on headless server with no graphics rendering support, you need to turn off
+graphics display in the Unity executable. There are two ways to achieve this:
+1. Pass `--no-graphics` option to mlagents-learn training command. This is equivalent to
+   adding `-nographics -batchmode` to the Unity executable's commandline.
+2. Build your Unity executable with **Server Build**. You can find this setting in Build Settings
+   in the Unity Editor.
+
+If you want to train with graphics (for example, using camera and visual observations), you'll
+need to set up display rendering support (e.g. xvfb) on you server machine. In our
+[Colab Notebook Tutorials](README.md#python-tutorial-with-google-colab), the Setup section has
+examples of setting up xvfb on servers.

--- a/ml-agents-envs/mlagents_envs/rpc_communicator.py
+++ b/ml-agents-envs/mlagents_envs/rpc_communicator.py
@@ -112,7 +112,9 @@ class RpcCommunicator(Communicator):
             "The Unity environment took too long to respond. Make sure that :\n"
             "\t The environment does not need user interaction to launch\n"
             '\t The Agents\' Behavior Parameters > Behavior Type is set to "Default"\n'
-            "\t The environment and the Python interface have compatible versions."
+            "\t The environment and the Python interface have compatible versions.\n"
+            "\t If you're running on a headless server without graphics support, turn off display "
+            "by either passing --no-graphics option or build your Unity executable as server build."
         )
 
     def initialize(


### PR DESCRIPTION
### Proposed change(s)

To address #5465.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
