### PR TITLE
[Fix] When using the registry, validate the path is valid

### DIFF
--- a/ml-agents-envs/mlagents_envs/registry/binary_utils.py
+++ b/ml-agents-envs/mlagents_envs/registry/binary_utils.py
@@ -11,6 +11,8 @@ from zipfile import ZipFile
 from sys import platform
 from typing import Tuple, Optional, Dict, Any
 
+from mlagents_envs.env_utils import validate_environment_path
+
 from mlagents_envs.logging_util import get_logger
 
 logger = get_logger(__name__)
@@ -84,6 +86,10 @@ def get_local_binary_path_if_exists(name: str, url: str) -> Optional[str]:
         for c in candidates:
             # Unity sometimes produces another .exe file that we must filter out
             if "UnityCrashHandler64" not in c:
+                # If the file is not valid, return None and delete faulty directory
+                if validate_environment_path(c) is None:
+                    shutil.rmtree(c)
+                    return None
                 return c
         return None
 


### PR DESCRIPTION
### Proposed change(s)

 If the binary does not contain a valid environment, remove faulty binary.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
