### PR TITLE
Suppressing some static persistance analyzer warnings from AppUI in development projects

### DIFF
--- a/DevProject/Assets/Default.ruleset
+++ b/DevProject/Assets/Default.ruleset
@@ -2,5 +2,6 @@
 <RuleSet Name="MLAgents" ToolsVersion="10.0">
   <Rules AnalyzerId="Unity.Serialization.Analyzer" RuleNamespace="Unity.Serialization.Analyzer">
     <Rule Id="UAC1005" Action="None" />
+    <Rule Id="UAC1015" Action="None" />
   </Rules>
 </RuleSet>

--- a/DevProject/Assets/csc.rsp
+++ b/DevProject/Assets/csc.rsp
@@ -1,3 +1,4 @@
 -warnaserror+
 -warnaserror-:618
 -nowarn:UAC1005
+-nowarn:UAC1015

--- a/Project/Assets/Default.ruleset
+++ b/Project/Assets/Default.ruleset
@@ -2,5 +2,6 @@
 <RuleSet Name="MLAgents" ToolsVersion="10.0">
   <Rules AnalyzerId="Unity.Serialization.Analyzer" RuleNamespace="Unity.Serialization.Analyzer">
     <Rule Id="UAC1005" Action="None" />
+    <Rule Id="UAC1015" Action="None" />
   </Rules>
 </RuleSet>

--- a/Project/Assets/csc.rsp
+++ b/Project/Assets/csc.rsp
@@ -1,3 +1,4 @@
 -warnaserror+
 -warnaserror-:618
 -nowarn:UAC1005
+-nowarn:UAC1015


### PR DESCRIPTION
### Proposed change(s)

Suppressing a false positive warning introduced in trunk (Unity 6.6) 

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

https://unity-ci.cds.internal.unity3d.com/job/68026092?utm_source=slack

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Test related change

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
