### PR TITLE
Update stale config to include bugs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,18 +10,17 @@ only: issues
 # Issue specific configuration
 issues:
   limitPerRun: 5
-  daysUntilStale: 14
+  daysUntilStale: 28
   daysUntilClose: 14
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
-    last 14 days. It will be closed in the next 14 days if no further activity occurs.
+    last 28 days. It will be closed in the next 14 days if no further activity occurs.
     Thank you for your contributions.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the
-    last 28 days. If this issue is still valid, please ping a maintainer.
+    last 42 days. If this issue is still valid, please ping a maintainer.
     Thank you for your contributions.
   exemptLabels:
-    - bug
     - request
     - help-wanted
     - announcement


### PR DESCRIPTION
### Proposed change(s)

Allow bugs to be marked stale but extend the period of time before bugs are marked stale to 2 sprints. Closed after no activity in 3 sprints.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/MLA-2277

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: GitHub mgmt

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
