### PR TITLE
Upgrade ML-Agents to 4.0.1

### DIFF
--- a/.yamato/com.unity.ml-agents-test.yml
+++ b/.yamato/com.unity.ml-agents-test.yml
@@ -8,7 +8,7 @@ test_editors:
       enableNoDefaultPackages: !!bool true
 
 trunk_editor:
-    - version: trunk
+    - version: 6000.4
       testProject: DevProject
 
 test_platforms:

--- a/.yamato/test_versions.metafile
+++ b/.yamato/test_versions.metafile
@@ -7,5 +7,5 @@ test_editors:
     extra_test: gym
   - version: 6000.0
     extra_test: sensor
-  - version: trunk
+  - version: 6000.3
     extra_test: llapi

--- a/DevProject/Packages/packages-lock.json
+++ b/DevProject/Packages/packages-lock.json
@@ -1,13 +1,15 @@
 {
   "dependencies": {
     "com.unity.ai.inference": {
-      "version": "2.2.1",
+      "version": "2.4.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.17",
         "com.unity.collections": "2.4.3",
-        "com.unity.modules.imageconversion": "1.0.0"
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.dt.app-ui": "1.3.1",
+        "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
@@ -51,6 +53,18 @@
       },
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
+    "com.unity.dt.app-ui": {
+      "version": "1.3.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.androidjni": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0"
+      },
+      "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
+    },
     "com.unity.ext.nunit": {
       "version": "2.0.5",
       "depth": 1,
@@ -79,7 +93,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ai.inference": "2.2.1",
+        "com.unity.ai.inference": "2.4.1",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.physics": "1.0.0"
@@ -200,6 +214,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.androidjni": {
+      "version": "1.0.0",
+      "depth": 3,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.hierarchycore": {
       "version": "1.0.0",
       "depth": 1,
@@ -235,6 +255,14 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.modules.screencapture": {
+      "version": "1.0.0",
+      "depth": 3,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
     },
     "com.unity.modules.ui": {
       "version": "1.0.0",

--- a/PerformanceProject/Packages/packages-lock.json
+++ b/PerformanceProject/Packages/packages-lock.json
@@ -1,13 +1,15 @@
 {
   "dependencies": {
     "com.unity.ai.inference": {
-      "version": "2.2.1",
+      "version": "2.4.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.17",
         "com.unity.collections": "2.4.3",
-        "com.unity.modules.imageconversion": "1.0.0"
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.dt.app-ui": "1.3.1",
+        "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
@@ -37,6 +39,18 @@
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.test-framework": "1.4.5",
         "com.unity.test-framework.performance": "3.0.3"
+      },
+      "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
+    },
+    "com.unity.dt.app-ui": {
+      "version": "1.3.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.androidjni": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0"
       },
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
@@ -106,7 +120,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ai.inference": "2.2.1",
+        "com.unity.ai.inference": "2.4.1",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.physics": "1.0.0"

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -8,12 +8,14 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ai.inference": {
-      "version": "2.2.1",
+      "version": "2.4.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.17",
+        "com.unity.dt.app-ui": "1.3.1",
         "com.unity.collections": "2.4.3",
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
         "com.unity.modules.imageconversion": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -55,6 +57,18 @@
         "com.unity.test-framework": "1.4.5",
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.test-framework.performance": "3.0.3"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.dt.app-ui": {
+      "version": "1.3.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.androidjni": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -105,7 +119,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.ai.inference": "2.2.1",
+        "com.unity.ai.inference": "2.4.1",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.physics": "1.0.0"
@@ -218,6 +232,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.androidjni": {
+      "version": "1.0.0",
+      "depth": 3,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.animation": {
       "version": "1.0.0",
       "depth": 2,
@@ -280,6 +300,14 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.modules.screencapture": {
+      "version": "1.0.0",
+      "depth": 3,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
     },
     "com.unity.modules.ui": {
       "version": "1.0.0",

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to
 ## [Unreleased]
 ### Minor Changes
 #### com.unity.ml-agents (C#)
-- Upgraded to Inference Engine 2.4.1 (#6264)
+- Upgraded to Inference Engine 2.4.1 (#6269)
 - Fixed tensor indexing to use correct CHW layout (#6239)
 - Updated the installation doc (#6242)
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 ### Minor Changes
 #### com.unity.ml-agents (C#)
+- Upgraded to Inference Engine 2.4.1 (#6264)
 - Fixed tensor indexing to use correct CHW layout (#6239)
 - Updated the installation doc (#6242)
 

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 #### ml-agents / ml-agents-envs
 - Set the Torch version constraint to 2.8 (#6251)
 - Fixed CUDA/CPU mismatch in threaded training (#6245)
+- Fixed HTTP Error when importing UnityToGymWrapper (#6269)
 
 ## [4.0.0] - 2025-08-28
 ### Major Changes

--- a/com.unity.ml-agents/package.json
+++ b/com.unity.ml-agents/package.json
@@ -5,7 +5,7 @@
   "unity": "6000.0",
   "description": "Use state-of-the-art machine learning to create intelligent character behaviors in any Unity environment (games, robotics, film, etc.).",
   "dependencies": {
-    "com.unity.ai.inference": "2.2.1",
+    "com.unity.ai.inference": "2.4.1",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.physics": "1.0.0"

--- a/ml-agents-envs/mlagents_envs/registry/unity_env_registry.py
+++ b/ml-agents-envs/mlagents_envs/registry/unity_env_registry.py
@@ -121,6 +121,6 @@ class UnityEnvRegistry(Mapping):
 
 default_registry = UnityEnvRegistry()
 # TODO restore when a new registry is available.
-default_registry.register_from_yaml(
-    "https://storage.googleapis.com/mlagents-test-environments/1.1.0/manifest.yaml"
-)  # noqa E501
+# default_registry.register_from_yaml(
+#    "https://storage.googleapis.com/mlagents-test-environments/1.1.0/manifest.yaml"
+# )  # noqa E501


### PR DESCRIPTION
Update Changelog
Update inference engine dependencies
Update the code dependencies to "com.unity.ai.inference": "2.4.1"
This is a re-spin of https://github.com/Unity-Technologies/ml-agents/pull/6264 in a new branch because the former had code signing issues. Credits @maryamziaa 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
