### PR TITLE
Added the "timeout_wait" parameter to the CLI ("--timeout-wait=").

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,15 +10,15 @@ only: issues
 # Issue specific configuration
 issues:
   limitPerRun: 5
-  daysUntilStale: 28
-  daysUntilClose: 14
+  daysUntilStale: 90
+  daysUntilClose: 30
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
-    last 28 days. It will be closed in the next 14 days if no further activity occurs.
+    last 90 days. It will be closed in the next 30 days if no further activity occurs.
     Thank you for your contributions.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the
-    last 42 days. If this issue is still valid, please ping a maintainer.
+    last 120 days. If this issue is still valid, please ping a maintainer.
     Thank you for your contributions.
   exemptLabels:
     - request

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
-    - run: sudo npm install -g markdown-link-check
+    - run: sudo npm install -g markdown-link-check@3.8.7
     - uses: pre-commit/action@v2.0.0
       with:
           extra_args: --hook-stage manual markdown-link-check --all-files

--- a/ml-agents/mlagents/trainers/cli_utils.py
+++ b/ml-agents/mlagents/trainers/cli_utils.py
@@ -289,6 +289,12 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Whether to run the Unity executable in no-graphics mode (i.e. without initializing "
         "the graphics driver. Use this only if your agents don't use visual observations.",
     )
+    eng_conf.add_argument(
+        "--timeout-wait",
+        default=60,
+        help="Time (in seconds) to wait for connection from environment.",
+        action=DetectDefault,
+    )
 
     torch_conf = argparser.add_argument_group(title="Torch Configuration")
     torch_conf.add_argument(

--- a/ml-agents/mlagents/trainers/learn.py
+++ b/ml-agents/mlagents/trainers/learn.py
@@ -95,6 +95,7 @@ def run_training(run_seed: int, options: RunOptions, num_areas: int) -> None:
         env_factory = create_environment_factory(
             env_settings.env_path,
             engine_settings.no_graphics,
+            engine_settings.timeout_wait,
             run_seed,
             num_areas,
             port,
@@ -169,6 +170,7 @@ def write_timing_tree(output_dir: str) -> None:
 def create_environment_factory(
     env_path: Optional[str],
     no_graphics: bool,
+    timeout_wait: int,
     seed: int,
     num_areas: int,
     start_port: Optional[int],
@@ -186,6 +188,7 @@ def create_environment_factory(
             seed=env_seed,
             num_areas=num_areas,
             no_graphics=no_graphics,
+            timeout_wait=timeout_wait,
             base_port=start_port,
             additional_args=env_args,
             side_channels=side_channels,

--- a/ml-agents/mlagents/trainers/settings.py
+++ b/ml-agents/mlagents/trainers/settings.py
@@ -851,6 +851,7 @@ class EngineSettings:
     target_frame_rate: int = parser.get_default("target_frame_rate")
     capture_frame_rate: int = parser.get_default("capture_frame_rate")
     no_graphics: bool = parser.get_default("no_graphics")
+    timeout_wait: int = parser.get_default("timeout_wait")
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
### Proposed change(s)

The timeout_wait parameter was not accessible through the CLI.
This is a problem when people need to debug their Unity scripts (temporarily pausing execution in the Unity Editor),
or when training is performed with human-in-the-loop,
as ml-agents will terminate the session after mere 60 seconds and throw a "UnityTimeOutException: The Unity environment took too long to respond."

Users should be able to set the timeout through the CLI with
```--timeout-wait=<seconds>```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [ ] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable)
- [ ] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable)

### Other comments
