### PR TITLE
Corrected rl_cycle.png path

### DIFF
--- a/docs/Background-Machine-Learning.md
+++ b/docs/Background-Machine-Learning.md
@@ -111,7 +111,7 @@ every step, but only when a robot arrives at a success or failure situation), is
 a defining characteristic of reinforcement learning and precisely why learning
 good policies can be difficult (and/or time-consuming) for complex environments.
 
-<div style="text-align: center"><img src="../images/rl_cycle.png" alt="The reinforcement learning lifecycle."></div>
+<div style="text-align: center"><img src="./images/rl_cycle.png" alt="The reinforcement learning lifecycle."></div>
 
 [Learning a policy](https://blogs.unity3d.com/2017/08/22/unity-ai-reinforcement-learning-with-q-learning/)
 usually requires many trials and iterative policy updates. More specifically,

--- a/docs/ELO-Rating-System.md
+++ b/docs/ELO-Rating-System.md
@@ -18,7 +18,7 @@ Simply explained, we face a zero-sum game **when one agent gets +1.0, its oppone
 
 For instance, Tennis is a zero-sum game: if you win the point you get +1.0 and your opponent gets -1.0 reward.
 
-## How works the ELO Rating System
+## How does the ELO Rating System work?
 - Each player **has an initial ELO score**. It's defined in the `initial_elo` trainer config hyperparameter.
 
 - The **difference in rating between the two players** serves as the predictor of the outcomes of a match.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -101,11 +101,11 @@ project by:
 1. Select the `package.json` file.
 
 <p align="center">
-  <img src="../images/unity_package_manager_window.png"
+  <img src="./images/unity_package_manager_window.png"
        alt="Unity Package Manager Window"
        height="150"
        border="10" />
-  <img src="../images/unity_package_json.png"
+  <img src="./images/unity_package_json.png"
      alt="package.json"
      height="150"
      border="10" />

--- a/docs/Learning-Environment-Examples.md
+++ b/docs/Learning-Environment-Examples.md
@@ -1,6 +1,6 @@
 # Example Learning Environments
 
-<img src="../images/example-envs.png" align="middle" width="3000"/>
+<img src="./images/example-envs.png" align="middle" width="3000"/>
 
 The Unity ML-Agents Toolkit includes an expanding set of example environments
 that highlight the various features of the toolkit. These environments can also

--- a/docs/ML-Agents-Overview.md
+++ b/docs/ML-Agents-Overview.md
@@ -189,7 +189,7 @@ The ML-Agents Toolkit contains five high-level components:
   algorithms.
 
 <p align="center">
-  <img src="../images/learning_environment_basic.png"
+  <img src="./images/learning_environment_basic.png"
        alt="Simplified ML-Agents Scene Block Diagram"
        width="600"
        border="10" />
@@ -224,7 +224,7 @@ can have the same Behavior. This does not mean that at each instance they will
 have identical observation and action _values_.
 
 <p align="center">
-  <img src="../images/learning_environment_example.png"
+  <img src="./images/learning_environment_example.png"
        alt="Example ML-Agents Scene Block Diagram"
        width="700"
        border="10" />
@@ -246,7 +246,7 @@ Channels_ is to exchange data with Python about _Environment Parameters_. The
 following diagram illustrates the above.
 
 <p align="center">
-  <img src="../images/learning_environment_full.png"
+  <img src="./images/learning_environment_full.png"
        alt="More Complete Example ML-Agents Scene Block Diagram"
        border="10" />
 </p>
@@ -466,7 +466,7 @@ episodes of demonstrations can reduce training steps by more than 4 times. See
 Behavioral Cloning + GAIL + Curiosity + RL below.
 
 <p align="center">
-  <img src="../images/mlagents-ImitationAndRL.png"
+  <img src="./images/mlagents-ImitationAndRL.png"
        alt="Using Demonstrations with Reinforcement Learning"
        width="700" border="0" />
 </p>


### PR DESCRIPTION
### Proposed change(s)

Inside file docs/Background-Machine-Learning.md, the path for rl_cycle.png was wrong; thus, the image was not showing. Made a small correction for that.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Documentation update

### Checklist
- [ ] Updated the documentation (if applicable)

### Other comments
