### PR TITLE
Upgrade pettingzoo to 1.24.x

### DIFF
--- a/docs/Python-LLAPI-Documentation.md
+++ b/docs/Python-LLAPI-Documentation.md
@@ -526,7 +526,7 @@ by one step.
 
 ```python
  | @abstractmethod
- | reset() -> None
+ | reset(seed: Optional[int] = None, options: Optional[Dict] = None) -> None
 ```
 
 Signals the environment that it must reset the simulation.

--- a/docs/Python-PettingZoo-API-Documentation.md
+++ b/docs/Python-PettingZoo-API-Documentation.md
@@ -21,7 +21,6 @@
     * [action\_space](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.action_space)
     * [side\_channel](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.side_channel)
     * [reset](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.reset)
-    * [seed](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.seed)
     * [render](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.render)
     * [close](#mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.close)
 
@@ -137,7 +136,7 @@ Initializes a Unity Parallel environment wrapper.
 #### reset
 
 ```python
- | reset() -> Dict[str, Any]
+ | reset(seed: Optional[int] = None, options: Optional[Dict] = None) -> Dict[str, Any]
 ```
 
 Resets the environment.
@@ -207,20 +206,10 @@ of an environment with `env.side_channel[<name-of-channel>]`.
 #### reset
 
 ```python
- | reset()
+ | reset(seed: Optional[int] = None, options: Optional[Dict] = None) -> None
 ```
 
 Resets the environment.
-
-<a name="mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.seed"></a>
-#### seed
-
-```python
- | seed(seed=None)
-```
-
-Reseeds the environment (making the resulting environment deterministic).
-`reset()` must be called after `seed()`, and before `step()`.
 
 <a name="mlagents_envs.envs.unity_pettingzoo_base_env.UnityPettingzooBaseEnv.render"></a>
 #### render

--- a/ml-agents-envs/mlagents_envs/base_env.py
+++ b/ml-agents-envs/mlagents_envs/base_env.py
@@ -558,7 +558,7 @@ class BaseEnv(ABC):
         """
 
     @abstractmethod
-    def reset(self) -> None:
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         """
         Signals the environment that it must reset the simulation.
         """

--- a/ml-agents-envs/mlagents_envs/environment.py
+++ b/ml-agents-envs/mlagents_envs/environment.py
@@ -313,7 +313,7 @@ class UnityEnvironment(BaseEnv):
                 )
         self._side_channel_manager.process_side_channel_message(output.side_channel)
 
-    def reset(self) -> None:
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         if self._loaded:
             outputs = self._communicator.exchange(
                 self._generate_reset_input(), self._poll_process

--- a/ml-agents-envs/mlagents_envs/envs/unity_parallel_env.py
+++ b/ml-agents-envs/mlagents_envs/envs/unity_parallel_env.py
@@ -20,11 +20,11 @@ class UnityParallelEnv(UnityPettingzooBaseEnv, ParallelEnv):
         """
         super().__init__(env, seed)
 
-    def reset(self) -> Dict[str, Any]:
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> Dict[str, Any]:  # type: ignore
         """
         Resets the environment.
         """
-        super().reset()
+        super().reset(seed)
 
         return self._observations
 

--- a/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
+++ b/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
@@ -232,15 +232,16 @@ class UnityPettingzooBaseEnv:
         self._infos = {}
         self._agent_id_to_index = {}
 
-    def reset(self):
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         """
         Resets the environment.
         """
+        self._seed = seed
         self._assert_loaded()
         self._agent_index = 0
         self._reset_states()
         self._possible_agents = set()
-        self._env.reset()
+        self._env.reset(seed)
         for behavior_name in self._env.behavior_specs.keys():
             _, _, _ = self._batch_update(behavior_name)
         self._live_agents.sort()  # unnecessary, only for passing API test
@@ -269,13 +270,6 @@ class UnityPettingzooBaseEnv:
         self._agent_id_to_index.update(id_map)
         self._possible_agents.update(agents)
         return dones, rewards, cumulative_rewards
-
-    def seed(self, seed=None):
-        """
-        Reseeds the environment (making the resulting environment deterministic).
-        `reset()` must be called after `seed()`, and before `step()`.
-        """
-        self._seed = seed
 
     def render(self, mode="human"):
         """

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -59,7 +59,7 @@ setup(
         "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",
         "gym>=0.21.0",
-        "pettingzoo==1.15.0",
+        "pettingzoo==1.24.3",
         "numpy>=1.23.5,<1.24.0",
         "filelock>=3.4.0",
     ],

--- a/ml-agents-envs/tests/simple_test_envs.py
+++ b/ml-agents-envs/tests/simple_test_envs.py
@@ -6,7 +6,7 @@ pettingzoo api tests, since current PZ api test doesn't allow spawning new agent
 """
 
 import random
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Optional, Tuple
 import numpy as np
 
 from mlagents_envs.base_env import (
@@ -273,7 +273,7 @@ class SimpleEnvironment(BaseEnv):
             self.rewards[name] += reward
             self.step_result[name] = self._make_batched_step(name, done, reward, 0.0)
 
-    def reset(self) -> None:  # type: ignore
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         for name in self.names:
             self._reset_agent(name)
             self.step_result[name] = self._make_batched_step(name, False, 0.0, 0.0)
@@ -483,7 +483,7 @@ class MultiAgentEnvironment(BaseEnv):
                             name, done, reward, 0.0
                         )
 
-    def reset(self) -> None:  # type: ignore
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         for name in self.names:
             for i in range(self.num_agents):
                 name_and_num = name + str(i)
@@ -497,7 +497,7 @@ class MultiAgentEnvironment(BaseEnv):
             for i in range(self.num_agents):
                 name_and_num = name + str(i)
                 self.dones[name_and_num] = False
-                self.envs[name_and_num].reset()
+                self.envs[name_and_num].reset(seed)
 
     @property
     def reset_parameters(self) -> Dict[str, str]:

--- a/ml-agents/mlagents/trainers/tests/simple_test_envs.py
+++ b/ml-agents/mlagents/trainers/tests/simple_test_envs.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Optional, Tuple
 import numpy as np
 
 from mlagents_envs.base_env import (
@@ -270,7 +270,7 @@ class SimpleEnvironment(BaseEnv):
             self.rewards[name] += reward
             self.step_result[name] = self._make_batched_step(name, done, reward, 0.0)
 
-    def reset(self) -> None:  # type: ignore
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         for name in self.names:
             self._reset_agent(name)
             self.step_result[name] = self._make_batched_step(name, False, 0.0, 0.0)
@@ -534,7 +534,7 @@ class MultiAgentEnvironment(BaseEnv):
                             name, done, reward, 0.0
                         )
 
-    def reset(self) -> None:  # type: ignore
+    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> None:
         for name in self.names:
             for i in range(self.num_agents):
                 name_and_num = name + str(i)


### PR DESCRIPTION
### Proposed change(s)

Pre-requisite for upgrading to Python 3.11 (which is supported by the 1.24.x pettingzoo releases)

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe) dependency update

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
