### PR TITLE
init add of wandb ai writer

### DIFF
--- a/ml-agents/mlagents/plugins/stats_writer.py
+++ b/ml-agents/mlagents/plugins/stats_writer.py
@@ -13,7 +13,7 @@ from mlagents.trainers.stats import StatsWriter
 from mlagents_envs import logging_util
 from mlagents.plugins import ML_AGENTS_STATS_WRITER
 from mlagents.trainers.settings import RunOptions
-from mlagents.trainers.stats import TensorboardWriter, GaugeWriter, ConsoleWriter
+from mlagents.trainers.stats import TensorboardWriter, GaugeWriter, ConsoleWriter, WandbWriter
 
 
 logger = logging_util.get_logger(__name__)
@@ -25,6 +25,7 @@ def get_default_stats_writers(run_options: RunOptions) -> List[StatsWriter]:
     * A TensorboardWriter to write information to TensorBoard
     * A GaugeWriter to record our internal stats
     * A ConsoleWriter to output to stdout.
+    * A Wandb.AI Writer
     """
     checkpoint_settings = run_options.checkpoint_settings
     return [
@@ -35,6 +36,7 @@ def get_default_stats_writers(run_options: RunOptions) -> List[StatsWriter]:
         ),
         GaugeWriter(),
         ConsoleWriter(),
+        WandbWriter()
     ]
 
 

--- a/ml-agents/mlagents/trainers/stats.py
+++ b/ml-agents/mlagents/trainers/stats.py
@@ -6,6 +6,7 @@ import abc
 import os
 import time
 from threading import RLock
+import wandb
 
 from mlagents_envs.side_channel.stats_side_channel import StatsAggregationMethod
 
@@ -284,6 +285,29 @@ class TensorboardWriter(StatsWriter):
             if summary is not None:
                 self.summary_writers[category].add_text("Hyperparameters", summary)
                 self.summary_writers[category].flush()
+
+
+class WandbWriter(StatsWriter):
+    def __init__(
+        self,
+        config: dict
+    ):
+        """
+        A Weights and Biases Wrapper that will add stats to your wandb.ai board.
+        """
+        wandb.init(reinit=True,
+                   config=config)
+
+    def write_stats(
+        self,
+        category : str,
+        values   : dict,
+        step     : int
+    ) -> None:
+        """
+        Write some stats for a given category and step
+        """
+        wandb.log({category : values}, step=step)
 
 
 class StatsReporter:

--- a/ml-agents/mlagents/trainers/tests/test_stats.py
+++ b/ml-agents/mlagents/trainers/tests/test_stats.py
@@ -12,6 +12,7 @@ from mlagents.trainers.stats import (
     StatsSummary,
     GaugeWriter,
     ConsoleWriter,
+    WandbWriter,
     StatsPropertyType,
     StatsAggregationMethod,
 )
@@ -248,3 +249,20 @@ class ConsoleWriterTest(unittest.TestCase):
         self.assertIn(
             "Mean Reward: 1.000. Std of Reward: 0.000. Training.", cm.output[0]
         )
+
+
+class WandbWriterTest(unittest.TestCase):
+    def test_wandb_full(self):
+        category = "GeneralStuff"
+        config   = {"caller" : "ml-agents"}
+        wandb_writer = WandbWriter(config=config)
+        wandb_writer.write_stats(
+            category = category,
+            values = {
+                "Environment/Cumulative Reward": -15,
+                "Is Training": True,
+                "Self-play/ELO": 1.0,
+            },
+            step = 10,
+        )
+


### PR DESCRIPTION
### Proposed change(s)

Added a very simplistic class of WandbWritter and an extremely poor unit test, which appears to work (on a test wandb.ai project). The idea is to be able to publish the exact Tensorboard stats on wandb.ai as it allows teams, projects and collaboration across colleagues. This is not a promotion, and I am not affiliated with wandb.ai in any way.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

NA

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments

Just testing the waters with WandB.ai writter; unit tests probably could do with a lot more work. I was told by Jason Rupert & Miguel Alonso to use the plugin system; so I'm unsure as to whether I was supposed to hack into the `stats_writer.py` or not. Feel free to reject the PR, but please provide guidance so I can finalise this to an acceptable level.