### PR TITLE
Upgrade Barracuda to 2.3.1-preview

### DIFF
--- a/DevProject/Packages/packages-lock.json
+++ b/DevProject/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.barracuda": {
-      "version": "2.3.0-preview",
+      "version": "2.3.1-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -55,7 +55,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.barracuda": "2.3.0-preview",
+        "com.unity.barracuda": "2.3.1-preview",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.barracuda": {
-      "version": "2.3.0-preview",
+      "version": "2.3.1-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -53,7 +53,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.barracuda": "2.3.0-preview",
+        "com.unity.barracuda": "2.3.1-preview",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to
 
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 - Added a new feature to replicate training areas dynamically during runtime. (#5568)
-- Update Barracuda to 2.3.0-preview
+- Update Barracuda to 2.3.1-preview
 
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,7 +5,7 @@
   "unity": "2019.4",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.barracuda": "2.3.0-preview",
+    "com.unity.barracuda": "2.3.1-preview",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0"
   }


### PR DESCRIPTION
### Proposed change(s)

Upgrade Barracuda references to 2.3.1-preview

Used #5291 #5305 #5343 as references.

⚠️  This is my first time doing this **PLEASE TRIPPLE CHECK**

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Internal JIRA: https://jira.unity3d.com/browse/MLA-2253

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: Upgrade dependency

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
