### PR TITLE
Fix m_Gridsize as public

### DIFF
--- a/com.unity.ml-agents/Runtime/Areas/TrainingAreaReplicator.cs
+++ b/com.unity.ml-agents/Runtime/Areas/TrainingAreaReplicator.cs
@@ -24,7 +24,7 @@ namespace Unity.MLAgents.Areas
         /// </summary>
         public float separation = 10f;
 
-        int3 m_GridSize = new int3(1, 1, 1);
+        public int3 m_GridSize = new int3(1, 1, 1);
         int m_areaCount = 0;
         string m_TrainingAreaName;
 


### PR DESCRIPTION
### Proposed change(s)

Hello ML-Agents Team!
Thanks for releasing ML-Agents 2.2.1 Version
m_GridSize was declared as private, Therefore I couldn't find Grid Size parameters in an Inspector window
So I set it as public. To make creators modify it easily.

Thanks

![image](https://user-images.githubusercontent.com/97542081/149939302-19f8242a-264f-4ddb-ba3a-33023ea085a8.png)