### PR TITLE
Update unity_pettingzoo_base_env.py

### DIFF
--- a/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
+++ b/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
@@ -168,7 +168,7 @@ class UnityPettingzooBaseEnv:
             if action.continuous is not None:
                 self._current_action[current_behavior].continuous[
                     current_index
-                ] = action.continuous[0]
+                ] = action.continuous
             if action.discrete is not None:
                 self._current_action[current_behavior].discrete[
                     current_index

--- a/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
+++ b/ml-agents-envs/mlagents_envs/envs/unity_pettingzoo_base_env.py
@@ -132,7 +132,7 @@ class UnityPettingzooBaseEnv:
                         continue
                 if act_spec.continuous_size > 0:
                     c_space = spaces.Box(
-                        -1, 1, (act_spec.continuous_size,), dtype=np.int32
+                        -np.float32(np.inf), np.float32(np.inf), (act_spec.continuous_size,), dtype=np.float32
                     )
                     if self._seed is not None:
                         c_space.seed(self._seed)


### PR DESCRIPTION
### Proposed change(s)

in the the ```_update_action_spaces``` method of the UnityPettingzooBaseEnv class, you force the actions to be of int32 and in the [-1,1] range (see the code below). This constraint doesn't apply to all scenarios

```python
act_spec.continuous_size > 0:
                    c_space = spaces.Box(
                        -1, 1, (act_spec.continuous_size,), dtype=np.int32
                    )
```

It makes more sense to use the same logic as in ```_update_observation_spaces```.

```python
obs_spaces = tuple(
                    spaces.Box(
                        low=-np.float32(np.inf),
                        high=np.float32(np.inf),
                        shape=spec.shape,
                        dtype=np.float32,
                    )
```
We can generalize to all scenarios by using:
```
if act_spec.continuous_size > 0:
                    c_space = spaces.Box(
                        -np.float32(np.inf), np.float32(np.inf), (act_spec.continuous_size,), dtype=np.float32
                    )
```



### Types of change(s)

- [x ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
