### PR TITLE
Updated references to the OpenAI blog

### DIFF
--- a/docs/ML-Agents-Overview.md
+++ b/docs/ML-Agents-Overview.md
@@ -385,7 +385,7 @@ your agent's behavior:
 
 ML-Agents provide an implementation of two reinforcement learning algorithms:
 
-- [Proximal Policy Optimization (PPO)](https://blog.openai.com/openai-baselines-ppo/)
+- [Proximal Policy Optimization (PPO)](https://openai.com/research/openai-baselines-ppo/)
 - [Soft Actor-Critic (SAC)](https://bair.berkeley.edu/blog/2018/12/14/sac/)
 
 The default algorithm is PPO. This is a method that has been shown to be more

--- a/localized_docs/KR/docs/Training-PPO.md
+++ b/localized_docs/KR/docs/Training-PPO.md
@@ -1,6 +1,6 @@
 # Proximal Policy Optimization를 이용한 학습
 
-ML-Agents는 [Proximal Policy Optimization (PPO)](https://blog.openai.com/openai-baselines-ppo/) 라는 강화학습 기법을 사용합니다.
+ML-Agents는 [Proximal Policy Optimization (PPO)](https://openai.com/research/openai-baselines-ppo/) 라는 강화학습 기법을 사용합니다.
 PPO는 에이전트의 관측 (Observation)을 통해 에이전트가 주어진 상태에서 최선의 행동을 선택할 수 있도록 하는 이상적인 함수를 인공신경망을 이용하여 근사하는 기법입니다.  ML-agents의 PPO 알고리즘은 텐서플로우로 구현되었으며 별도의 파이썬 프로세스 (소켓 통신을 통해 실행중인 유니티 프로그램과 통신)에서 실행됩니다.
 
 에이전트를 학습하기 위해서 사용자는 에이전트가 최대화하도록 시도하는 보상 시그널을 하나 혹은 그 이상 설정해야합니다.  사용 가능한 보상 시그널들과 관련된 하이퍼파라미터에 대해서는 [보상 시그널](Reward-Signals.md) 문서를 참고해주십시오.

--- a/localized_docs/zh-CN/docs/Getting-Started-with-Balance-Ball.md
+++ b/localized_docs/zh-CN/docs/Getting-Started-with-Balance-Ball.md
@@ -246,7 +246,7 @@ Reinforcement Learning（强化学习）算法。
 与其他许多 RL 算法相比，这种算法经证明是一种安全、
 有效且更通用的方法，因此我们选择它作为与 ML-Agents
 一起使用的示例算法。有关 PPO 的更多信息，
-请参阅 OpenAI 近期发布的[博客文章](https://blog.openai.com/openai-baselines-ppo/)，
+请参阅 OpenAI 近期发布的[博客文章](https://openai.com/research/openai-baselines-ppo/)，
 其中对 PPO 进行了说明。
 
 

--- a/localized_docs/zh-CN/docs/Learning-Environment-Design.md
+++ b/localized_docs/zh-CN/docs/Learning-Environment-Design.md
@@ -2,7 +2,7 @@
 
 Reinforcement learning（强化学习）是一种人工智能技术，通过奖励期望的行为来训练 _agent_ 执行任务。在 reinforcement learning（强化学习）过程中，agent 会探索自己所处的环境，观测事物的状态，并根据这些观测结果采取相应动作。如果该动作带来了更好的状态，agent 会得到正奖励。如果该动作带来的状态不太理想，则 agent 不会得到奖励或会得到负奖励（惩罚）。随着 agent 在训练期间不断学习，它会优化自己的决策能力，以便随着时间的推移获得最高奖励。
 
-ML-Agents 使用一种称为 [Proximal Policy Optimization (PPO)](https://blog.openai.com/openai-baselines-ppo/) 的 reinforcement learning（强化学习）技术。PPO 使用神经网络来逼近理想函数；这种理想函数将 agent 的观测结果映射为 agent 在给定状态下可以采取的最佳动作。ML-Agents PPO 算法在 TensorFlow 中实现，并在单独的 Python 过程中运行（通过一个socket与正在运行的 Unity 应用程序进行通信）。
+ML-Agents 使用一种称为 [Proximal Policy Optimization (PPO)](https://openai.com/research/openai-baselines-ppo/) 的 reinforcement learning（强化学习）技术。PPO 使用神经网络来逼近理想函数；这种理想函数将 agent 的观测结果映射为 agent 在给定状态下可以采取的最佳动作。ML-Agents PPO 算法在 TensorFlow 中实现，并在单独的 Python 过程中运行（通过一个socket与正在运行的 Unity 应用程序进行通信）。
 
 **注意：**如果您并非要专门研究机器学习和 reinforcement learning（强化学习）主题，只想训练 agent 完成任务，则可以将 PPO 训练视为一个_黑盒_。在 Unity 内部以及在 Python 训练方面有一些与训练相关的参数可进行调整，但您不需要深入了解算法本身就可以成功创建和训练 agent。[训练 ML-Agents](/docs/Training-ML-Agents.md)提供了执行训练过程的逐步操作程序。
 


### PR DESCRIPTION
The URL for the PPO article on the OpenAI blog was changed from https://blog.openai.com/openai-baselines-ppo/ to https://openai.com/research/openai-baselines-ppo/. The subdomain `blog.openai.com` is no longer exists.

### Proposed change(s)

Update the URL to up-to-date.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)
