### PR TITLE
Fixed python version pinning issue on colab.yml gha.

### DIFF
--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.9
+        python-version: 3.9.x
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'


### PR DESCRIPTION
### Proposed change(s)

Fixed python version pinning issue on colab.yml gha.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
