### PR TITLE
Two small bugfixes to pettingzoo wrapper

### DIFF
--- a/pettingzoo-unity/pettingzoo_unity/pettingzoo_wrapper.py
+++ b/pettingzoo-unity/pettingzoo_unity/pettingzoo_wrapper.py
@@ -307,6 +307,10 @@ class UnityToPettingZooWrapper(AECEnv):
             np.zeros((num_agents, len(a_spec.discrete_branches)), dtype=np.int32),
         )
 
+    @property
+    def _cumulative_rewards(self):
+        return self._cumm_rewards
+
     def reset(self):
         """
         Resets the environment.
@@ -399,6 +403,9 @@ class UnityToPettingZooWrapper(AECEnv):
 
     @property
     def agent_selection(self):
+        if not self._live_agents:
+            # If we had an agent finish then return that agent even though it isn't alive.
+            return self._agents[0]
         return self._agents[self._agent_index]
 
     @property


### PR DESCRIPTION
### Proposed change(s)

A couple of bugfixes I needed when testing with MLA --> PettingZoo --> RLlib

1. Add the missing `_cumulative_rewards` property
2. Update `agent_selection` to not error out when an agent finishes an episode.
    * ⚠️ I don't know if this is the correct way to address this problem. Please let me know what this should look like since I don't 100% grok the PettingZoo API.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

