### PR TITLE
Fix VAIL

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -23,6 +23,7 @@ terminated teammates. (#5441)
 - Fixed wrong attribute name in argparser for torch device option (#5433)(#5467)
 - Fixed conflicting CLI and yaml options regarding resume & initialize_from (#5495)
 - Fixed failing tests for gym-unity due to gym 0.20.0 release
+- Fixed a bug in VAIL where the variational bottleneck was not properly passing gradients (#5546)
 ## [2.1.0-exp.1] - 2021-06-09
 ### Minor Changes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)

--- a/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_gail.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_reward_providers/test_gail.py
@@ -149,7 +149,7 @@ def test_reward_decreases_vail(
         RewardSignalType.GAIL, behavior_spec, gail_settings
     )
 
-    for _ in range(300):
+    for _ in range(20):
         gail_rp.update(buffer_policy)
         reward_expert = gail_rp.evaluate(buffer_expert)[0]
         reward_policy = gail_rp.evaluate(buffer_policy)[0]

--- a/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
+++ b/ml-agents/mlagents/trainers/torch/components/reward_providers/gail_reward_provider.py
@@ -152,7 +152,7 @@ class DiscriminatorNetwork(torch.nn.Module):
         z_mu: Optional[torch.Tensor] = None
         if self._settings.use_vail:
             z_mu = self._z_mu_layer(hidden)
-            hidden = torch.normal(z_mu, self._z_sigma * use_vail_noise)
+            hidden = z_mu + torch.randn_like(z_mu) * self._z_sigma * use_vail_noise
         estimate = self._estimator(hidden)
         return estimate, z_mu
 
@@ -251,7 +251,7 @@ class DiscriminatorNetwork(torch.nn.Module):
         if self._settings.use_vail:
             use_vail_noise = True
             z_mu = self._z_mu_layer(hidden)
-            hidden = torch.normal(z_mu, self._z_sigma * use_vail_noise)
+            hidden = z_mu + torch.randn_like(z_mu) * self._z_sigma * use_vail_noise
         estimate = self._estimator(hidden).squeeze(1).sum()
         gradient = torch.autograd.grad(estimate, encoder_input, create_graph=True)[0]
         # Norm's gradient could be NaN at 0. Use our own safe_norm


### PR DESCRIPTION
### Proposed change(s)

Fixes the implementation of the variational bottleneck in VAIL which was using torch.normal. torch.normal is not reparameterized and gradients are broken.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
