### PR TITLE
Update dotnet-format to address breaking changes introduced by upstream changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,8 @@ jobs:
         ruby-version: '2.6'
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
+        include-prerelease: true
     - uses: pre-commit/action@v2.0.0
 
   markdown-link-check:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,9 +84,10 @@ repos:
     exclude: ".*localized.*"
 
 - repo: https://github.com/dotnet/format
-  rev: "7e343070a0355c86f72bdee226b5e19ffcbac931"  # TODO - update to a tagged version when one that includes the hook is ready.
+  rev: v5.1.225507
   hooks:
   - id: dotnet-format
+    entry: dotnet-format whitespace
     args: [--folder, --include]
 
 # "Local" hooks, see https://pre-commit.com/#repository-local-hooks


### PR DESCRIPTION
### Proposed change(s)

Pre-commit is using a version of dotnet and dotnet-format and has picked up a newer version of the utility that is not compatible with .NET 3.1 or 5.x -- it installs it's packages using `dotnet tool install`. This version's default entrypoint is also incompatible with our project structure, as the style and analyzer subcommands are now run by default and do not support the --folder option.

The entrypoint can be over-ridden to specify the whitespace module, which should match previous behavior.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
Internal tracking issue: https://jira.unity3d.com/browse/MLA-2198
Other projects experience similar issues: https://github.com/icosa-gallery/open-brush/pull/167
dotnet-format issues tracking this:
dotnet/format#1317
dotnet/format#1318


### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
