### PR TITLE
Removing link to ML-Agents Challenge 1 on Unity Connect

### DIFF
--- a/docs/Learning-Environment-Examples.md
+++ b/docs/Learning-Environment-Examples.md
@@ -6,9 +6,7 @@ The Unity ML-Agents Toolkit includes an expanding set of example environments
 that highlight the various features of the toolkit. These environments can also
 serve as templates for new environments or as ways to test new ML algorithms.
 Environments are located in `Project/Assets/ML-Agents/Examples` and summarized
-below. Additionally, our
-[first ML Challenge](https://connect.unity.com/challenges/ml-agents-1) contains
-environments created by the community.
+below.
 
 For the environments that highlight specific features of the toolkit, we provide
 the pre-trained model files and the training config file that enables you to


### PR DESCRIPTION
Removing link to Unity Connect that is now deprecated

### Proposed change(s)

Describe the changes made in this PR.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
