### PR TITLE
Fix: data on both cuda:0 and cuda:1 when using --torch-device cuda:1

### DIFF
--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -52,7 +52,7 @@ def set_torch_config(torch_settings: TorchSettings) -> None:
     _device = torch.device(device_str)
 
     if _device.type == "cuda":
-        torch.set_default_device(_device.type)
+        torch.set_default_device(_device)
         torch.set_default_dtype(torch.float32)
     else:
         torch.set_default_dtype(torch.float32)


### PR DESCRIPTION
### Proposed change(s)
Solves:
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0! (when checking argument for argument mat1 in method wrapper_CUDA_addmm)
when using --torch-device cuda:1

- [x] Bug fix
- [x] Code refactor
