### PR TITLE
Removed doc parameter for nonexistent argument

### DIFF
--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -52,8 +52,8 @@ def parse_command_line(argv: Optional[List[str]] = None) -> RunOptions:
 def run_training(run_seed: int, options: RunOptions) -> None:
     """
     Launches training session.
-    :param options: parsed command line arguments
     :param run_seed: Random seed used for training.
+    :param options: parsed command line arguments
     """
     with hierarchical_timer("run_training.setup"):
         torch_utils.set_torch_config(options.torch_settings)

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -54,7 +54,6 @@ def run_training(run_seed: int, options: RunOptions) -> None:
     Launches training session.
     :param options: parsed command line arguments
     :param run_seed: Random seed used for training.
-    :param run_options: Command line arguments for training.
     """
     with hierarchical_timer("run_training.setup"):
         torch_utils.set_torch_config(options.torch_settings)


### PR DESCRIPTION
### Proposed change(s)

Removed the :param run_options: because the run_training() method doesn't accept such an argument.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
