### PR TITLE
Updated document on DecisionStep feature in DecisionRequester

### DIFF
--- a/com.unity.ml-agents/Runtime/DecisionRequester.cs
+++ b/com.unity.ml-agents/Runtime/DecisionRequester.cs
@@ -64,7 +64,7 @@ namespace Unity.MLAgents
 
         internal void Awake()
         {
-            Debug.Assert(DecisionStep < DecisionPeriod, "DecisionStep must be between 0 than DecisionPeriod - 1.");
+            Debug.Assert(DecisionStep < DecisionPeriod, "DecisionStep must be between 0 and DecisionPeriod - 1.");
             m_Agent = gameObject.GetComponent<Agent>();
             Debug.Assert(m_Agent != null, "Agent component was not found on this gameObject and is required.");
             Academy.Instance.AgentPreStep += MakeRequests;

--- a/docs/Learning-Environment-Design-Agents.md
+++ b/docs/Learning-Environment-Design-Agents.md
@@ -106,9 +106,12 @@ intervals, add a `Decision Requester` component to the Agent's GameObject.
 Making decisions at regular step intervals is generally most appropriate for
 physics-based simulations. For example, an agent in a robotic simulator that
 must provide fine-control of joint torques should make its decisions every step
-of the simulation. On the other hand, an agent that only needs to make decisions
-when certain game or simulation events occur, such as in a turn-based game,
-should call `Agent.RequestDecision()` manually.
+of the simulation. In games such as real-time strategy, where many agents make
+their decisions at regular intervals, the decision timing for each agent can be
+staggered by setting the `DecisionStep` parameter in the `Decision Requester`
+component for each agent. On the other hand, an agent that only needs to make
+decisions when certain game or simulation events occur, such as in a turn-based
+game, should call `Agent.RequestDecision()` manually.
 
 ## Observations and Sensors
 In order for an agent to learn, the observations should include all the


### PR DESCRIPTION
* Updated docs/Learning-Environment-Design-Agents.md
* Fixed a typo in comments in com.unity.ml-agents/Runtime/DecisioRequester.cs

### Proposed change(s)

This is a PR for updating documentation on "DecisionStep" feature in Decision Requester component.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

The DecisionStep feature was merged under the PR: https://github.com/Unity-Technologies/ml-agents/pull/5939.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
