### PR TITLE
Bobd/codesign mac

### DIFF
--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -24,6 +24,8 @@ pack:
         - "upm-ci~/packages/**/*"
   triggers:
     cancel_old_ci: true
+  dependencies:
+    - .yamato/com.unity.ml-agents-pack.yml#sign_macOS
 
 sign_macOS:
   name: Sign MacOS Shared Libraries

--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -31,10 +31,6 @@ sign_macOS:
     type: Unity::VM::osx
     image: package-ci/macos-13:v4
     flavor: m1.mac
-  sources:
-    checkout_mode: sparse
-    files:
-      sparse_checkout_rules: .yamato/sparse-checkouts/upm-packages.txt
   commands:
     - brick_source: git@github.cds.internal.unity3d.com:unity/macos.cds.ci.code-signing.git@v1.2.2
       variables:
@@ -56,9 +52,3 @@ sign_macOS:
         - "{{ shared_library.path }}"
 {% endfor -%}
 {% endfor -%}
-
-sign:
-  name: Sign Shared Libraries
-  dependencies:
-    - .yamato/pack.yml#sign_macOS
-    - .yamato/pack.yml#sign_windows

--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -31,6 +31,10 @@ sign_macOS:
     type: Unity::VM::osx
     image: package-ci/macos-13:v4
     flavor: m1.mac
+  sources:
+    checkout_mode: sparse
+    files:
+      sparse_checkout_rules: .yamato/sparse-checkouts/upm-packages.txt
   commands:
     - brick_source: git@github.cds.internal.unity3d.com:unity/macos.cds.ci.code-signing.git@v1.2.2
       variables:

--- a/.yamato/com.unity.ml-agents-pack.yml
+++ b/.yamato/com.unity.ml-agents-pack.yml
@@ -1,3 +1,6 @@
+{% metadata_file .yamato/env.metafile -%}
+---
+
 pack:
   name: Pack
   agent:
@@ -21,3 +24,41 @@ pack:
         - "upm-ci~/packages/**/*"
   triggers:
     cancel_old_ci: true
+
+sign_macOS:
+  name: Sign MacOS Shared Libraries
+  agent:
+    type: Unity::VM::osx
+    image: package-ci/macos-13:v4
+    flavor: m1.mac
+  sources:
+    checkout_mode: sparse
+    files:
+      sparse_checkout_rules: .yamato/sparse-checkouts/upm-packages.txt
+  commands:
+    - brick_source: git@github.cds.internal.unity3d.com:unity/macos.cds.ci.code-signing.git@v1.2.2
+      variables:
+        CERTIFICATE_NAME: apple-developer-id-application-unity-technologies-sf
+    - command: |-
+        security unlock-keychain -p $UNITY_KEYCHAIN_PASSWORD /Users/$USER/Library/Keychains/login.keychain-db
+{% for package in packages -%}
+{% for shared_library in package.native_plugins.macOS -%}
+        codesign --force --verify --verbose --timestamp --sign $(<certificate_thumbprint.txt) "{{ shared_library.path }}"
+        codesign -d -vv "{{ shared_library.path }}"
+{% endfor -%}
+{% endfor -%}
+        security lock-keychain /Users/$USER/Library/Keychains/login.keychain-db
+  artifacts:
+{% for package in packages -%}
+{% for shared_library in package.native_plugins.macOS -%}
+    {{ shared_library.name }}:
+      paths:
+        - "{{ shared_library.path }}"
+{% endfor -%}
+{% endfor -%}
+
+sign:
+  name: Sign Shared Libraries
+  dependencies:
+    - .yamato/pack.yml#sign_macOS
+    - .yamato/pack.yml#sign_windows

--- a/.yamato/env.metafile
+++ b/.yamato/env.metafile
@@ -5,4 +5,4 @@ packages:
     native_plugins:
       macOS:
         - name: libgrpc_macOS
-          path: Plugins/ProtoBuffer/runtimes/osx/native/libgrpc_csharp_ext.x64.bundle
+          path: com.unity.ml-agents/Plugins/ProtoBuffer/runtimes/osx/native/libgrpc_csharp_ext.x64.bundle

--- a/.yamato/env.metafile
+++ b/.yamato/env.metafile
@@ -1,0 +1,8 @@
+packages:
+  - name: com.unity.ml-agents
+    short_name: ml-agents
+    path: com.unity.ml-agents
+    native_plugins:
+      macOS:
+        - name: libgrpc_macOS
+          path: Plugins/ProtoBuffer/runtimes/osx/native/libgrpc_csharp_ext.x64.bundle

--- a/.yamato/sparse-checkouts/upm-packages.txt
+++ b/.yamato/sparse-checkouts/upm-packages.txt
@@ -1,0 +1,3 @@
+.github
+.yamato
+com.unity.ml-agents

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -21,6 +21,8 @@ package_pack_-_ml-agents:
     packages:
       paths:
       - upm-ci~/packages/**/*
+  dependencies:
+    - path: .yamato/com.unity.ml-agents-pack.yml#sign_macOS
   variables:
     UPMCI_ACK_LARGE_PACKAGE: 1
     UPMPVP_CONTEXT_WRENCH: 0.10.5.0


### PR DESCRIPTION
### Proposed change(s)

Code signing the .bundle file on macOS. This is required to notarize the Mac Editor with Apple.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://jira.unity3d.com/browse/SENTIS-1181
https://jira.unity3d.com/browse/POI-2479

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ x] CI Fix

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)
Tested manually on Mac that the file is signed in the package after getting the package bundle from Yamato artifacts

### Other comments

The code signing needs to take place before the pack job. Change the pack job from Wrench as well to add it as a dependency.

<img width="894" height="531" alt="Capture d’écran, le 2025-11-13 à 18 38 43" src="https://github.com/user-attachments/assets/925b4008-8686-4d16-8ad4-b427ae795ef4" />

