### PR TITLE
[WIP] Added normalization to critic during training for poca, ppo, and sac.

### DIFF
--- a/ml-agents/mlagents/trainers/poca/trainer.py
+++ b/ml-agents/mlagents/trainers/poca/trainer.py
@@ -73,6 +73,7 @@ class POCATrainer(RLTrainer):
         # Update the normalization
         if self.is_training:
             self.policy.update_normalization(agent_buffer_trajectory)
+            self.optimizer.critic.update_normalization(agent_buffer_trajectory)
 
         # Get all value estimates
         (

--- a/ml-agents/mlagents/trainers/ppo/trainer.py
+++ b/ml-agents/mlagents/trainers/ppo/trainer.py
@@ -74,6 +74,7 @@ class PPOTrainer(RLTrainer):
         # Update the normalization
         if self.is_training:
             self.policy.update_normalization(agent_buffer_trajectory)
+            self.optimizer.critic.update_normalization(agent_buffer_trajectory)
 
         # Get all value estimates
         (

--- a/ml-agents/mlagents/trainers/sac/trainer.py
+++ b/ml-agents/mlagents/trainers/sac/trainer.py
@@ -140,6 +140,7 @@ class SACTrainer(RLTrainer):
         # Update the normalization
         if self.is_training:
             self.policy.update_normalization(agent_buffer_trajectory)
+            self.optimizer.critic.update_normalization(agent_buffer_trajectory)
 
         # Evaluate all reward functions for reporting purposes
         self.collected_rewards["environment"][agent_id] += np.sum(


### PR DESCRIPTION
### Proposed change(s)

Added call to normalize critic observations during training while processing trajectories for poca, ppo and sac.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

- https://github.com/Unity-Technologies/ml-agents/issues/5583

### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
