### PR TITLE
Fix analytics error when compiling XBOX and PS5

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to
 ### Bug Fixes
 - Fixed a bug where the critics were not being normalized during training. (#5595)
 - Fixed the bug where curriculum learning would crash because of the incorrect run_options parsing. (#5586)
+- Fixed a bug where ml-agents code wouldn't compile on platforms that didn't support analytics (PS4/5, XBoxOne) (#5628)
 
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
 

--- a/com.unity.ml-agents/Runtime/Analytics/InferenceAnalytics.cs
+++ b/com.unity.ml-agents/Runtime/Analytics/InferenceAnalytics.cs
@@ -7,7 +7,7 @@ using Unity.MLAgents.Policies;
 using Unity.MLAgents.Sensors;
 using UnityEngine;
 
-#if MLA_UNITY_ANALYTICS_MODULE
+#if MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
 using UnityEngine.Analytics;
 #endif
 

--- a/com.unity.ml-agents/Runtime/Analytics/InferenceAnalytics.cs
+++ b/com.unity.ml-agents/Runtime/Analytics/InferenceAnalytics.cs
@@ -44,7 +44,7 @@ namespace Unity.MLAgents.Analytics
         const int k_MaxNumberOfElements = 1000;
 
 
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
         /// <summary>
         /// Models that we've already sent events for.
         /// </summary>
@@ -53,7 +53,7 @@ namespace Unity.MLAgents.Analytics
 
         static bool EnableAnalytics()
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (s_EventRegistered)
             {
                 return true;
@@ -106,7 +106,7 @@ namespace Unity.MLAgents.Analytics
             IList<IActuator> actuators
         )
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             // The event shouldn't be able to report if this is disabled but if we know we're not going to report
             // Lets early out and not waste time gathering all the data
             if (!IsAnalyticsEnabled())

--- a/com.unity.ml-agents/Runtime/Analytics/TrainingAnalytics.cs
+++ b/com.unity.ml-agents/Runtime/Analytics/TrainingAnalytics.cs
@@ -5,7 +5,11 @@ using Unity.MLAgents.Actuators;
 using Unity.MLAgents.Sensors;
 using UnityEngine;
 #if MLA_UNITY_ANALYTICS_MODULE
+
+#if ENABLE_CLOUD_SERVICES_ANALYTICS
 using UnityEngine.Analytics;
+#endif
+
 #if UNITY_EDITOR
 using UnityEditor.Analytics;
 #endif
@@ -43,7 +47,7 @@ namespace Unity.MLAgents.Analytics
 
         private static bool s_SentEnvironmentInitialized;
 
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
         /// <summary>
         /// Whether or not we've registered this particular event yet
         /// </summary>
@@ -64,7 +68,7 @@ namespace Unity.MLAgents.Analytics
 
         internal static bool EnableAnalytics()
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (s_EventsRegistered)
             {
                 return true;
@@ -106,7 +110,7 @@ namespace Unity.MLAgents.Analytics
 
         public static bool IsAnalyticsEnabled()
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             return EditorAnalytics.enabled;
 #else
             return false;
@@ -135,7 +139,7 @@ namespace Unity.MLAgents.Analytics
             // Debug.Log(
             //     $"Would send event {k_TrainingEnvironmentInitializedEventName} with body {JsonUtility.ToJson(tbiEvent, true)}"
             // );
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (AnalyticsUtils.s_SendEditorAnalytics)
             {
                 EditorAnalytics.SendEventWithLimit(k_TrainingEnvironmentInitializedEventName, tbiEvent);
@@ -151,7 +155,7 @@ namespace Unity.MLAgents.Analytics
             IList<IActuator> actuators
         )
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (!IsAnalyticsEnabled())
                 return;
 
@@ -208,7 +212,7 @@ namespace Unity.MLAgents.Analytics
         [Conditional("MLA_UNITY_ANALYTICS_MODULE")]
         public static void TrainingBehaviorInitialized(TrainingBehaviorInitializedEvent rawTbiEvent)
         {
-#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE
+#if UNITY_EDITOR && MLA_UNITY_ANALYTICS_MODULE && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (!IsAnalyticsEnabled())
                 return;
 


### PR DESCRIPTION
### Proposed change(s)

Bugfix: Turns off analytics for platforms that don't support them. To use analytics safely you must wrap usage with `#if ENABLE_CLOUD_SERVICES_ANALYTICS
` 
See https://docs.unity3d.com/ScriptReference/Analytics.Analytics.html


### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Internal JIRA: https://jira.unity3d.com/browse/MLA-2151


### Types of change(s)

- [x] Bug fix


### Testing

Errors went away when compiling for XBox in windows VM

ALSO: 2020.3 is failing because of an existing issue https://jira.unity3d.com/browse/MLA-2311