### PR TITLE
Fix stacking sensor

### DIFF
--- a/com.unity.ml-agents.tests/Tests/Runtime/Sensor/StackingSensorTests.cs
+++ b/com.unity.ml-agents.tests/Tests/Runtime/Sensor/StackingSensorTests.cs
@@ -279,6 +279,35 @@ namespace Unity.MLAgents.Tests
         }
 
         [Test]
+        public void TestStackedGetCompressedObservationMultiChannel()
+        {
+            var wrapped = new Dummy3DSensor();
+            wrapped.ObservationSpec = ObservationSpec.Visual(4, 1, 1);
+            var sensor = new StackingSensor(wrapped, 2);
+
+            var singleEmptyPNG = sensor.CreateEmptyPNG();
+            var emptyObservation = singleEmptyPNG.Concat(singleEmptyPNG).ToArray();
+
+            wrapped.CurrentObservation = new[, ,] { { { 1f } }, { { 2f } }, { { 3f } }, { { 4f } } };
+            var expected1 = emptyObservation.Concat(
+                Array.ConvertAll(new[] { 1f, 2f, 3f, 4f }, (z) => (byte)z)).ToArray();
+            Assert.AreEqual(sensor.GetCompressedObservation(), expected1);
+
+            sensor.Update();
+            wrapped.CurrentObservation = new[, ,] { { { 5f } }, { { 6f } }, { { 7f } }, { { 8f } } };
+            var expected2 = Array.ConvertAll(
+                new[] { 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f }, (z) => (byte)z);
+            Assert.AreEqual(sensor.GetCompressedObservation(), expected2);
+
+            // Test reset
+            sensor.Reset();
+            wrapped.CurrentObservation = new[, ,] { { { 9f } }, { { 10f } }, { { 11f } }, { { 12f } } };
+            var expected3 = emptyObservation.Concat(
+                Array.ConvertAll(new[] { 9f, 10f, 11f, 12f }, (z) => (byte)z)).ToArray();
+            Assert.AreEqual(sensor.GetCompressedObservation(), expected3);
+        }
+
+        [Test]
         public void TestStackingSensorBuiltInSensorType()
         {
             var dummySensor = new Dummy3DSensor();

--- a/com.unity.ml-agents/CHANGELOG.md
+++ b/com.unity.ml-agents/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Minor Changes
+#### com.unity.ml-agents (C#)
+Fixed StackingSensor compressed observation for sensors with more than 3 channels.
+
+
 ## [4.0.3] - 2026-04-17
 ### Minor Changes
 #### com.unity.ml-agents (C#)

--- a/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
@@ -82,7 +82,18 @@ namespace Unity.MLAgents.Sensors
             if (m_WrappedSensor.GetCompressionSpec().SensorCompressionType != SensorCompressionType.None)
             {
                 m_StackedCompressedObservations = new byte[numStackedObservations][];
-                m_EmptyCompressedObservation = CreateEmptyPNG();
+
+                // Generate Single Empty PNG
+                Byte[] singleEmptyPNG = CreateEmptyPNG();
+                List<byte> emptyCompressedObservationList = new List<byte>();
+
+                // Combine Multiple Empty PNGs for channels more than 3
+                for (int i = 0; i < (m_WrappedSpec.Shape[^1] + 2) / 3; i++)
+                {
+                    emptyCompressedObservationList.AddRange(singleEmptyPNG);
+                }
+                m_EmptyCompressedObservation = emptyCompressedObservationList.ToArray();
+
                 for (var i = 0; i < numStackedObservations; i++)
                 {
                     m_StackedCompressedObservations[i] = m_EmptyCompressedObservation;

--- a/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
+++ b/com.unity.ml-agents/Runtime/Sensors/StackingSensor.cs
@@ -85,12 +85,12 @@ namespace Unity.MLAgents.Sensors
             {
                 m_StackedCompressedObservations = new byte[numStackedObservations][];
 
+                var numEmptyPNGs = (m_WrappedSpec.Shape[0] + 2) / 3;
                 // Generate Single Empty PNG
-                Byte[] singleEmptyPNG = CreateEmptyPNG();
+                byte[] singleEmptyPNG = CreateEmptyPNG();
                 List<byte> emptyCompressedObservationList = new List<byte>();
-
                 // Combine Multiple Empty PNGs for channels more than 3
-                for (int i = 0; i < (m_WrappedSpec.Shape[^1] + 2) / 3; i++)
+                for (int i = 0; i < numEmptyPNGs; i++)
                 {
                     emptyCompressedObservationList.AddRange(singleEmptyPNG);
                 }


### PR DESCRIPTION
### Proposed change(s)

Fix Stacking Sensor when more than 3 channels.
Update PR #5806 that fixes issue #5790 - GridSensor Observation Stacks Greater Than 1 Throws Exception.
The prepared empty PNG is now multiplied based on the channel number used.
Co-authored-by: @x-mug 

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)
