### PR TITLE
Fix bug with stacking sensor(#5790)

### DIFF
--- a/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
@@ -82,7 +82,18 @@ namespace Unity.MLAgents.Sensors
             if (m_WrappedSensor.GetCompressionSpec().SensorCompressionType != SensorCompressionType.None)
             {
                 m_StackedCompressedObservations = new byte[numStackedObservations][];
-                m_EmptyCompressedObservation = CreateEmptyPNG();
+
+                // Generate Single Empty PNG
+                Byte[] singleEmptyPNG = CreateEmptyPNG();
+                List<byte> emptyCompressedObservationList = new List<byte>();
+
+                // Combine Multiple Empty PNGs for channels more than 3
+                for (int i = 0; i < (m_WrappedSpec.Shape[^1] + 2) / 3; i++)
+                {
+                    emptyCompressedObservationList.AddRange(singleEmptyPNG);
+                }
+                m_EmptyCompressedObservation = emptyCompressedObservationList.ToArray();
+
                 for (var i = 0; i < numStackedObservations; i++)
                 {
                     m_StackedCompressedObservations[i] = m_EmptyCompressedObservation;


### PR DESCRIPTION
grid sensor and all PNG compression used will face this bug when channel number is larger than 3 && used stacking observation (stack > 1)

### Proposed change(s)

Describe the changes made in this PR.

The prepared empty PNG will be multiplied based on the channel number used

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://github.com/Unity-Technologies/ml-agents/issues/5790

### Types of change(s)

- [√] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [√] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
