### PR TITLE
Remove unused TouchedTarget() methods from examples

### DIFF
--- a/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
@@ -279,12 +279,4 @@ public class CrawlerAgent : Agent
         //This reward will approach 1 if it matches perfectly and approach zero as it deviates
         return Mathf.Pow(1 - Mathf.Pow(velDeltaMagnitude / TargetWalkingSpeed, 2), 2);
     }
-
-    /// <summary>
-    /// Agent touched the target
-    /// </summary>
-    public void TouchedTarget()
-    {
-        AddReward(1f);
-    }
 }

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -285,14 +285,6 @@ public class WalkerAgent : Agent
         return Mathf.Pow(1 - Mathf.Pow(velDeltaMagnitude / MTargetWalkingSpeed, 2), 2);
     }
 
-    /// <summary>
-    /// Agent touched the target
-    /// </summary>
-    public void TouchedTarget()
-    {
-        AddReward(1f);
-    }
-
     public void SetTorsoMass()
     {
         m_JdController.bodyPartsDict[chest].rb.mass = m_ResetParams.GetWithDefault("chest_mass", 8);

--- a/Project/Assets/ML-Agents/Examples/Worm/Scripts/WormAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Worm/Scripts/WormAgent.cs
@@ -125,14 +125,6 @@ public class WormAgent : Agent
         }
     }
 
-    /// <summary>
-    /// Agent touched the target
-    /// </summary>
-    public void TouchedTarget()
-    {
-        AddReward(1f);
-    }
-
     public override void OnActionReceived(ActionBuffers actionBuffers)
     {
         // The dictionary with all the body parts in it are in the jdController


### PR DESCRIPTION
Crawler, Walker, and Worm all have TouchedTarget methods to add +1 reward
that are, as near as I can tell, completely unused. These are not mentioned
anywhere in documentation and are potentially very confusing to someone
examining the example code. Remove these methods to make the code cleaner
and easier to read.
