### PR TITLE
Reorder angles in RayPerceptionSensor

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/RayPerceptionSensorComponentBase.cs
@@ -209,15 +209,16 @@ namespace Unity.MLAgents.Sensors
         internal static float[] GetRayAngles(int raysPerDirection, float maxRayDegrees)
         {
             // Example:
-            // { 90, 90 - delta, 90 + delta, 90 - 2*delta, 90 + 2*delta }
+            // { 90 - 3*delta, 90 - 2*delta, ..., 90, 90 + delta, ..., 90 + 3*delta }
             var anglesOut = new float[2 * raysPerDirection + 1];
             var delta = maxRayDegrees / raysPerDirection;
-            anglesOut[0] = 90f;
-            for (var i = 0; i < raysPerDirection; i++)
+            
+            for (var i =  0; i < 2 * raysPerDirection + 1; i++)
             {
-                anglesOut[2 * i + 1] = 90 - (i + 1) * delta;
-                anglesOut[2 * i + 2] = 90 + (i + 1) * delta;
+                // 90 - (num_rays) * delta + i * delta
+                anglesOut[i] = 90 - (raysPerDirection - i) * delta;
             }
+            
             return anglesOut;
         }
 


### PR DESCRIPTION
### Proposed change(s)

This PR changes the order in which rays are recorded in the RayPerceptionSensor. Currently, they start from the central ray, and then alternate between one to the left and one to the right. This makes it tricky to process these observations with a convolutional layer, which in my experience caused at least some people to reimplement a ray sensor instead of using the built-in one.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Mentioned in Issue #5737 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
