### PR TITLE
Fix serialization of RigidBodySensorComponents

### DIFF
--- a/com.unity.ml-agents.extensions/Runtime/Sensors/PoseExtractor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/PoseExtractor.cs
@@ -14,16 +14,17 @@ namespace Unity.MLAgents.Extensions.Sensors
     /// Poses are either considered in model space, which is relative to a root body,
     /// or in local space, which is relative to their parent.
     /// </summary>
-    public abstract class PoseExtractor
+    [Serializable]
+    public abstract class PoseExtractor : ISerializationCallbackReceiver
     {
-        int[] m_ParentIndices;
+        [SerializeField] int[] m_ParentIndices;
         Pose[] m_ModelSpacePoses;
         Pose[] m_LocalSpacePoses;
 
         Vector3[] m_ModelSpaceLinearVelocities;
         Vector3[] m_LocalSpaceLinearVelocities;
 
-        bool[] m_PoseEnabled;
+        [SerializeField] bool[] m_PoseEnabled;
 
 
         /// <summary>
@@ -177,11 +178,8 @@ namespace Unity.MLAgents.Extensions.Sensors
 #endif
             m_ParentIndices = parentIndices;
             var numPoses = parentIndices.Length;
-            m_ModelSpacePoses = new Pose[numPoses];
-            m_LocalSpacePoses = new Pose[numPoses];
 
-            m_ModelSpaceLinearVelocities = new Vector3[numPoses];
-            m_LocalSpaceLinearVelocities = new Vector3[numPoses];
+            CreateSensorArrays(numPoses);
 
             m_PoseEnabled = new bool[numPoses];
             // All poses are enabled by default. Generally we'll want to disable the root though.
@@ -189,6 +187,25 @@ namespace Unity.MLAgents.Extensions.Sensors
             {
                 m_PoseEnabled[i] = true;
             }
+        }
+
+        public void OnBeforeSerialize()
+        {
+            // no-op
+        }
+
+        public void OnAfterDeserialize()
+        {
+            CreateSensorArrays(m_ParentIndices.Length);
+        }
+
+        private void CreateSensorArrays(int numPoses)
+        {
+            m_ModelSpacePoses = new Pose[numPoses];
+            m_LocalSpacePoses = new Pose[numPoses];
+
+            m_ModelSpaceLinearVelocities = new Vector3[numPoses];
+            m_LocalSpaceLinearVelocities = new Vector3[numPoses];
         }
 
         /// <summary>

--- a/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodyPoseExtractor.cs
+++ b/com.unity.ml-agents.extensions/Runtime/Sensors/RigidBodyPoseExtractor.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Unity.MLAgents.Extensions.Sensors
 {
@@ -8,15 +10,16 @@ namespace Unity.MLAgents.Extensions.Sensors
     /// Utility class to track a hierarchy of RigidBodies. These are assumed to have a root node,
     /// and child nodes are connect to their parents via Joints.
     /// </summary>
+    [Serializable]
     public class RigidBodyPoseExtractor : PoseExtractor
     {
-        Rigidbody[] m_Bodies;
+        [SerializeField] Rigidbody[] m_Bodies;
 
         /// <summary>
         /// Optional game object used to determine the root of the poses, separate from the actual Rigidbodies
         /// in the hierarchy. For locomotion
         /// </summary>
-        GameObject m_VirtualRoot;
+        [SerializeField] GameObject m_VirtualRoot;
 
         /// <summary>
         /// Initialize given a root RigidBody.


### PR DESCRIPTION
### Proposed change(s)

The settings of `RigidBodySensorComponent`s were not getting serialized
and saved properly before. Now they are.
Fixes #5774

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
