### PR TITLE
Fix visual observation tensor indexing for Unity inference

### DIFF
--- a/com.unity.ml-agents/Runtime/Inference/TensorExtensions.cs
+++ b/com.unity.ml-agents/Runtime/Inference/TensorExtensions.cs
@@ -57,9 +57,9 @@ namespace Unity.MLAgents.Inference
         {
             int index =
                 n * shape.Height() * shape.Width() * shape.Channels() +
-                h * shape.Width() * shape.Channels() +
-                w * shape.Channels() +
-                c;
+                c * shape.Height() * shape.Width() +
+                h * shape.Width() +
+                w;
             return index;
         }
     }


### PR DESCRIPTION
## Summary
 - Fix tensor indexing in Unity inference to use correct CHW layout
 - Fixed erroneous behavior of the agent on the Unity side when there is more than one visual channel

 ## Problem
The indexing formula was calculating HWC layout while Unity's visual sensors write data in CHW format.

## Solution
  Corrected TensorExtensions.Index() to properly calculate CHW tensor indices that match Unity's observation writer
  format.