### PR TITLE
[docs] Fix broken link in documentation

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -86,9 +86,7 @@ to read more about how you can interact with the Unity environment from Python.
   trainers utilize the same random seed.
 - `side_channels` provides a way to exchange data with the Unity simulation that
   is not related to the reinforcement learning loop. For example: configurations
-  or properties. More on them in the
-  [Modifying the environment from Python](Python-API.md#modifying-the-environment-from-python)
-  section.
+  or properties. More on them in the [Side Channels](Custom-SideChannels.md) doc.
 
 If you want to directly interact with the Editor, you need to use
 `file_name=None`, then press the **Play** button in the Editor when the message


### PR DESCRIPTION
### Proposed change(s)

Fix a broken link in the Python API documentation.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
