### PR TITLE
Raise minimum numpy version to 1.23.5 to fix installation errors on windows

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to
 - Fixed 3DBall sample package to remove Barracuda dependency. (#6030)
 
 #### ml-agents / ml-agents-envs
-- Bumped numpy version to >=1.21.2,<1.24.0 (#5997)
+- Bumped numpy version to >=1.23.5,<1.24.0 (#6081)
 - Bumped onnx version to 1.15.0 (#6062)
 - Bumped protobuf version to >=3.6,<21 (#6062)
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -60,7 +60,7 @@ setup(
         "pyyaml>=3.1.0",
         "gym>=0.21.0",
         "pettingzoo==1.15.0",
-        "numpy>=1.21.2,<1.24.0",
+        "numpy>=1.23.5,<1.24.0",
         "filelock>=3.4.0",
     ],
     python_requires=">=3.10.1,<=3.10.12",

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -58,7 +58,7 @@ setup(
         "grpcio>=1.11.0,<=1.48.2",
         "h5py>=2.9.0",
         f"mlagents_envs=={VERSION}",
-        "numpy>=1.21.2,<1.24.0",
+        "numpy>=1.23.5,<1.24.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",


### PR DESCRIPTION
### Proposed change(s)

Fixes the following errors when installing ml-agents-envs on windows if numpy 1.21.2 is already installed:
```
  Building wheel for numpy (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for numpy (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [326 lines of output]
      setup.py:63: RuntimeWarning: NumPy 1.21.2 may not yet support Python 3.10.
        warnings.warn(
      Running from numpy source directory.
```

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

Fixes https://github.com/Unity-Technologies/ml-agents/issues/6047

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) dependency upgrade

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
