### PR TITLE
Fix pre-commit action failures: switch to ruby/setup-ruby

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,11 +17,12 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.10.x
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       env:
         ImageOS: ubuntu20
       with:
-        ruby-version: '2.6'
+        ruby-version: '2.7'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '7.0.100'


### PR DESCRIPTION
### Proposed change(s)

Fixes pre-commit errors of the form:
```
Run actions/setup-ruby@v1
  with:
    ruby-version: 2.6
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.13/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.13/x64/lib
    ImageOS: ubuntu20
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.6 not found
```
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Failed run before: https://github.com/Unity-Technologies/ml-agents/actions/runs/8141034251/job/22247444613?pr=6062
Successful run after: https://github.com/Unity-Technologies/ml-agents/actions/runs/8141124283/job/22247720005?pr=6063

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) Fix pre-commit error 

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
