### PR TITLE
Fix deprecated instanceID API usages in com.unity.ml-agents

### DIFF
--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -14,6 +14,7 @@ test_linux_training_int_{{ editor.version }}_{{ editor.extra_test }}:
       eval "$($HOME/anaconda/bin/conda shell.bash hook)"
       conda activate python3.10
       python -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+      python -m pip install --upgrade setuptools
       python -u -m ml-agents.tests.yamato.training_int_tests
   dependencies:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}_{{ editor.extra_test }}

--- a/.yamato/training-int-tests.yml
+++ b/.yamato/training-int-tests.yml
@@ -14,7 +14,6 @@ test_linux_training_int_{{ editor.version }}_{{ editor.extra_test }}:
       eval "$($HOME/anaconda/bin/conda shell.bash hook)"
       conda activate python3.10
       python -m pip install pyyaml --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-      python -m pip install --upgrade setuptools
       python -u -m ml-agents.tests.yamato.training_int_tests
   dependencies:
     - .yamato/standalone-build-test.yml#test_linux_standalone_{{ editor.version }}_{{ editor.extra_test }}

--- a/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3Board.cs
+++ b/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3Board.cs
@@ -57,9 +57,18 @@ namespace Unity.MLAgentsExamples
             };
         }
 
+        int CreateNewSeed()
+        {
+#if UNITY_6000_3_OR_NEWER
+            return gameObject.GetEntityId().GetHashCode();
+#else
+            return gameObject.GetInstanceID();
+#endif
+        }
+
         void Start()
         {
-            m_Random = new System.Random(RandomSeed == -1 ? gameObject.GetInstanceID() : RandomSeed);
+            m_Random = new System.Random(RandomSeed == -1 ? CreateNewSeed() : RandomSeed);
             InitRandom();
         }
 

--- a/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3ExampleActuatorComponent.cs
+++ b/Project/Assets/ML-Agents/Examples/Match3/Scripts/Match3ExampleActuatorComponent.cs
@@ -10,7 +10,7 @@ namespace Unity.MLAgentsExamples
         public override IActuator[] CreateActuators()
         {
             var board = GetComponent<Match3Board>();
-            var seed = RandomSeed == -1 ? gameObject.GetInstanceID() : RandomSeed + 1;
+            var seed = RandomSeed == -1 ? CreateNewSeed() : RandomSeed + 1;
             return new IActuator[] { new Match3ExampleActuator(board, ForceHeuristic, ActuatorName, seed) };
         }
     }

--- a/com.unity.ml-agents/Runtime/Integrations/Match3/Match3ActuatorComponent.cs
+++ b/com.unity.ml-agents/Runtime/Integrations/Match3/Match3ActuatorComponent.cs
@@ -49,6 +49,15 @@ namespace Unity.MLAgents.Integrations.Match3
             set => m_ForceHeuristic = value;
         }
 
+        protected int CreateNewSeed()
+        {
+#if UNITY_6000_3_OR_NEWER
+            return gameObject.GetEntityId().GetHashCode();
+#else
+            return gameObject.GetInstanceID();
+#endif
+        }
+
         /// <inheritdoc/>
         public override IActuator[] CreateActuators()
         {
@@ -58,7 +67,7 @@ namespace Unity.MLAgents.Integrations.Match3
                 return Array.Empty<IActuator>();
             }
 
-            var seed = m_RandomSeed == -1 ? gameObject.GetInstanceID() : m_RandomSeed + 1;
+            var seed = m_RandomSeed == -1 ? CreateNewSeed() : m_RandomSeed + 1;
             return new IActuator[] { new Match3Actuator(board, m_ForceHeuristic, seed, m_ActuatorName) };
         }
 

--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -1,11 +1,6 @@
 import os
 
-try:
-    from importlib.metadata import version, PackageNotFoundError
-except ImportError:
-    # Python < 3.8 compatibility
-    from importlib_metadata import version, PackageNotFoundError
-
+from importlib.metadata import version, PackageNotFoundError
 from packaging.version import Version
 from mlagents.torch_utils import cpu_utils
 from mlagents.trainers.settings import TorchSettings

--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -18,9 +18,7 @@ def assert_torch_installed():
         torch_version = version("torch")
     except PackageNotFoundError:
         pass
-    assert torch_version is not None and Version(torch_version) >= Version(
-        "1.6.0"
-    ), (
+    assert torch_version is not None and Version(torch_version) >= Version("1.6.0"), (
         "A compatible version of PyTorch was not installed. Please visit the PyTorch homepage "
         + "(https://pytorch.org/get-started/locally/) and follow the instructions to install. "
         + "Version 1.6.0 and later are supported."

--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -1,7 +1,12 @@
 import os
 
-from distutils.version import LooseVersion
-import pkg_resources
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # Python < 3.8 compatibility
+    from importlib_metadata import version, PackageNotFoundError
+
+from packaging.version import Version
 from mlagents.torch_utils import cpu_utils
 from mlagents.trainers.settings import TorchSettings
 from mlagents_envs.logging_util import get_logger
@@ -13,12 +18,12 @@ logger = get_logger(__name__)
 def assert_torch_installed():
     # Check that torch version 1.6.0 or later has been installed. If not, refer
     # user to the PyTorch webpage for install instructions.
-    torch_pkg = None
+    torch_version = None
     try:
-        torch_pkg = pkg_resources.get_distribution("torch")
-    except pkg_resources.DistributionNotFound:
+        torch_version = version("torch")
+    except PackageNotFoundError:
         pass
-    assert torch_pkg is not None and LooseVersion(torch_pkg.version) >= LooseVersion(
+    assert torch_version is not None and Version(torch_version) >= Version(
         "1.6.0"
     ), (
         "A compatible version of PyTorch was not installed. Please visit the PyTorch homepage "

--- a/ml-agents/setup.py
+++ b/ml-agents/setup.py
@@ -59,6 +59,7 @@ setup(
         "h5py>=2.9.0",
         f"mlagents_envs=={VERSION}",
         "numpy>=1.23.5,<1.24.0",
+        "packaging>=20.0",
         "Pillow>=4.2.1",
         "protobuf>=3.6,<3.21",
         "pyyaml>=3.1.0",


### PR DESCRIPTION
Fix deprecated instanceID API usages in com.unity.ml-agents

### Proposed change(s)

Fixing issue with GetInstanceID being obsolete since Unity 6.3. Now calling GetEntityId() where GetInstanceID() was used before to keep package and examples compatible with Unity 6.0, 6.3, 6.4 and 6.5

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)
 [UUM-132069](https://jira.unity3d.com/browse/UUM-132069)


### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
Tested with DevProject and Project with 6.0, 6.3 and 6.5
