### PR TITLE
[FIX] prioritize cli options over yaml

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 - Fixed a bug in multi-agent cooperative training where agents might not receive all of the states of
 terminated teammates. (#5441)
 - Fixed wrong attribute name in argparser for torch device option (#5433)(#5467)
-
+- Fixed conflicting CLI and yaml options regarding resume & initialize_from (#5495)
 ## [2.1.0-exp.1] - 2021-06-09
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -733,7 +733,7 @@ class TrainerSettings(ExportableSettings):
                     f"Please add an entry in the configuration file for {key}, or set default_settings."
                 )
             else:
-                logger.warn(
+                logger.warning(
                     f"Behavior name {key} does not match any behaviors specified "
                     f"in the trainer configuration file. A default configuration will be used."
                 )

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -782,21 +782,18 @@ class CheckpointSettings:
                     f"both 'resume' and 'initialize_from={self.initialize_from}' are set!"
                     f" current run will be resumed ignoring initialization."
                 )
-                # go with resume and ignore init
                 self.initialize_from = parser.get_default("initialize_from")
         elif "initialize_from" in _non_default_args and self.resume is True:
             logger.warning(
                 f"both 'resume' and 'initialize_from={self.initialize_from}' are set!"
                 f"{self.run_id} is initialized_from {self.initialize_from} and resume will be ignored."
             )
-            # go with initialize from and ignore resume
             self.resume = parser.get_default("resume")
         elif self.resume is True and self.initialize_from is not None:
             logger.warning(
                 f"both 'resume' and 'initialize_from={self.initialize_from}' are set in yaml file!"
                 f" current run will be resumed ignoring initialization."
             )
-            # go with resume and ignore init
             self.initialize_from = parser.get_default("initialize_from")
 
 

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -788,7 +788,7 @@ class CheckpointSettings:
                 )
                 self.resume = parser.get_default("resume")
         elif self.resume and self.initialize_from is not None:
-            #no cli args but both are set in yaml file
+            # no cli args but both are set in yaml file
             logger.warning(
                 f"Both 'resume' and 'initialize_from={self.initialize_from}' are set in yaml file!"
                 f" Current run will be resumed ignoring initialization."

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -783,12 +783,13 @@ class CheckpointSettings:
                     f" current run will be resumed ignoring initialization."
                 )
                 self.initialize_from = parser.get_default("initialize_from")
-        elif "initialize_from" in _non_default_args and self.resume is True:
-            logger.warning(
-                f"both 'resume' and 'initialize_from={self.initialize_from}' are set!"
-                f"{self.run_id} is initialized_from {self.initialize_from} and resume will be ignored."
-            )
-            self.resume = parser.get_default("resume")
+        elif "initialize_from" in _non_default_args:
+            if self.resume is True:
+                logger.warning(
+                    f"both 'resume' and 'initialize_from={self.initialize_from}' are set!"
+                    f"{self.run_id} is initialized_from {self.initialize_from} and resume will be ignored."
+                )
+                self.resume = parser.get_default("resume")
         elif self.resume is True and self.initialize_from is not None:
             logger.warning(
                 f"both 'resume' and 'initialize_from={self.initialize_from}' are set in yaml file!"

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -133,7 +133,6 @@ def test_commandline_args(mock_file):
     full_args = [
         "mytrainerpath",
         "--env=./myenvfile",
-        "--resume",
         "--inference",
         "--run-id=myawesomerun",
         "--seed=7890",
@@ -156,7 +155,14 @@ def test_commandline_args(mock_file):
     assert opt.engine_settings.no_graphics is True
     assert opt.debug is True
     assert opt.checkpoint_settings.inference is True
+    assert opt.checkpoint_settings.resume is False
+
+    # ignore init if resume set
+    full_args.append("--resume")
+    opt = parse_command_line(full_args)
+    assert opt.checkpoint_settings.initialize_from is None # ignore init if resume set
     assert opt.checkpoint_settings.resume is True
+
 
 
 @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PARAMETER_YAML)

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -160,9 +160,8 @@ def test_commandline_args(mock_file):
     # ignore init if resume set
     full_args.append("--resume")
     opt = parse_command_line(full_args)
-    assert opt.checkpoint_settings.initialize_from is None # ignore init if resume set
+    assert opt.checkpoint_settings.initialize_from is None  # ignore init if resume set
     assert opt.checkpoint_settings.resume is True
-
 
 
 @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PARAMETER_YAML)

--- a/ml-agents/mlagents/trainers/tests/test_learn.py
+++ b/ml-agents/mlagents/trainers/tests/test_learn.py
@@ -157,7 +157,7 @@ def test_commandline_args(mock_file):
     assert opt.checkpoint_settings.inference is True
     assert opt.checkpoint_settings.resume is False
 
-    # ignore init if resume set
+    # ignore init if resume is set
     full_args.append("--resume")
     opt = parse_command_line(full_args)
     assert opt.checkpoint_settings.initialize_from is None  # ignore init if resume set

--- a/ml-agents/mlagents/trainers/tests/test_settings.py
+++ b/ml-agents/mlagents/trainers/tests/test_settings.py
@@ -481,6 +481,10 @@ def test_exportable_settings(use_defaults):
     # Check that the two exports are the same
     assert dict_export == second_export
 
+    # check if cehckpoint_settings priorotizes resume over initialize from
+    run_options2.checkpoint_settings.prioritize_resume_init()
+    assert run_options2.checkpoint_settings.initialize_from is None
+
 
 def test_environment_settings():
     # default args


### PR DESCRIPTION
### Proposed change(s)

steps to reproduce the bug:

1. run exp1 for 1M steps
2. initialize exp2 from last one with yaml["checkpoint_settings"]["initialize_from"] and continue running for eg. 200k
3. resume exp2  from  cmd and the step count continues from 1M instead of 200k

solution: checkpointSetting class now prioritize the command line arguments (resume or initialize_from for now) over conflicting yaml options. yaml option is nuke with a warning

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
