### PR TITLE
Crash on quit runmode

### DIFF
--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 - Upgraded to Inference Engine 2.4.1 (#6269)
 - Fixed tensor indexing to use correct CHW layout (#6239)
 - Updated the installation doc (#6242)
+- Fixed Unity Editor crashing when quitting in play mode (#6267)
 
 #### ml-agents / ml-agents-envs
 - Set the Torch version constraint to 2.8 (#6251)

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 - Upgraded to Inference Engine 2.4.1 (#6269)
 - Fixed tensor indexing to use correct CHW layout (#6239)
 - Updated the installation doc (#6242)
-- Fixed Unity Editor crashing when quitting in play mode (#6267)
+- Fixed Unity Editor crashing when quitting in play mode (#6274)
 
 #### ml-agents / ml-agents-envs
 - Set the Torch version constraint to 2.8 (#6251)

--- a/com.unity.ml-agents/Runtime/Academy.cs
+++ b/com.unity.ml-agents/Runtime/Academy.cs
@@ -261,6 +261,7 @@ namespace Unity.MLAgents
             LazyInitialize();
 
 #if UNITY_EDITOR
+            EditorApplication.quitting += Dispose;
             EditorApplication.playModeStateChanged += HandleOnPlayModeChanged;
 #endif
         }


### PR DESCRIPTION
Dispose was not called in Academy when editor was quitting resulting in a crash in the Job system when CPU Workers were disposed in finalizers called from background threads (they need to be called on the Main thread)

By calling Dispose before tearing down the job system, CPU Workers are disposed properly the same way they are when you leave play mode.

### Proposed change(s)

Added a Dispose action in Academy when Editor Application is quitting

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
