### PR TITLE
Add torch version constraint to be equal or less than 2.8.0 to prevent breaking onnx changes in torch 2.9.0

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 - Fixed tensor indexing to use correct CHW layout (#6239)
 
 #### ml-agents / ml-agents-envs
+- Set the Torch version constraint to 2.8 (#6251)
 - Fixed CUDA/CPU mismatch in threaded training (#6245)
 
 ## [4.0.0] - 2025-08-15

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -62,7 +62,7 @@ setup(
         "Pillow>=4.2.1",
         "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",
-        "torch==2.8.0",
+        "torch>=2.1.1,<=2.8.0",
         "tensorboard>=2.14",
         # adding six explicit dependency since tensorboard needs it but doesn't declare it as a dep
         "six>=1.16",

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -62,7 +62,7 @@ setup(
         "Pillow>=4.2.1",
         "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",
-        "torch>=2.1.1",
+        "torch==2.8.0",
         "tensorboard>=2.14",
         # adding six explicit dependency since tensorboard needs it but doesn't declare it as a dep
         "six>=1.16",


### PR DESCRIPTION
### Proposed change(s)

The new ` 2.9.0` torch version released 2 day ago results in an issue finding `onnxscript`. `ml-agents` is configured to take any version >= `2.1.1` so it will take this version. Full credits to @Nitesh-joestar for identifying the issue and the fix for this in https://github.com/Unity-Technologies/ml-agents/issues/6250.

Adding a constraint that maximum version is `2.8.0` prevents this error.

I'm not exactly of the exact root cause but it seems there were some backwards incompatible changes to onnx: https://github.com/pytorch/pytorch/releases/tag/v2.9.0#backwards-incompatible-changes.

Stack trace on exiting training:
```
  File "C:\Users\REDACTED\miniconda3\envs\mlagents\lib\site-packages\mlagents\trainers\torch_entities\model_serialization.py", line 164, in export_policy_model
    torch.onnx.export(
  File "C:\Users\REDACTED\miniconda3\envs\mlagents\lib\site-packages\torch\onnx\__init__.py", line 282, in export
    from torch.onnx._internal.exporter import _compat
  File "C:\Users\REDACTED\miniconda3\envs\mlagents\lib\site-packages\torch\onnx\_internal\exporter\_compat.py", line 16, in <module>
    from torch.onnx._internal.exporter import (
  File "C:\Users\REDACTED\miniconda3\envs\mlagents\lib\site-packages\torch\onnx\_internal\exporter\_core.py", line 18, in <module>
    import onnxscript
ModuleNotFoundError: No module named 'onnxscript'
```
### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
https://github.com/Unity-Technologies/ml-agents/issues/6250

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
Tested with torch version 2.8.0, running training, then exiting training; and confirm file saved correctly:
```
[INFO] Exported results\5\Basic\Basic-269.onnx
[INFO] Copied results\5\Basic\Basic-269.onnx to results\5\Basic.onnx.
```