### PR TITLE
Upgrade ONNX to 1.15.0

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
 
 #### ml-agents / ml-agents-envs
 - Bumped numpy version to >=1.21.2,<1.24.0 (#5997)
+- Bumped onnx version to 1.15.0 (#6062)
+- Bumped protobuf version to >=3.6,<21 (#6062)
 
 ## [3.0.0-exp.1] - 2023-10-09
 ### Major Changes

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -56,7 +56,7 @@ setup(
         "cloudpickle",
         "grpcio>=1.11.0,<=1.48.2",
         "Pillow>=4.2.1",
-        "protobuf>=3.6,<3.20",
+        "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",
         "gym>=0.21.0",
         "pettingzoo==1.15.0",

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -60,7 +60,7 @@ setup(
         f"mlagents_envs=={VERSION}",
         "numpy>=1.21.2,<1.24.0",
         "Pillow>=4.2.1",
-        "protobuf>=3.6,<3.20",
+        "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",
         "torch>=2.1.1",
         "tensorboard>=2.14",
@@ -72,7 +72,7 @@ setup(
         "attrs>=19.3.0",
         "huggingface_hub>=0.14",
         'pypiwin32==223;platform_system=="Windows"',
-        "onnx==1.12.0",
+        "onnx==1.15.0",
     ],
     python_requires=">=3.10.1,<=3.10.12",
     entry_points={


### PR DESCRIPTION
### Proposed change(s)

This fixes builds of ONNX on OS X while installing ml-agents.

OS X builds use Xcode by default, and the Xcode compiler defaults to using C++98 mode for C++ ( https://stackoverflow.com/a/21349148 ). This causes errors building protocol buffer libraries, which need to be compiled with support for C++14 or newer ( https://github.com/protocolbuffers/protobuf/issues/12393#issuecomment-1508983035 ).

[This ONNX commit](https://github.com/onnx/onnx/commit/a979e756133167e0bdf5af23441cca4d189e805c) changes its compilation to use C++14 mode: releases that include this commit (1.15.0 or newer) build with Xcode by default.

ONNX 1.15.0 uses a newer protocol buffer library, so allow newer versions here too.
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) dependency upgrade

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
