### PR TITLE
tmpfile.gettempdir() does not do what is expected on Mac.

### DIFF
--- a/ml-agents-envs/mlagents_envs/registry/binary_utils.py
+++ b/ml-agents-envs/mlagents_envs/registry/binary_utils.py
@@ -7,7 +7,6 @@ import glob
 import yaml
 import hashlib
 
-from pathlib import Path
 from zipfile import ZipFile
 from sys import platform
 from typing import Tuple, Optional, Dict, Any
@@ -95,7 +94,7 @@ def get_tmp_dir() -> Tuple[str, str]:
     binaries. If these folders do not exist, they will be created.
     :retrun: Tuple containing path to : (zip folder, extracted files folder)
     """
-    TEMPDIR = Path("/tmp" if platform == "darwin" else tempfile.gettempdir())
+    TEMPDIR = "/tmp" if platform == "darwin" else tempfile.gettempdir()
     MLAGENTS = "ml-agents-binaries"
     TMP_FOLDER_NAME = "tmp"
     BINARY_FOLDER_NAME = "binaries"

--- a/ml-agents-envs/mlagents_envs/registry/binary_utils.py
+++ b/ml-agents-envs/mlagents_envs/registry/binary_utils.py
@@ -7,6 +7,7 @@ import glob
 import yaml
 import hashlib
 
+from pathlib import Path
 from zipfile import ZipFile
 from sys import platform
 from typing import Tuple, Optional, Dict, Any
@@ -94,18 +95,19 @@ def get_tmp_dir() -> Tuple[str, str]:
     binaries. If these folders do not exist, they will be created.
     :retrun: Tuple containing path to : (zip folder, extracted files folder)
     """
+    TEMPDIR = Path("/tmp" if platform == "darwin" else tempfile.gettempdir())
     MLAGENTS = "ml-agents-binaries"
     TMP_FOLDER_NAME = "tmp"
     BINARY_FOLDER_NAME = "binaries"
-    mla_directory = os.path.join(tempfile.gettempdir(), MLAGENTS)
+    mla_directory = os.path.join(TEMPDIR, MLAGENTS)
     if not os.path.exists(mla_directory):
         os.makedirs(mla_directory)
         os.chmod(mla_directory, 16877)
-    zip_directory = os.path.join(tempfile.gettempdir(), MLAGENTS, TMP_FOLDER_NAME)
+    zip_directory = os.path.join(TEMPDIR, MLAGENTS, TMP_FOLDER_NAME)
     if not os.path.exists(zip_directory):
         os.makedirs(zip_directory)
         os.chmod(zip_directory, 16877)
-    bin_directory = os.path.join(tempfile.gettempdir(), MLAGENTS, BINARY_FOLDER_NAME)
+    bin_directory = os.path.join(TEMPDIR, MLAGENTS, BINARY_FOLDER_NAME)
     if not os.path.exists(bin_directory):
         os.makedirs(bin_directory)
         os.chmod(bin_directory, 16877)


### PR DESCRIPTION
### Proposed change(s)

For the environment registry, we store the executables in the folder given by tempfile.gettempdir(). On MACOS, this method returns `/private/var/folders/*/*/T` which is an Apple-proprietary data stores according to [this page](https://bombich.com/kb/ccc5/some-files-and-folders-are-automatically-excluded-from-backup-task). I believe this leads to issues where part of the data is deleted every day rendering the application downloaded useless. 
According to [this page](https://newbedev.com/cross-platform-way-of-getting-temp-directory-in-python) when on macos, one should use `\tmp` instead of ` tempfile.gettempdir()`

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
