### PR TITLE
Updated backward compat mac training yamato test.

### DIFF
--- a/.yamato/training-backcompat-tests.yml
+++ b/.yamato/training-backcompat-tests.yml
@@ -1,6 +1,6 @@
 
-test_mac_backcompat_2020.3:
-  {% capture editor_version %}2020.3{% endcapture %}
+test_mac_backcompat_2019.4:
+  {% capture editor_version %}2019.4{% endcapture %}
   {% capture csharp_backcompat_version %}1.0.0{% endcapture %}
   # This test has to run on mac because it requires the custom build of tensorflow without AVX
   # Test against 2020.1 because 2020.2 has to run against package version 1.2.0


### PR DESCRIPTION
### Proposed change(s)

Fixed failing yamato test for backward compat.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
