### PR TITLE
Fix test failures on trunk with input system 1.1.1

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -61,9 +61,8 @@ all_package_tests:
         {% endfor %}
     triggers:
         cancel_old_ci: true
-        recurring:
-            - branch: main
-              frequency: daily
+        expression: |
+          pull_request.target eq "main"
 
   {% for package in packages %}
   {% for editor in test_editors %}

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -61,8 +61,9 @@ all_package_tests:
         {% endfor %}
     triggers:
         cancel_old_ci: true
-        expression: |
-          pull_request.target eq "main"
+        recurring:
+            - branch: main
+              frequency: daily
 
   {% for package in packages %}
   {% for editor in test_editors %}

--- a/com.unity.ml-agents.extensions/Tests/Runtime/Input/InputActuatorComponentTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Runtime/Input/InputActuatorComponentTests.cs
@@ -49,6 +49,11 @@ namespace Unity.MLAgents.Extensions.Tests.Runtime.Input
         public override void TearDown()
         {
             m_ActuatorComponent.CleanupActionAsset();
+            var objects = GameObject.FindObjectsOfType<GameObject>();
+            foreach (var o in objects)
+            {
+                UnityEngine.Object.DestroyImmediate(o);
+            }
             base.TearDown();
         }
 


### PR DESCRIPTION
### Proposed change(s)

Some game objects left over from input system tests is causing other tests to fail during tear down with input system package going from 1.1.0 to 1.1.1.

Clean up all the game objects in input system tests.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
[JIRA](https://jira.unity3d.com/browse/MLA-2221)


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
