### PR TITLE
Include extensions in Doxygen docs

### DIFF
--- a/docs/dox-ml-agents.conf
+++ b/docs/dox-ml-agents.conf
@@ -783,7 +783,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../com.unity.ml-agents/Runtime/
+INPUT                  = ../com.unity.ml-agents/Runtime/ ../com.unity.ml-agents.extensions/Runtime/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2051,7 +2051,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = MLA_INPUT_SYSTEM UNITY_2020_1_OR_NEWER
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Classes in the `com.unity.ml-agents.extensions` package might get more
use if people knew they existed. Add them to docs here.
