### PR TITLE
Update to release_20 in installation instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,17 +62,17 @@ of our tutorials / guides assume you have access to our example environments).
 the repository if you would like to explore more examples.
 
 ```sh
-git clone --branch release_19 https://github.com/Unity-Technologies/ml-agents.git
+git clone --branch release_20 https://github.com/Unity-Technologies/ml-agents.git
 ```
 
-The `--branch release_19` option will switch to the tag of the latest stable
+The `--branch release_20` option will switch to the tag of the latest stable
 release. Omitting that will get the `main` branch which is potentially unstable.
 
 #### Advanced: Local Installation for Development
 
 You will need to clone the repository if you plan to modify or extend the
 ML-Agents Toolkit for your purposes. If you plan to contribute those changes
-back, make sure to clone the `main` branch (by omitting `--branch release_19`
+back, make sure to clone the `main` branch (by omitting `--branch release_20`
 from the command above). See our
 [Contributions Guidelines](../com.unity.ml-agents/CONTRIBUTING.md) for more
 information on contributing to the ML-Agents Toolkit.


### PR DESCRIPTION
### Proposed change(s)

This PR updates the installation instructions to recommend cloning the `release_20` tag rather then `release_19`. Based on the README, this seems like the most recent stable release.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)
