### PR TITLE
Remove numpy np.bool deprecation notice

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,15 +10,15 @@ only: issues
 # Issue specific configuration
 issues:
   limitPerRun: 5
-  daysUntilStale: 28
-  daysUntilClose: 14
+  daysUntilStale: 90
+  daysUntilClose: 30
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
-    last 28 days. It will be closed in the next 14 days if no further activity occurs.
+    last 90 days. It will be closed in the next 30 days if no further activity occurs.
     Thank you for your contributions.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the
-    last 42 days. If this issue is still valid, please ping a maintainer.
+    last 120 days. If this issue is still valid, please ping a maintainer.
     Thank you for your contributions.
   exemptLabels:
     - request

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
-    - run: sudo npm install -g markdown-link-check
+    - run: sudo npm install -g markdown-link-check@3.8.7
     - uses: pre-commit/action@v2.0.0
       with:
           extra_args: --hook-stage manual markdown-link-check --all-files

--- a/ml-agents-envs/mlagents_envs/rpc_utils.py
+++ b/ml-agents-envs/mlagents_envs/rpc_utils.py
@@ -373,7 +373,7 @@ def steps_from_proto(
 
     max_step = np.array(
         [agent_info.max_step_reached for agent_info in terminal_agent_info_list],
-        dtype=np.bool,
+        dtype=bool,
     )
     decision_agent_id = np.array(
         [agent_info.id for agent_info in decision_agent_info_list], dtype=np.int32
@@ -389,7 +389,7 @@ def steps_from_proto(
         ):
             n_agents = len(decision_agent_info_list)
             a_size = np.sum(behavior_spec.action_spec.discrete_branches)
-            mask_matrix = np.ones((n_agents, a_size), dtype=np.bool)
+            mask_matrix = np.ones((n_agents, a_size), dtype=bool)
             for agent_index, agent_info in enumerate(decision_agent_info_list):
                 if agent_info.action_mask is not None:
                     if len(agent_info.action_mask) == a_size:
@@ -397,7 +397,7 @@ def steps_from_proto(
                             False if agent_info.action_mask[k] else True
                             for k in range(a_size)
                         ]
-            action_mask = (1 - mask_matrix).astype(np.bool)
+            action_mask = (1 - mask_matrix).astype(bool)
             indices = _generate_split_indices(
                 behavior_spec.action_spec.discrete_branches
             )


### PR DESCRIPTION

### Proposed change(s)

Removes the numpy deprecation notice regarding `np.bool`. Here we instead use `bool`.
```
/usr/local/lib/python3.8/dist-packages/mlagents_envs/rpc_utils.py:376: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

N/A

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
N/A (removes deprecation)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
