### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -43,7 +43,7 @@ Consequently, to install and use the ML-Agents Toolkit you will need to:
 strongly recommend that you install Unity through the Unity Hub as it will
 enable you to manage multiple Unity versions.
 
-### Install **Python 3.10.12** or Higher
+### Install **Python 3.10.12**
 
 We recommend [installing](https://www.python.org/downloads/) Python 3.10.
 If you are using Windows, please install the x86-64 version and not x86.


### PR DESCRIPTION
Removing "or higher" because:
(i) ./ml-agents/setup.py requires >=3.10.1,<=3.10.12  (ii) python 3.10.13 is the default conda install, and 3.10.13 does not work correctly with numpy 1.21.2

### Proposed change(s)

Remove the phrase "or higher" from "[Install Python 3.10.12 or Higher](https://github.com/Unity-Technologies/ml-agents/blob/develop/docs/Installation.md#install-python-31012-or-higher)"

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://github.com/Unity-Technologies/ml-agents/pull/5997/commits/30fbd5078c241da1d938caee368dfb4dce962476

This is one issue related to the "or higher" clause on the python version:
https://github.com/Unity-Technologies/ml-agents/issues/6002


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
