### PR TITLE
Updating image to ubuntu-ci:v1.0.1

### DIFF
--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -2,7 +2,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.medium
   commands:
     - |

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -22,7 +22,7 @@ test_platforms:
       flavor: b1.large
     - name: linux
       type: Unity::VM
-      image: ml-agents/ubuntu-ci:v1.0.0
+      image: ml-agents/ubuntu-ci:v1.0.1
       flavor: b1.large
 
 packages:

--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -8,7 +8,7 @@ test_editors:
       enableNoDefaultPackages: !!bool true
 
 trunk_editor:
-    - version: 6000.3.0a3
+    - version: trunk
       testProject: DevProject
 
 test_platforms:

--- a/.yamato/compressed-sensor-test.yml
+++ b/.yamato/compressed-sensor-test.yml
@@ -5,7 +5,7 @@ test_compressed_obs_{{ editor.version }}_{{ editor.extra_test }}:
   name: Test Compressed Sensor Observation {{ editor.version }} {{ editor.extra_test }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/coverage_tests.metafile
+++ b/.yamato/coverage_tests.metafile
@@ -5,7 +5,7 @@ coverage_test_editors:
 coverage_test_platforms:
     - name: linux
       type: Unity::VM
-      image: ml-agents/ubuntu-ci:v1.0.0
+      image: ml-agents/ubuntu-ci:v1.0.1
       flavor: b1.medium
 
 coverage_test_packages:

--- a/.yamato/gym-interface-test.yml
+++ b/.yamato/gym-interface-test.yml
@@ -5,7 +5,7 @@ test_gym_interface_{{ editor.version }}_{{ editor.extra_test }}:
   name: Test Linux Gym Interface {{ editor.version }} {{ editor.extra_test }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/protobuf-generation-test.yml
+++ b/.yamato/protobuf-generation-test.yml
@@ -2,7 +2,7 @@ test_linux_protobuf_generation:
   name: Protobuf Generation Tests
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.large
   variables:
     GRPC_VERSION: "1.14.1"

--- a/.yamato/pytest-gpu.yml
+++ b/.yamato/pytest-gpu.yml
@@ -2,7 +2,7 @@ pytest_gpu:
   name: Pytest GPU
   agent:
     type: Unity::VM::GPU
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.large
   commands:
     - |

--- a/.yamato/python-ll-api-test.yml
+++ b/.yamato/python-ll-api-test.yml
@@ -5,7 +5,7 @@ test_linux_ll_api_{{ editor.version }}_{{ editor.extra_test }}:
   name: Test Linux LL-API {{ editor.version }} {{ editor.extra_test }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/standalone-build-test.yml
+++ b/.yamato/standalone-build-test.yml
@@ -5,7 +5,7 @@ test_linux_standalone_{{ editor.version }}_{{ editor.extra_test }}:
   name: Test Linux Standalone {{ editor.version }} {{ editor.extra_test }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.large
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/standalone-build-webgl-test.yml
+++ b/.yamato/standalone-build-webgl-test.yml
@@ -3,7 +3,7 @@ test_webgl_standalone_{{ editor_version }}:
   name: Test WebGL Standalone {{ editor_version }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.large
   variables:
     UNITY_VERSION: {{ editor_version }}

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -7,5 +7,5 @@ test_editors:
     extra_test: gym
   - version: 6000.0
     extra_test: sensor
-  - version: 6000.3.0a3
+  - version: trunk
     extra_test: llapi

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -5,7 +5,7 @@ test_linux_training_int_{{ editor.version }}_{{ editor.extra_test }}:
   name: Test Linux Fast Training {{ editor.version }} {{ editor.extra_test }}
   agent:
     type: Unity::VM
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     flavor: b1.medium
   variables:
     UNITY_VERSION: {{ editor.version }}

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -5,7 +5,7 @@
 package_pack_-_ml-agents:
   name: Package Pack - ml-agents
   agent:
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     type: Unity::VM
     flavor: b1.large
   commands:

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -68,7 +68,7 @@ preview_apv_-_6000_0_-_macos:
 preview_apv_-_6000_0_-_ubuntu:
   name: Preview APV - 6000.0 - ubuntu
   agent:
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     type: Unity::VM
     flavor: b1.large
   commands:

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -5,7 +5,7 @@
 publish_dry_run_ml-agents:
   name: Publish Dry Run ml-agents
   agent:
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     type: Unity::VM
     flavor: b1.large
   commands:
@@ -57,7 +57,7 @@ publish_dry_run_ml-agents:
 publish_ml-agents:
   name: Publish ml-agents
   agent:
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     type: Unity::VM
     flavor: b1.large
   commands:

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -64,7 +64,7 @@ validate_-_ml-agents_-_6000_0_-_macos:
 validate_-_ml-agents_-_6000_0_-_ubuntu:
   name: Validate - ml-agents - 6000.0 - ubuntu
   agent:
-    image: ml-agents/ubuntu-ci:v1.0.0
+    image: ml-agents/ubuntu-ci:v1.0.1
     type: Unity::VM
     flavor: b1.large
   commands:


### PR DESCRIPTION
### Proposed change(s)

Updating the bokken image version (from ubuntu 20.04 to 22.04).
There was a linux toolchain + sysroot update which upgraded the version of glibc that MLA yamato tests compile against. 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [ x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
