### PR TITLE
Return deterministic actions for training

### DIFF
--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -96,7 +96,8 @@ def _create_parser() -> argparse.ArgumentParser:
         default=False,
         dest="deterministic",
         action=DetectDefaultStoreTrue,
-        help="Whether to select actions deterministically in policy. `dist.mean` for continuous action space, and `dist.argmax` for deterministic action space ",
+        help="Whether to select actions deterministically in policy. `dist.mean` for continuous action "
+        "space, and `dist.argmax` for deterministic action space ",
     )
     argparser.add_argument(
         "--force",

--- a/ml-agents/mlagents/trainers/tests/torch/test_action_model.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_action_model.py
@@ -65,23 +65,20 @@ def test_deterministic_sample_action():
     agent_action2 = action_model._sample_action(dists)
     agent_action3 = action_model._sample_action(dists)
 
-    chance_counter = 0
-
-    if not torch.equal(
+    assert not torch.equal(
         agent_action1.continuous_tensor, agent_action2.continuous_tensor
-    ):
-        chance_counter += 1
+    )
 
-    if not torch.equal(
+    assert not torch.equal(
         agent_action1.continuous_tensor, agent_action3.continuous_tensor
-    ):
-        chance_counter += 1
+    )
 
-    assert chance_counter > 1
     chance_counter = 0
     if not torch.equal(agent_action1.discrete_tensor, agent_action2.discrete_tensor):
         chance_counter += 1
     if not torch.equal(agent_action1.discrete_tensor, agent_action3.discrete_tensor):
+        chance_counter += 1
+    if not torch.equal(agent_action2.discrete_tensor, agent_action3.discrete_tensor):
         chance_counter += 1
     assert chance_counter > 1
 

--- a/ml-agents/mlagents/trainers/tests/torch/test_action_model.py
+++ b/ml-agents/mlagents/trainers/tests/torch/test_action_model.py
@@ -65,7 +65,6 @@ def test_deterministic_sample_action():
     agent_action2 = action_model._sample_action(dists)
     agent_action3 = action_model._sample_action(dists)
 
-
     assert not torch.equal(
         agent_action1.continuous_tensor, agent_action2.continuous_tensor
     )
@@ -73,7 +72,6 @@ def test_deterministic_sample_action():
     assert not torch.equal(
         agent_action1.continuous_tensor, agent_action3.continuous_tensor
     )
-
 
     chance_counter = 0
     if not torch.equal(agent_action1.discrete_tensor, agent_action2.discrete_tensor):

--- a/ml-agents/mlagents/trainers/torch/distributions.py
+++ b/ml-agents/mlagents/trainers/torch/distributions.py
@@ -225,6 +225,7 @@ class MultiCategoricalDistribution(nn.Module):
         # We do -1 * tensor + constant instead of constant - tensor because it seems
         # Barracuda might swap the inputs of a "Sub" operation
         logits = logits * allow_mask - 1e8 * block_mask
+
         return logits
 
     def _split_masks(self, masks: torch.Tensor) -> List[torch.Tensor]:


### PR DESCRIPTION
### Proposed change(s)

This PR will add an ability to retrieve actions deterministically based on the input to the model. A new run-options configuration has been added as well as a new CLI flag `--deterministic`.  

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
