### PR TITLE
[Cherrypick] Fix test failures on trunk with input system 1.1.1 (#5542) to 2.0.1 verified

### DIFF
--- a/com.unity.ml-agents.extensions/Tests/Runtime/Input/InputActuatorComponentTests.cs
+++ b/com.unity.ml-agents.extensions/Tests/Runtime/Input/InputActuatorComponentTests.cs
@@ -49,6 +49,11 @@ namespace Unity.MLAgents.Extensions.Tests.Runtime.Input
         public override void TearDown()
         {
             m_ActuatorComponent.CleanupActionAsset();
+            var objects = GameObject.FindObjectsOfType<GameObject>();
+            foreach (var o in objects)
+            {
+                UnityEngine.Object.DestroyImmediate(o);
+            }
             base.TearDown();
         }
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Bug Fixes
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 - Fixed the bug where curriculum learning would crash because of the incorrect run_options parsing. (#5586)
+- Fixed tests with input system package upgrade from 1.1.0 to 1.1.1. (#5542)
 #### ml-agents / ml-agents-envs / gym-unity (Python)
 
 ## [2.0.0] - 2021-09-01


### PR DESCRIPTION
### Proposed change(s)

Cherrypick #5542 to fix failures on trunk with the upgrade from input 1.1.0 to input 1.1.1

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
