### PR TITLE
add support for mac m1/m2 chips mps gpu

### DIFF
--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -53,6 +53,8 @@ def set_torch_config(torch_settings: TorchSettings) -> None:
 
     if _device.type == "cuda":
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
+    elif _device.type == 'mps':
+        torch.set_default_device(device_str)
     else:
         torch.set_default_tensor_type(torch.FloatTensor)
     logger.debug(f"default Torch device: {_device}")


### PR DESCRIPTION
need upgrade onnx and protobuf, add setup default device for torch, so user can use command params "--torch-device mps:0" to launch gpu training on mac

### Proposed change(s)

add support for mac m1/m2 chips mps gpu
user can use command params
"--torch-device mps:0" to launch gpu training on mac

