### PR TITLE
Update ML-Agents to Python 3.10.12 (Colab)

### DIFF
--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -59,7 +59,7 @@ setup(
         "numpy==1.21.2",
         "filelock>=3.4.0",
     ],
-    python_requires=">=3.8.13,<=3.10.11",
+    python_requires=">=3.8.13,<=3.10.12",
     # TODO: Remove this once mypy stops having spurious setuptools issues.
     cmdclass={"verify": VerifyVersionCommand},  # type: ignore
 )

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -80,7 +80,7 @@ setup(
         'pypiwin32==223;platform_system=="Windows"',
         "importlib_metadata==4.4; python_version<'3.8'",
     ],
-    python_requires=">=3.8.13,<=3.10.11",
+    python_requires=">=3.8.13,<=3.10.12",
     entry_points={
         "console_scripts": [
             "mlagents-learn=mlagents.trainers.learn:main",


### PR DESCRIPTION
### Proposed change(s)

Describe the changes made in this PR.
- Context: Google Colab updated their machines to Python 3.10.12 I suppose during the night since there's no information on the release notes.
- Problem: MLAgents requires Python <= 3.10.11
- Solution: Update the two setup.py 

- For now I updated to 3.10.12 **but given how Google Colab loves to change Python version every month we should maybe remove the .11 .12 part? And just replace by <= 3.10?**

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
