### PR TITLE
Release 19 branch lts deprecation

### DIFF
--- a/.yamato/com.unity.ml-agents-optional-dep-tests.yml
+++ b/.yamato/com.unity.ml-agents-optional-dep-tests.yml
@@ -1,13 +1,13 @@
 optional_deps:
     - name: Analytics
       project: "OptionalDepedencyTests/NoAnalyticsModule"
-      version: 2020.2
+      version: 2020.3
     - name: Physics
       project: OptionalDepedencyTests/NoPhysicsModule
-      version: 2020.2
+      version: 2020.3
     - name: Physics2D
       project: OptionalDepedencyTests/NoPhysics2DModule
-      version: 2020.2
+      version: 2020.3
 ---
 
   {% for optional_dep in optional_deps %}

--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -7,7 +7,7 @@ pack:
   commands:
     - |
       python3 -m pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
-      unity-downloader-cli -u 2019.4 -c editor --wait --fast
+      unity-downloader-cli -u 2020.3 -c editor --wait --fast
       ./.Editor/Unity -projectPath Project -batchMode -executeMethod Unity.MLAgents.SampleExporter.ExportCuratedSamples -logFile -
       npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
       upm-ci project pack --project-path Project

--- a/.yamato/com.unity.ml-agents-performance.yml
+++ b/.yamato/com.unity.ml-agents-performance.yml
@@ -1,6 +1,6 @@
 test_editors:
-  - version: 2019.4
-  - version: 2020.2
+  - version: 2020.3
+  - version: 2021.2
 ---
 {% for editor in test_editors %}
 Run_Mac_Perfomance_Tests{{ editor.version }}:

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -1,10 +1,10 @@
 {% metadata_file .yamato/coverage_tests.metafile %}
 test_editors:
-    - version: 2019.4
+    - version: 2020.3
         # We want some scene tests to run in the DevProject, but packages there only support 2020+
       testProject: Project
       enableNoDefaultPackages: !!bool true
-    - version: 2020.2
+    - version: 2020.3
       testProject: DevProject
       enableNoDefaultPackages: !!bool true
     - version: 2021.2

--- a/.yamato/coverage_tests.metafile
+++ b/.yamato/coverage_tests.metafile
@@ -1,5 +1,5 @@
 coverage_test_editors:
-    - version: 2020.2
+    - version: 2020.3
       testProject: DevProject
 
 coverage_test_platforms:

--- a/.yamato/standalone-build-webgl-test.yml
+++ b/.yamato/standalone-build-webgl-test.yml
@@ -1,4 +1,4 @@
-{% capture editor_version %}2020.2{% endcapture %}
+{% capture editor_version %}2020.3{% endcapture %}
 test_webgl_standalone_{{ editor_version }}:
   name: Test WebGL Standalone {{ editor_version }}
   agent:

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -3,7 +3,7 @@
 # For each "other" test, we only run it against a single version of the
 # editor to reduce the number of yamato jobs
 test_editors:
-  - version: 2019.4
+  - version: 2020.3
     extra_test: gym
   - version: 2020.3
     extra_test: sensor

--- a/.yamato/training-backcompat-tests.yml
+++ b/.yamato/training-backcompat-tests.yml
@@ -1,6 +1,6 @@
 
-test_mac_backcompat_2019.4:
-  {% capture editor_version %}2019.4{% endcapture %}
+test_mac_backcompat_2020.3:
+  {% capture editor_version %}2020.3{% endcapture %}
   {% capture csharp_backcompat_version %}1.0.0{% endcapture %}
   # This test has to run on mac because it requires the custom build of tensorflow without AVX
   # Test against 2020.1 because 2020.2 has to run against package version 1.2.0

--- a/Project/Packages/manifest.json
+++ b/Project/Packages/manifest.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.5",
+    "com.unity.ide.visualstudio": "2.0.12",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.ml-agents": "file:../../com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../../com.unity.ml-agents.extensions",
     "com.unity.nuget.newtonsoft-json": "2.0.0",
-    "com.unity.test-framework": "1.1.24",
+    "com.unity.test-framework": "1.1.29",
     "com.unity.toolchain.macos-x86_64-linux-x86_64": "0.1.20-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",

--- a/Project/Packages/manifest.json
+++ b/Project/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.5",
-    "com.unity.ide.visualstudio": "2.0.12",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.ml-agents": "file:../../com.unity.ml-agents",
     "com.unity.ml-agents.extensions": "file:../../com.unity.ml-agents.extensions",

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -34,15 +34,6 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.ide.visualstudio": {
-      "version": "2.0.12",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.test-framework": "1.1.9"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.inputsystem": {
       "version": "1.3.0",
       "depth": 0,

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -34,6 +34,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.12",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.9"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.inputsystem": {
       "version": "1.3.0",
       "depth": 0,
@@ -65,7 +74,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ml-agents": "2.1.0-exp.1",
+        "com.unity.ml-agents": "2.2.0",
         "com.unity.modules.physics": "1.0.0"
       }
     },
@@ -93,7 +102,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -163,6 +172,18 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.uielementsnative": "1.0.0"
+      }
+    },
+    "com.unity.modules.uielementsnative": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/Project/ProjectSettings/ProjectVersion.txt
+++ b/Project/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.25f1
-m_EditorVersionWithRevision: 2019.4.25f1 (01a0494af254)
+m_EditorVersion: 2020.3.25f1
+m_EditorVersionWithRevision: 2020.3.25f1 (9b9180224418)

--- a/com.unity.ml-agents.extensions/package.json
+++ b/com.unity.ml-agents.extensions/package.json
@@ -2,7 +2,7 @@
   "name": "com.unity.ml-agents.extensions",
   "displayName": "ML Agents Extensions",
   "version": "0.6.0-preview",
-  "unity": "2019.4",
+  "unity": "2020.3",
   "description": "A source-only package for new features based on ML-Agents",
   "dependencies": {
     "com.unity.ml-agents": "2.2.0",

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 ### Major Changes
 
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
+- The minimum supported Unity version was updated to 2020.3. (#)
 - Added a new feature to replicate training areas dynamically during runtime. (#5568)
 - Update Barracuda to 2.3.1-preview (#5591)
 - Update Input System to 1.3.0 (#5661)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 ### Major Changes
 
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-- The minimum supported Unity version was updated to 2020.3. (##5673)
+- The minimum supported Unity version was updated to 2020.3. (#5673)
 - Added a new feature to replicate training areas dynamically during runtime. (#5568)
 - Update Barracuda to 2.3.1-preview (#5591)
 - Update Input System to 1.3.0 (#5661)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 ### Major Changes
 
 #### com.unity.ml-agents / com.unity.ml-agents.extensions (C#)
-- The minimum supported Unity version was updated to 2020.3. (#)
+- The minimum supported Unity version was updated to 2020.3. (##5673)
 - Added a new feature to replicate training areas dynamically during runtime. (#5568)
 - Update Barracuda to 2.3.1-preview (#5591)
 - Update Input System to 1.3.0 (#5661)

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -2,7 +2,7 @@
   "name": "com.unity.ml-agents",
   "displayName": "ML Agents",
   "version": "2.2.0",
-  "unity": "2019.4",
+  "unity": "2020.3",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
     "com.unity.barracuda": "2.3.1-preview",

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -26,7 +26,7 @@ The ML-Agents Toolkit contains several components:
 
 Consequently, to install and use the ML-Agents Toolkit you will need to:
 
-- Install Unity (2019.4 or later)
+- Install Unity (2020.3 or later)
 - Install Python (3.6.1 or higher)
 - Clone this repository (Optional)
   - __Note:__ If you do not clone the repository, then you will not be
@@ -38,7 +38,7 @@ Consequently, to install and use the ML-Agents Toolkit you will need to:
 - Install the `com.unity.ml-agents.extensions` Unity package (Optional)
 - Install the `mlagents` Python package
 
-### Install **Unity 2019.4** or Later
+### Install **Unity 2020.3** or Later
 
 [Download](https://unity3d.com/get-unity/download) and install Unity. We
 strongly recommend that you install Unity through the Unity Hub as it will

--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -2,7 +2,7 @@
 
 # Migrating
 ## Migrating the package to version 2.0
-- The official version of Unity ML-Agents supports is now 2019.4 LTS. If you run
+- The official version of Unity ML-Agents supports is now 2020.3 LTS. If you run
   into issues, please consider deleting your project's Library folder and reponening your
   project.
 - If you used any of the APIs that were deprecated before version 2.0, you need to use their replacement. These

--- a/ml-agents/tests/yamato/yamato_utils.py
+++ b/ml-agents/tests/yamato/yamato_utils.py
@@ -45,7 +45,7 @@ def run_standalone_build(
     unity_exe = get_unity_executable_path()
     print(f"Running BuildStandalonePlayer via {unity_exe}")
 
-    # enum values from https://docs.unity3d.com/2019.4/Documentation/ScriptReference/BuildTarget.html
+    # enum values from https://docs.unity3d.com/2020.3/Documentation/ScriptReference/BuildTarget.html
     build_target_to_enum: Mapping[Optional[str], str] = {
         "mac": "StandaloneOSX",
         "osx": "StandaloneOSX",


### PR DESCRIPTION
### Proposed change(s)

Deprecated support for Unity version 2019.4. Supported version is now 2020.3.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (please describe) LTS support updated to 2020.3.

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [X] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [X] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [X] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
Updated yamato CI to support Unity v2020.3+.