### PR TITLE
Add depth map support for camera sensor

### DIFF
--- a/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
+++ b/com.unity.ml-agents/Editor/CameraSensorComponentEditor.cs
@@ -24,6 +24,7 @@ namespace Unity.MLAgents.Editor
                 EditorGUILayout.PropertyField(so.FindProperty("m_Width"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Height"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_Grayscale"), true);
+                EditorGUILayout.PropertyField(so.FindProperty("m_RGBD"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_ObservationStacks"), true);
                 EditorGUILayout.PropertyField(so.FindProperty("m_ObservationType"), true);
             }

--- a/com.unity.ml-agents/Runtime/Resources.meta
+++ b/com.unity.ml-agents/Runtime/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca0aab04b837598dc99f548d13baf0c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Runtime/Resources/DepthShader.shader
+++ b/com.unity.ml-agents/Runtime/Resources/DepthShader.shader
@@ -1,0 +1,64 @@
+Shader "Custom/DepthShader"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+                float4 screenPos: TEXTCOORD1;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.screenPos = ComputeScreenPos(o.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            sampler2D _MainTex, _CameraDepthTexture;
+
+            float4 frag (v2f i) : SV_Target
+            {
+                // Extract color from texture
+                float4 color = tex2D(_MainTex, i.uv);
+
+                // Extract depth from camera depth texture
+                float depth = LinearEyeDepth(tex2D(_CameraDepthTexture, i.screenPos.xy));
+
+                // Clip depth to far plane
+                float farPlane = _ProjectionParams.z;
+                if (depth > farPlane) depth = 0;
+
+                // Convert color from linear to sRGB
+                color.rgb = LinearToGammaSpace(saturate(color.rgb));
+
+                // Store depth in alpha channel
+                color.a = depth;
+
+                return color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/com.unity.ml-agents/Runtime/Resources/DepthShader.shader.meta
+++ b/com.unity.ml-agents/Runtime/Resources/DepthShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8c36e1786391089c18743562d1d2de06
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ml-agents/Runtime/Sensors/CompressionSpec.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/CompressionSpec.cs
@@ -14,7 +14,12 @@ namespace Unity.MLAgents.Sensors
         /// <summary>
         /// PNG format. Data will be stored in binary format.
         /// </summary>
-        PNG
+        PNG,
+
+        /// <summary>
+        /// OpenEXR format.
+        /// </summary>
+        OPENEXR
     }
 
     /// <summary>

--- a/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/ObservationWriter.cs
@@ -296,7 +296,8 @@ namespace Unity.MLAgents.Sensors
         public static int WriteTexture(
             this ObservationWriter obsWriter,
             Texture2D texture,
-            bool grayScale)
+            bool grayScale,
+            bool rgbd = false)
         {
             if (texture.format == TextureFormat.RGB24)
             {
@@ -306,7 +307,7 @@ namespace Unity.MLAgents.Sensors
             var width = texture.width;
             var height = texture.height;
 
-            var texturePixels = texture.GetPixels32();
+            var texturePixels = texture.GetPixels();
 
             // During training, we convert from Texture to PNG before sending to the trainer, which has the
             // effect of flipping the image. We need another flip here at inference time to match this.
@@ -316,22 +317,25 @@ namespace Unity.MLAgents.Sensors
                 {
                     var currentPixel = texturePixels[(height - h - 1) * width + w];
 
-                    if (grayScale)
+                    if (grayScale && !rgbd)
                     {
                         obsWriter[0, h, w] =
-                            (currentPixel.r + currentPixel.g + currentPixel.b) / 3f / 255.0f;
+                            (currentPixel.r + currentPixel.g + currentPixel.b) / 3f;
                     }
                     else
                     {
-                        // For Color32, the r, g and b values are between 0 and 255.
-                        obsWriter[0, h, w] = currentPixel.r / 255.0f;
-                        obsWriter[1, h, w] = currentPixel.g / 255.0f;
-                        obsWriter[2, h, w] = currentPixel.b / 255.0f;
+                        obsWriter[0, h, w] = currentPixel.r;
+                        obsWriter[1, h, w] = currentPixel.g;
+                        obsWriter[2, h, w] = currentPixel.b;
+                        if (rgbd)
+                        {
+                            obsWriter[3, h, w] = currentPixel.a;
+                        }
                     }
                 }
             }
 
-            return height * width * (grayScale ? 1 : 3);
+            return height * width * (rgbd ? 4 : grayScale ? 1 : 3);
         }
 
         internal static int WriteTextureRGB24(

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -62,6 +62,7 @@ setup(
         "pettingzoo==1.15.0",
         "numpy>=1.23.5,<1.24.0",
         "filelock>=3.4.0",
+        "OpenEXR==3.2.4",
     ],
     python_requires=">=3.10.1,<=3.10.12",
     # TODO: Remove this once mypy stops having spurious setuptools issues.

--- a/ml-agents-envs/tests/test_rpc_utils.py
+++ b/ml-agents-envs/tests/test_rpc_utils.py
@@ -236,7 +236,7 @@ def proto_from_steps_and_action(
 def test_process_pixels():
     in_array = np.random.rand(3, 128, 64)
     byte_arr = generate_compressed_data(in_array)
-    out_array = process_pixels(byte_arr, 3)
+    out_array = process_pixels(byte_arr, PNG, 3)
     assert out_array.shape == (3, 128, 64)
     assert np.sum(in_array - out_array) / np.prod(in_array.shape) < 0.01
     assert np.allclose(in_array, out_array, atol=0.01)
@@ -248,7 +248,7 @@ def test_process_pixels_multi_png():
     num_channels = 7
     in_array = np.random.rand(num_channels, height, width)
     byte_arr = generate_compressed_data(in_array)
-    out_array = process_pixels(byte_arr, num_channels)
+    out_array = process_pixels(byte_arr, PNG, num_channels)
     assert out_array.shape == (num_channels, height, width)
     assert np.sum(in_array - out_array) / np.prod(in_array.shape) < 0.01
     assert np.allclose(in_array, out_array, atol=0.01)
@@ -257,7 +257,7 @@ def test_process_pixels_multi_png():
 def test_process_pixels_gray():
     in_array = np.random.rand(3, 128, 64)
     byte_arr = generate_compressed_data(in_array)
-    out_array = process_pixels(byte_arr, 1)
+    out_array = process_pixels(byte_arr, PNG, 1)
     assert out_array.shape == (1, 128, 64)
     assert np.mean(in_array.mean(axis=0, keepdims=True) - out_array) < 0.01
     assert np.allclose(in_array.mean(axis=0, keepdims=True), out_array, atol=0.01)


### PR DESCRIPTION
### Proposed change(s)

Add depth map support for camera sensor. Also add OpenEXR support for frame encoding.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments

RGBD option has priority over Grayscale option. Compatibility should not be broken with previous versions.

The depth component is stored in the image alpha channel. Float RenderTexture and Texture32, as well as OpenEXR encoding ensure that depth is not compressed to 8-bits.

N.B. Adding compression flags to EXR encoding slows down the read/write rate.

[Screencast from 27-06-2024 09:43:00.webm](https://github.com/Unity-Technologies/ml-agents/assets/74063264/79c4dfad-0b5e-40dc-90a6-afbb56284bd4)

