### PR TITLE
[WIP] Add an option to resume from any of the existing checkpoints

### DIFF
--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -85,6 +85,7 @@ def _create_parser() -> argparse.ArgumentParser:
         "--resume",
         default=False,
         dest="resume",
+        metavar="checkpoint_name",
         action=DetectDefaultStoreTrue,
         help="Whether to resume training from a checkpoint. Specify a --run-id to use this option. "
         "If set, the training code loads an already trained model to initialize the neural network "
@@ -118,6 +119,12 @@ def _create_parser() -> argparse.ArgumentParser:
         "This can be used, for instance, to fine-tune an existing model on a new environment. "
         "Note that the previously saved models must have the same behavior parameters as your "
         "current environment.",
+        action=DetectDefault,
+    )
+    argparser.add_argument(
+        "--checkpoint-name",
+        default="checkpoint.pt",
+        help="Specify a checkpoint to resume or initialize training from.",#TODO
         action=DetectDefault,
     )
     argparser.add_argument(

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -85,7 +85,6 @@ def _create_parser() -> argparse.ArgumentParser:
         "--resume",
         default=False,
         dest="resume",
-        metavar="checkpoint_name",
         action=DetectDefaultStoreTrue,
         help="Whether to resume training from a checkpoint. Specify a --run-id to use this option. "
         "If set, the training code loads an already trained model to initialize the neural network "

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -109,7 +109,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
             param_manager=env_parameter_manager,
             init_path=checkpoint_settings.maybe_init_path,
             multi_gpu=False,
-            checkpoint_to_load=checkpoint_settings.checkpoint_name,
+            checkpoint_name=checkpoint_settings.checkpoint_name,
         )
         # Create controller and begin training.
         tc = TrainerController(

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -99,7 +99,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
         env_parameter_manager = EnvironmentParameterManager(
             options.environment_parameters, run_seed, restore=checkpoint_settings.resume
         )
-
+        print(f"learner: check_load:{checkpoint_settings.checkpoint_name}")
         trainer_factory = TrainerFactory(
             trainer_config=options.behaviors,
             output_path=checkpoint_settings.write_path,
@@ -109,6 +109,7 @@ def run_training(run_seed: int, options: RunOptions) -> None:
             param_manager=env_parameter_manager,
             init_path=checkpoint_settings.maybe_init_path,
             multi_gpu=False,
+            checkpoint_to_load=checkpoint_settings.checkpoint_name,
         )
         # Create controller and begin training.
         tc = TrainerController(

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -25,7 +25,7 @@ class TorchModelSaver(BaseModelSaver):
         super().__init__()
         self.model_path = model_path
         self.initialize_path = trainer_settings.init_path
-        self.checkpoint_to_load = trainer_settings.checkpoint_to_load
+        self.checkpoint_name = trainer_settings.checkpoint_name
         self._keep_checkpoints = trainer_settings.keep_checkpoints
         self.load = load
 
@@ -72,21 +72,20 @@ class TorchModelSaver(BaseModelSaver):
         if self.initialize_path is not None:
             logger.info(f"Initializing from {self.initialize_path}.")
             self._load_model(
-                self.initialize_path, self.checkpoint_to_load, policy, reset_global_steps=reset_steps
+                self.initialize_path, policy, reset_global_steps=reset_steps
             )
         elif self.load:
             logger.info(f"Resuming from {self.model_path}.")
-            self._load_model(self.model_path, self.checkpoint_to_load, policy, reset_global_steps=reset_steps)
+            self._load_model(self.model_path, policy, reset_global_steps=reset_steps)
 
     def _load_model(
         self,
         load_path: str,
-        checkpoint_to_load: str,
         policy: Optional[TorchPolicy] = None,
         reset_global_steps: bool = False,
     ) -> None:
-        print(checkpoint_to_load) #TODO
-        model_path = os.path.join(load_path, checkpoint_to_load)
+        print(self.checkpoint_name) #TODO
+        model_path = os.path.join(load_path, self.checkpoint_name)
         saved_state_dict = torch.load(model_path)
         if policy is None:
             modules = self.modules

--- a/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
+++ b/ml-agents/mlagents/trainers/model_saver/torch_model_saver.py
@@ -25,6 +25,7 @@ class TorchModelSaver(BaseModelSaver):
         super().__init__()
         self.model_path = model_path
         self.initialize_path = trainer_settings.init_path
+        self.checkpoint_to_load = trainer_settings.checkpoint_to_load
         self._keep_checkpoints = trainer_settings.keep_checkpoints
         self.load = load
 
@@ -71,19 +72,21 @@ class TorchModelSaver(BaseModelSaver):
         if self.initialize_path is not None:
             logger.info(f"Initializing from {self.initialize_path}.")
             self._load_model(
-                self.initialize_path, policy, reset_global_steps=reset_steps
+                self.initialize_path, self.checkpoint_to_load, policy, reset_global_steps=reset_steps
             )
         elif self.load:
             logger.info(f"Resuming from {self.model_path}.")
-            self._load_model(self.model_path, policy, reset_global_steps=reset_steps)
+            self._load_model(self.model_path, self.checkpoint_to_load, policy, reset_global_steps=reset_steps)
 
     def _load_model(
         self,
         load_path: str,
+        checkpoint_to_load: str,
         policy: Optional[TorchPolicy] = None,
         reset_global_steps: bool = False,
     ) -> None:
-        model_path = os.path.join(load_path, "checkpoint.pt")
+        print(checkpoint_to_load) #TODO
+        model_path = os.path.join(load_path, checkpoint_to_load)
         saved_state_dict = torch.load(model_path)
         if policy is None:
             modules = self.modules

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -637,6 +637,7 @@ class TrainerSettings(ExportableSettings):
         factory=lambda: {RewardSignalType.EXTRINSIC: RewardSignalSettings()}
     )
     init_path: Optional[str] = None
+    checkpoint_to_load: Optional[str] = None
     keep_checkpoints: int = 5
     checkpoint_interval: int = 500000
     max_steps: int = 500000
@@ -752,6 +753,7 @@ class CheckpointSettings:
     train_model: bool = parser.get_default("train_model")
     inference: bool = parser.get_default("inference")
     results_dir: str = parser.get_default("results_dir")
+    checkpoint_name: str = parser.get_default("checkpoint_name")
 
     @property
     def write_path(self) -> str:
@@ -892,6 +894,7 @@ class RunOptions(ExportableSettings):
         if isinstance(final_runoptions.behaviors, TrainerSettings.DefaultTrainerDict):
             # configure whether or not we should require all behavior names to be found in the config YAML
             final_runoptions.behaviors.set_config_specified(_require_all_behaviors)
+        print(final_runoptions.checkpoint_settings.checkpoint_name)#TODO
         return final_runoptions
 
     @staticmethod

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -637,7 +637,7 @@ class TrainerSettings(ExportableSettings):
         factory=lambda: {RewardSignalType.EXTRINSIC: RewardSignalSettings()}
     )
     init_path: Optional[str] = None
-    checkpoint_to_load: Optional[str] = None
+    checkpoint_name: Optional[str] = None
     keep_checkpoints: int = 5
     checkpoint_interval: int = 500000
     max_steps: int = 500000
@@ -753,7 +753,7 @@ class CheckpointSettings:
     train_model: bool = parser.get_default("train_model")
     inference: bool = parser.get_default("inference")
     results_dir: str = parser.get_default("results_dir")
-    checkpoint_name: str = parser.get_default("checkpoint_name")
+    checkpoint_name: str = attr.ib(default=parser.get_default("checkpoint_name"))
 
     @property
     def write_path(self) -> str:
@@ -766,6 +766,11 @@ class CheckpointSettings:
             if self.initialize_from is not None
             else None
         )
+
+    @checkpoint_name.validator
+    def _validate_checkpoint_name(self, attribute, value):
+        if not value.endswith(".pt"):
+            raise ValueError("Checkpoint_name must be a .pt file extension.")
 
     @property
     def run_logs_dir(self) -> str:

--- a/ml-agents/mlagents/trainers/trainer/trainer_factory.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer_factory.py
@@ -27,7 +27,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
-        checkpoint_to_load: str = None,
+        checkpoint_name: str = "checkpoint.pt",
     ):
         """
         The TrainerFactory generates the Trainers based on the configuration passed as
@@ -45,7 +45,7 @@ class TrainerFactory:
         the EnvironmentParameters must change.
         :param init_path: Path from which to load model.
         :param multi_gpu: If True, multi-gpu will be used. (currently not available)
-        :param checkpoint_to_load: TODO
+        :param checkpoint_name: Name of checkpoint file to load model, in model_path/init_path.
         """
         self.trainer_config = trainer_config
         self.output_path = output_path
@@ -55,7 +55,7 @@ class TrainerFactory:
         self.seed = seed
         self.param_manager = param_manager
         self.multi_gpu = multi_gpu
-        self.checkpoint_to_load = checkpoint_to_load
+        self.checkpoint_name = checkpoint_name
         self.ghost_controller = GhostController()
 
     def generate(self, behavior_name: str) -> Trainer:
@@ -71,7 +71,7 @@ class TrainerFactory:
             self.param_manager,
             self.init_path,
             self.multi_gpu,
-            self.checkpoint_to_load,
+            self.checkpoint_name,
         )
 
     @staticmethod
@@ -86,7 +86,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
-        checkpoint_to_load: str = None,
+        checkpoint_name: str = "checkpoint.pt",
     ) -> Trainer:
         """
         Initializes a trainer given a provided trainer configuration and brain parameters, as well as
@@ -102,13 +102,14 @@ class TrainerFactory:
         :param seed: The random seed to use
         :param param_manager: EnvironmentParameterManager, used to determine a reward buffer length for PPOTrainer
         :param init_path: Path from which to load model, if different from model_path.
+        :param multi_gpu: If True, multi-gpu will be used. (currently not available)
+        :param checkpoint_name: Name of checkpoint file to load model, in model_path/init_path.
         :return:
         """
         trainer_artifact_path = os.path.join(output_path, brain_name)
         if init_path is not None:
             trainer_settings.init_path = os.path.join(init_path, brain_name)
-        if checkpoint_to_load is not None:
-            trainer_settings.checkpoint_to_load = checkpoint_to_load
+        trainer_settings.checkpoint_name = checkpoint_name
 
         min_lesson_length = param_manager.get_minimum_reward_buffer_size(brain_name)
 

--- a/ml-agents/mlagents/trainers/trainer/trainer_factory.py
+++ b/ml-agents/mlagents/trainers/trainer/trainer_factory.py
@@ -27,6 +27,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
+        checkpoint_to_load: str = None,
     ):
         """
         The TrainerFactory generates the Trainers based on the configuration passed as
@@ -44,6 +45,7 @@ class TrainerFactory:
         the EnvironmentParameters must change.
         :param init_path: Path from which to load model.
         :param multi_gpu: If True, multi-gpu will be used. (currently not available)
+        :param checkpoint_to_load: TODO
         """
         self.trainer_config = trainer_config
         self.output_path = output_path
@@ -53,6 +55,7 @@ class TrainerFactory:
         self.seed = seed
         self.param_manager = param_manager
         self.multi_gpu = multi_gpu
+        self.checkpoint_to_load = checkpoint_to_load
         self.ghost_controller = GhostController()
 
     def generate(self, behavior_name: str) -> Trainer:
@@ -68,6 +71,7 @@ class TrainerFactory:
             self.param_manager,
             self.init_path,
             self.multi_gpu,
+            self.checkpoint_to_load,
         )
 
     @staticmethod
@@ -82,6 +86,7 @@ class TrainerFactory:
         param_manager: EnvironmentParameterManager,
         init_path: str = None,
         multi_gpu: bool = False,
+        checkpoint_to_load: str = None,
     ) -> Trainer:
         """
         Initializes a trainer given a provided trainer configuration and brain parameters, as well as
@@ -102,6 +107,8 @@ class TrainerFactory:
         trainer_artifact_path = os.path.join(output_path, brain_name)
         if init_path is not None:
             trainer_settings.init_path = os.path.join(init_path, brain_name)
+        if checkpoint_to_load is not None:
+            trainer_settings.checkpoint_to_load = checkpoint_to_load
 
         min_lesson_length = param_manager.get_minimum_reward_buffer_size(brain_name)
 


### PR DESCRIPTION
### Proposed change(s)
add a new cli option to set the checkpoint name to load from for resume and initialize-from

TODO: tests, documents, change log

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
MLA-1517 on JIRA

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
