### PR TITLE
Fix cuda not being used on windows: update pytorch version

### DIFF
--- a/.yamato/pytest-gpu.yml
+++ b/.yamato/pytest-gpu.yml
@@ -11,7 +11,7 @@ pytest_gpu:
       python3 -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
       python3 -u -m ml-agents.tests.yamato.setup_venv
       python3 -m pip install --progress-bar=off -r test_requirements.txt --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-      python3 -m pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu117 --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+      python3 -m pip install torch==2.2.1+cu121 torchvision==0.17.1+cu121 torchaudio==0.17.1 --index-url https://download.pytorch.org/whl/cu121
       if python -c "exec('import torch \nif not torch.cuda.is_available(): raise')" &> /dev/null; then
         echo 'all good'
       else

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -146,10 +146,12 @@ offer a dedicated [guide on Virtual Environments](Using-Virtual-Environment.md).
 #### (Windows) Installing PyTorch
 
 On Windows, you'll have to install the PyTorch package separately prior to
-installing ML-Agents. Activate your virtual environment and run from the command line:
+installing ML-Agents in order to make sure the cuda-enabled version is used,
+rather than the CPU-only version. Activate your virtual environment and run from
+the command line:
 
 ```sh
-pip3 install torch~=1.13.1 -f https://download.pytorch.org/whl/torch_stable.html
+pip3 install torch~=2.2.1 --index-url https://download.pytorch.org/whl/cu121
 ```
 
 Note that on Windows, you may also need Microsoft's


### PR DESCRIPTION
### Proposed change(s)

These references were missed when upgrading from pytorch 1.x to 2.x in #6013

References found by running `grep -R '1\.13\.1' .`

Install command chosen from the guide at https://pytorch.org/get-started/locally/

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Probably related to https://github.com/Unity-Technologies/ml-agents/issues/6055 : the user screenshot shows they're running the CPU-only version of cuda on a windows machine.

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
