### PR TITLE
Stop pinning numpy to a specific version

### DIFF
--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -57,7 +57,6 @@ setup(
         "pyyaml>=3.1.0",
         "gym>=0.21.0",
         "pettingzoo==1.15.0",
-        "numpy==1.21.2",
         "filelock>=3.4.0",
     ],
     python_requires=">=3.8.13,<=3.10.11",


### PR DESCRIPTION
### Proposed change(s)
I think this might have been a typo as numpy was specified twice. However, I removed the second line that pins numpy to a specific version. Requiring this exact version of numpy breaks compatibility with pytorch versions > 2.0.0.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
N/A

### Types of change(s)
Bug Fix

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [x] Updated the migration guide (if applicable)

### Other comments
N/A
