### PR TITLE
Fix dead links to Tensorboard

### DIFF
--- a/docs/Background-PyTorch.md
+++ b/docs/Background-PyTorch.md
@@ -24,7 +24,7 @@ One component of training models with PyTorch is setting the values of
 certain model attributes (called _hyperparameters_). Finding the right values of
 these hyperparameters can require a few iterations. Consequently, we leverage a
 visualization tool called
-[TensorBoard](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard).
+[TensorBoard](https://www.tensorflow.org/tensorboard).
 It allows the visualization of certain agent attributes (e.g. reward) throughout
 training which can be helpful in both building intuitions for the different
 hyperparameters and setting the optimal values for your Unity environment. We

--- a/docs/Using-Tensorboard.md
+++ b/docs/Using-Tensorboard.md
@@ -2,7 +2,7 @@
 
 The ML-Agents Toolkit saves statistics during learning session that you can view
 with a TensorFlow utility named,
-[TensorBoard](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard).
+[TensorBoard](https://www.tensorflow.org/tensorboard).
 
 The `mlagents-learn` command saves training statistics to a folder named
 `results`, organized by the `run-id` value you assign to a training session.

--- a/markdown-link-check.full.json
+++ b/markdown-link-check.full.json
@@ -23,6 +23,10 @@
         {
             "pattern": "https://www.researchgate.net/",
             "comment": "Issue with GHE certs / firewall"
+        },
+        {
+            "pattern": "https://www.tensorflow.org/",
+            "comment": "Valid links failing with errors like 'https://www.tensorflow.org/tensorboard → Status: 0 Error: Exceeded maxRedirects. Probably stuck in a redirect loop'"
         }
     ]
 }


### PR DESCRIPTION
### Proposed change(s)

Ignore spurious dead links to tensorflow.org pages, since we're seeing an infinite redirect for some reason that doesn't reproduce in the browser or with `curl`.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
