### PR TITLE
Fix GPU continuous build: correct torch version, and remove torchaudio and torchvideo

### DIFF
--- a/.yamato/pytest-gpu.yml
+++ b/.yamato/pytest-gpu.yml
@@ -11,7 +11,7 @@ pytest_gpu:
       python3 -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
       python3 -u -m ml-agents.tests.yamato.setup_venv
       python3 -m pip install --progress-bar=off -r test_requirements.txt --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-      python3 -m pip install torch==2.2.1+cu118 torchvision==0.17.1+cu118 torchaudio==2.2.1+cu118 --index-url https://download.pytorch.org/whl/cu118
+      python3 -m pip install torch==2.2.1+cu118 --index-url https://download.pytorch.org/whl/cu118
       if python -c "exec('import torch \nif not torch.cuda.is_available(): raise')" &> /dev/null; then
         echo 'all good'
       else

--- a/.yamato/pytest-gpu.yml
+++ b/.yamato/pytest-gpu.yml
@@ -11,10 +11,11 @@ pytest_gpu:
       python3 -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
       python3 -u -m ml-agents.tests.yamato.setup_venv
       python3 -m pip install --progress-bar=off -r test_requirements.txt --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-      python3 -m pip install torch==2.2.1+cu121 torchvision==0.17.1+cu121 torchaudio==0.17.1 --index-url https://download.pytorch.org/whl/cu121
+      python3 -m pip install torch==2.2.1+cu118 torchvision==0.17.1+cu118 torchaudio==2.2.1+cu118 --index-url https://download.pytorch.org/whl/cu118
       if python -c "exec('import torch \nif not torch.cuda.is_available(): raise')" &> /dev/null; then
         echo 'all good'
       else
+        echo 'cuda device not available!'
         exit 1
       fi
       python3 -m pytest -m "not slow" --junitxml=junit/test-results.xml -p no:warnings


### PR DESCRIPTION
### Proposed change(s)

Remove torchaudio and torchvideo, which are unused (which fixes trying to download the wrong torchaudio version)

Use a slightly older cuda version, since that makes cuda detection work on the machines we're running on (RTX 2080's on Ubuntu 18.04, which presumably aren't compatible with CUDA 12).

Passing GPU run with this change: https://unity-ci.cds.internal.unity3d.com/job/34891013/logs

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
