### PR TITLE
tighten test_process_pixels_gray bound

### DIFF
--- a/ml-agents-envs/mlagents_envs/tests/test_rpc_utils.py
+++ b/ml-agents-envs/mlagents_envs/tests/test_rpc_utils.py
@@ -258,7 +258,7 @@ def test_process_pixels_gray():
     byte_arr = generate_compressed_data(in_array)
     out_array = process_pixels(byte_arr, 1)
     assert out_array.shape == (128, 64, 1)
-    assert np.mean(in_array.mean(axis=2, keepdims=True) - out_array) < 0.01
+    assert np.mean(in_array.mean(axis=2, keepdims=True) - out_array) < 0.002
     assert np.allclose(in_array.mean(axis=2, keepdims=True), out_array, atol=0.01)
 
 


### PR DESCRIPTION
### Proposed change(s)
The test `test_process_pixels_gray` in `test_rpc_utils.py` has an assertion bound (`assert (np.mean((in_array.mean(axis=2, keepdims=True) - out_array)) < 0.01)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150849534-9af11dd5-d138-4bcd-b5c2-aa44267e7ff3.png" width="450">
</p>

Here we see that the bound of `0.01` is too loose since the original distribution (in orange) is less than `0.01`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150849632-36890904-548f-40d8-a5ae-637ddbe70feb.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.01` (red dotted line) has a catch rate of 0.33.

To improve this test, I propose to tighten the bound to `0.002` (the blue dotted line). The new bound has a catch rate of 0.67 (+0.34 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed 100 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.6.13
pytorch=1.8.1
```

my ml-agents Experiment SHA:
`d2ee1e2569aa68d3ac0e1dd8d91f1bf812b9df27`

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)
