### PR TITLE
Add pyproject

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -11,14 +11,15 @@ and this project adheres to
 #### com.unity.ml-agents (C#)
 - Upgraded to Inference Engine 2.2.1 (#6212)
 - The minimum supported Unity version was updated to 6000.0. (#6207)
-- Merge the extension package com.unity.ml-agents.extensions to the main package com.unity.ml-agents. (#6227)
+- Merged the extension package com.unity.ml-agents.extensions to the main package com.unity.ml-agents. (#6227)
 
 ### Minor Changes
 #### com.unity.ml-agents (C#)
-- Remove broken sample from the package (#6230)
+- Removed broken sample from the package (#6230)
 
 #### ml-agents / ml-agents-envs
 - Bumped grpcio version to >=1.11.0,<=1.53.2 (#6208)
+- Used pyproject.toml to build python packages (#6235)
 
 ## [3.0.0] - 2024-09-02
 ### Major Changes

--- a/ml-agents-envs/pyproject.toml
+++ b/ml-agents-envs/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42.0.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/ml-agents-envs/pyproject.toml
+++ b/ml-agents-envs/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# This section is necessary for setuptools_scm to work correctly

--- a/ml-agents-envs/pyproject.toml
+++ b/ml-agents-envs/pyproject.toml
@@ -1,6 +1,0 @@
-[build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-# This section is necessary for setuptools_scm to work correctly

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -5,13 +5,19 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 # Get version information without importing the package
-with open(os.path.join("mlagents_envs", "__init__.py"), "r") as f:
+with open(os.path.join("mlagents_envs", "__init__.py")) as f:
     init_text = f.read()
-    
+
 # Extract version with regex to avoid import
 VERSION = re.search(r'__version__ = "([^"]+)"', init_text).group(1)
-EXPECTED_TAG = re.search(r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text)
-EXPECTED_TAG = EXPECTED_TAG.group(2) if EXPECTED_TAG.group(2) else None
+version_tag_match = re.search(
+    r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text
+)
+EXPECTED_TAG = (
+    version_tag_match.group(2)
+    if version_tag_match and version_tag_match.group(2)
+    else None
+)
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents-envs/setup.py
+++ b/ml-agents-envs/setup.py
@@ -1,11 +1,17 @@
 import os
 import sys
+import re
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-import mlagents_envs
 
-VERSION = mlagents_envs.__version__
-EXPECTED_TAG = mlagents_envs.__release_tag__
+# Get version information without importing the package
+with open(os.path.join("mlagents_envs", "__init__.py"), "r") as f:
+    init_text = f.read()
+    
+# Extract version with regex to avoid import
+VERSION = re.search(r'__version__ = "([^"]+)"', init_text).group(1)
+EXPECTED_TAG = re.search(r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text)
+EXPECTED_TAG = EXPECTED_TAG.group(2) if EXPECTED_TAG.group(2) else None
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents/pyproject.toml
+++ b/ml-agents/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42.0.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/ml-agents/pyproject.toml
+++ b/ml-agents/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# This section is necessary for setuptools_scm to work correctly

--- a/ml-agents/pyproject.toml
+++ b/ml-agents/pyproject.toml
@@ -1,6 +1,0 @@
-[build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-# This section is necessary for setuptools_scm to work correctly

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -1,13 +1,22 @@
 import os
 import sys
+import re
 
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-from mlagents.plugins import ML_AGENTS_STATS_WRITER, ML_AGENTS_TRAINER_TYPE
-import mlagents.trainers
 
-VERSION = mlagents.trainers.__version__
-EXPECTED_TAG = mlagents.trainers.__release_tag__
+# Define plugin constants directly to avoid importing
+ML_AGENTS_STATS_WRITER = "mlagents.plugins.stats_writer"
+ML_AGENTS_TRAINER_TYPE = "mlagents.plugins.trainer_type"
+
+# Get version information without importing the package
+with open(os.path.join("mlagents", "trainers", "__init__.py"), "r") as f:
+    init_text = f.read()
+    
+# Extract version with regex to avoid import
+VERSION = re.search(r'__version__ = "([^"]+)"', init_text).group(1)
+EXPECTED_TAG = re.search(r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text)
+EXPECTED_TAG = EXPECTED_TAG.group(2) if EXPECTED_TAG.group(2) else None
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -10,13 +10,19 @@ ML_AGENTS_STATS_WRITER = "mlagents.plugins.stats_writer"
 ML_AGENTS_TRAINER_TYPE = "mlagents.plugins.trainer_type"
 
 # Get version information without importing the package
-with open(os.path.join("mlagents", "trainers", "__init__.py"), "r") as f:
+with open(os.path.join("mlagents", "trainers", "__init__.py")) as f:
     init_text = f.read()
-    
+
 # Extract version with regex to avoid import
 VERSION = re.search(r'__version__ = "([^"]+)"', init_text).group(1)
-EXPECTED_TAG = re.search(r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text)
-EXPECTED_TAG = EXPECTED_TAG.group(2) if EXPECTED_TAG.group(2) else None
+version_tag_match = re.search(
+    r'__release_tag__ = ([^"]*None[^"]*|"([^"]+)")', init_text
+)
+EXPECTED_TAG = (
+    version_tag_match.group(2)
+    if version_tag_match and version_tag_match.group(2)
+    else None
+)
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-# This section is necessary for setuptools_scm to work correctly
-write_to = "version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# This section is necessary for setuptools_scm to work correctly
+write_to = "version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### Proposed change(s)

Use `pyproject.toml` to build python packages `ml-agents-envs` and `ml-agents` due to depreciation of legacy `setup.py bdist_wheel` mechanism for building projects: https://github.com/pypa/pip/issues/6334. I followed the `I am an AUTHOR of the affected project` section to fix the issue. Without this fix the build fails. 


### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Use `pyproject.toml` to build python packages

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
