### PR TITLE
Add PyTorch XPU as Target Device

### DIFF
--- a/ml-agents/mlagents/torch_utils/torch.py
+++ b/ml-agents/mlagents/torch_utils/torch.py
@@ -52,6 +52,9 @@ def set_torch_config(torch_settings: TorchSettings) -> None:
     if _device.type == "cuda":
         torch.set_default_device(_device.type)
         torch.set_default_dtype(torch.float32)
+    elif _device.type == "xpu":
+        torch.set_default_device(_device.type)
+        torch.set_default_dtype(torch.float32)
     else:
         torch.set_default_dtype(torch.float32)
     logger.debug(f"default Torch device: {_device}")


### PR DESCRIPTION
### Proposed change(s)

Add PyTorch XPU as target device to support Intel Arc GPUs.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

[Steps to Setup Unity Machine Learning Agents Toolkit and PyTorch XPU](https://github.com/ekaakurniawan/DRLND/blob/development/doc/setup_unity_ml_agents_pytorch_xpu.md)

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
Please advise on adding the test.
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments
