### PR TITLE
MLA-2312 - Add ELO as completion criteria option for curriculum lessons

### DIFF
--- a/config/poca/SoccerTwosCurriculum.yaml
+++ b/config/poca/SoccerTwosCurriculum.yaml
@@ -1,0 +1,46 @@
+behaviors:
+  SoccerTwos:
+    trainer_type: poca
+    hyperparameters:
+      batch_size: 2048
+      buffer_size: 20480
+      learning_rate: 0.0003
+      beta: 0.005
+      epsilon: 0.2
+      lambd: 0.95
+      num_epoch: 3
+      learning_rate_schedule: constant
+    network_settings:
+      normalize: false
+      hidden_units: 512
+      num_layers: 2
+      vis_encode_type: simple
+    reward_signals:
+      extrinsic:
+        gamma: 0.99
+        strength: 1.0
+    keep_checkpoints: 5
+    max_steps: 50000000
+    time_horizon: 1000
+    summary_freq: 10000
+    self_play:
+      save_steps: 50000
+      team_change: 200000
+      swap_steps: 2000
+      window: 10
+      play_against_latest_model_ratio: 0.5
+      initial_elo: 1200.0
+environment_parameters:
+  ball_touch:
+    curriculum:
+      - name: Lesson0 # The '-' is important as this is a list
+        completion_criteria:
+          measure: Elo
+          behavior: SoccerTwos
+          signal_smoothing: false
+          min_lesson_length: 100
+          threshold: 1250.0
+        value: 1.0    
+      - name: Lesson1 # The '-' is important as this is a list
+        value: 0.0    
+        

--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -149,6 +149,8 @@ class EnvironmentParameterManager:
         of training steps this behavior's trainer has performed.
         :param trainer_reward_buffer: A dictionary from behavior_name to the list of
         the most recent episode returns for this behavior's trainer.
+        :trainer_elo_score: A Dictionary from behavior_name to the minimum Elo score
+        to be reached.
         :returns: A tuple of two booleans : (True if any lesson has changed, True if
         environment needs to reset)
         """

--- a/ml-agents/mlagents/trainers/environment_parameter_manager.py
+++ b/ml-agents/mlagents/trainers/environment_parameter_manager.py
@@ -137,6 +137,7 @@ class EnvironmentParameterManager:
         trainer_steps: Dict[str, int],
         trainer_max_steps: Dict[str, int],
         trainer_reward_buffer: Dict[str, List[float]],
+        trainer_elo_score: Dict[str, int],
     ) -> Tuple[bool, bool]:
         """
         Given progress metrics, calculates if at least one environment parameter is
@@ -169,6 +170,7 @@ class EnvironmentParameterManager:
                         float(trainer_steps[behavior_to_consider])
                         / float(trainer_max_steps[behavior_to_consider]),
                         trainer_reward_buffer[behavior_to_consider],
+                        trainer_elo_score[behavior_to_consider] if trainer_elo_score else None,
                         self._smoothed_values[param_name],
                     )
                     self._smoothed_values[param_name] = new_smoothing

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -525,7 +525,6 @@ class CompletionCriteriaSettings:
         # Is the min number of episodes reached
         if len(reward_buffer) < self.min_lesson_length:
             return False, smoothing
-        #BUG?  Shouldn't we check if the max number of steps has passed if it isn't a PROGRESS measure?
         if self.measure == CompletionCriteriaSettings.MeasureType.PROGRESS:
             if progress > self.threshold:
                 return True, smoothing

--- a/ml-agents/mlagents/trainers/tests/test_env_param_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_env_param_manager.py
@@ -209,16 +209,19 @@ def test_curriculum_raises_all_completion_criteria_conversion():
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},   #TODO: trainer_elo_scores aren't set properly for tests
     ) == (True, True)
     assert param_manager.update_lessons(
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (True, True)
     assert param_manager.update_lessons(
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (False, False)
     assert param_manager.get_current_lesson_number() == {"param_1": 2}
 
@@ -279,17 +282,20 @@ def test_create_manager():
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 99},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (False, False)
     # Not enough episodes reward
     assert param_manager.update_lessons(
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (False, False)
     assert param_manager.update_lessons(
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (True, True)
     assert param_manager.get_current_lesson_number() == {
         "param_1": 1,
@@ -310,6 +316,7 @@ def test_create_manager():
         trainer_steps={"fake_behavior": 700},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [0] * 101},
+        trainer_elo_score={"fake_behavior": 1220.0},
     ) == (True, False)
     assert param_manager.get_current_samplers() == {
         "param_1": UniformSettings(seed=1337 + 2, min_value=1, max_value=3),

--- a/ml-agents/mlagents/trainers/tests/test_env_param_manager.py
+++ b/ml-agents/mlagents/trainers/tests/test_env_param_manager.py
@@ -244,8 +244,8 @@ def test_curriculum_raises_all_completion_criteria_conversion():
         trainer_steps={"fake_behavior": 500},
         trainer_max_steps={"fake_behavior": 1000},
         trainer_reward_buffer={"fake_behavior": [1000] * 101},
-        trainer_elo_score={"fake_behavior": 1200.0},
-    ) == (False, False)
+        trainer_elo_score={"fake_behavior": 1500.0},
+    ) == (False, False)   # No step to advance to
     assert param_manager.get_current_lesson_number() == {"param_1": 3}
 
 test_everything_config_yaml = """

--- a/ml-agents/mlagents/trainers/trainer_controller.py
+++ b/ml-agents/mlagents/trainers/trainer_controller.py
@@ -211,10 +211,15 @@ class TrainerController:
         reward_buff = {k: list(t.reward_buffer) for (k, t) in self.trainers.items()}
         curr_step = {k: int(t.get_step) for (k, t) in self.trainers.items()}
         max_step = {k: int(t.get_max_steps) for (k, t) in self.trainers.items()}
+        try:
+            curr_elo = {k: float(t.current_elo) for (k, t) in self.trainers.items()}
+        except AttributeError:
+            curr_elo = None
+
         # Attempt to increment the lessons of the brains who
         # were ready.
         updated, param_must_reset = self.param_manager.update_lessons(
-            curr_step, max_step, reward_buff
+            curr_step, max_step, reward_buff, curr_elo
         )
         if updated:
             for trainer in self.trainers.values():


### PR DESCRIPTION
https://jira.unity3d.com/browse/MLA-2313

-Add Elo as a measure for completion.
-Update CI tests accordingly.